### PR TITLE
addResources requires extension

### DIFF
--- a/packages/common/src/resourceHelpers.ts
+++ b/packages/common/src/resourceHelpers.ts
@@ -50,6 +50,7 @@
 import * as auth from "@esri/arcgis-rest-auth";
 import * as generalHelpers from "./generalHelpers";
 import * as portal from "@esri/arcgis-rest-portal";
+import * as request from "@esri/arcgis-rest-request";
 import * as restHelpers from "./restHelpers";
 
 // ------------------------------------------------------------------------------------------------------------------ //
@@ -102,6 +103,17 @@ export function addResourceFromBlob(
   filename: string,
   requestOptions: auth.IUserRequestOptions
 ): Promise<any> {
+  // Check that the filename has an extension because it is required by the addResources call
+  if (filename && filename.indexOf(".") < 0) {
+    return new Promise((resolve, reject) => {
+      reject(
+        new request.ArcGISAuthError(
+          "Filename must have an extension indicating its type"
+        )
+      );
+    });
+  }
+
   const addRsrcOptions = {
     id: itemId,
     resource: blob,

--- a/packages/common/test/resourceHelpers.test.ts
+++ b/packages/common/test/resourceHelpers.test.ts
@@ -19,6 +19,7 @@
  */
 
 import * as auth from "@esri/arcgis-rest-auth";
+import * as request from "@esri/arcgis-rest-request";
 import * as resourceHelpers from "../src/resourceHelpers";
 
 import { getAnImageResponse } from "./mocks/agolItems";
@@ -55,6 +56,8 @@ describe("Module `resourceHelpers`: common functions involving the management of
     owningSystemUrl: "https://www.arcgis.com",
     authInfo: {}
   };
+
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000; // default is 5000 ms
 
   afterEach(() => {
     fetchMock.restore();
@@ -93,7 +96,7 @@ describe("Module `resourceHelpers`: common functions involving the management of
         const blob = new Blob(["abc", "def", "ghi"], { type: "text/xml" });
         const itemId = "itm1234567890";
         const folder = "";
-        const filename = "aFilename";
+        const filename = "aFilename.xml";
         const updateUrl =
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/itm1234567890/addResources";
         const expected = { success: true, id: itemId };
@@ -120,11 +123,37 @@ describe("Module `resourceHelpers`: common functions involving the management of
           }, done.fail);
       });
 
-      it("has filename with folder", done => {
+      it("has a filename without an extension", done => {
         const blob = new Blob(["abc", "def", "ghi"], { type: "text/xml" });
         const itemId = "itm1234567890";
         const folder = "aFolder";
         const filename = "aFilename";
+        const expected = new request.ArcGISAuthError(
+          "Filename must have an extension indicating its type"
+        );
+
+        resourceHelpers
+          .addResourceFromBlob(
+            blob,
+            itemId,
+            folder,
+            filename,
+            MOCK_USER_REQOPTS
+          )
+          .then(
+            () => done.fail,
+            (response: any) => {
+              expect(response).toEqual(expected);
+              done();
+            }
+          );
+      });
+
+      it("has filename with folder", done => {
+        const blob = new Blob(["abc", "def", "ghi"], { type: "text/xml" });
+        const itemId = "itm1234567890";
+        const folder = "aFolder";
+        const filename = "aFilename.xml";
         const updateUrl =
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/itm1234567890/addResources";
         const expected = { success: true, id: itemId };
@@ -279,7 +308,7 @@ describe("Module `resourceHelpers`: common functions involving the management of
           {
             type: resourceHelpers.EFileType.Resource,
             folder: "storageFolder",
-            filename: "storageFilename",
+            filename: "storageFilename.png",
             url: "https://myserver/images/resource.png"
           }
         ];
@@ -374,7 +403,7 @@ describe("Module `resourceHelpers`: common functions involving the management of
         const filePaths: resourceHelpers.ISourceFileCopyPath[] = [
           {
             folder: "storageFolder",
-            filename: "storageFilename",
+            filename: "storageFilename.png",
             url: "https://myserver/images/thumbnail.png"
           }
         ];
@@ -386,7 +415,7 @@ describe("Module `resourceHelpers`: common functions involving the management of
         const expectedFetch = getAnImageResponse();
         const updateUrl =
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/itm1234567890/addResources";
-        const expectedUpdate: string[] = ["storageFolder/storageFilename"];
+        const expectedUpdate: string[] = ["storageFolder/storageFilename.png"];
 
         fetchMock
           .post("https://www.arcgis.com/sharing/rest/info", expectedServerInfo)
@@ -450,7 +479,7 @@ describe("Module `resourceHelpers`: common functions involving the management of
         const destination = {
           itemId: "itm1234567890",
           folder: "storageFolder",
-          filename: "storageFilename",
+          filename: "storageFilename.png",
           requestOptions: MOCK_USER_REQOPTS
         };
         const fetchUrl =

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -2017,6 +2017,10 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         ab766cba0dd44ec080420acc10990282: {}
       };
 
+      fetchMock.post(
+        "http://utility/geomServer/findTransformations/rest/info",
+        '{"error":{"code":403,"message":"Access not allowed request","details":[]}}'
+      );
       _getCreateServiceOptions(
         itemTemplate,
         requestOptions,
@@ -2051,7 +2055,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
       }, done.fail);
     });
 
-    it("can get options for HOSTED service with values when name contains quid", done => {
+    it("can get options for HOSTED service with values when name contains guid", done => {
       const requestOptions: IUserRequestOptions = {
         authentication: new UserSession({
           username: "jsmith",
@@ -2097,6 +2101,10 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         ab766cba0dd44ec080420acc10990282: {}
       };
 
+      fetchMock.post(
+        "http://utility/geomServer/findTransformations/rest/info",
+        '{"error":{"code":403,"message":"Access not allowed request","details":[]}}'
+      );
       _getCreateServiceOptions(
         itemTemplate,
         requestOptions,
@@ -2180,6 +2188,10 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         mockItems.get400Failure()
       );
 
+      fetchMock.post(
+        "http://utility/geomServer/findTransformations/rest/info",
+        '{"error":{"code":403,"message":"Access not allowed request","details":[]}}'
+      );
       _getCreateServiceOptions(
         itemTemplate,
         requestOptions,

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -1938,6 +1938,10 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         ab766cba0dd44ec080420acc10990282: {}
       };
 
+      fetchMock.post(
+        "http://utility/geomServer/findTransformations/rest/info",
+        '{"error":{"code":403,"message":"Access not allowed request","details":[]}}'
+      );
       _getCreateServiceOptions(
         itemTemplate,
         requestOptions,

--- a/packages/simple-types/src/simple-types.ts
+++ b/packages/simple-types/src/simple-types.ts
@@ -157,13 +157,8 @@ export function convertItemToTemplate(
             form.convertItemToTemplate(itemTemplate);
 
             if (itemDataResponse) {
-              let filename = "formData.zip";
-              if (typeof File !== "undefined") {
-                const formData: File = itemDataResponse as File;
-                if (formData.name) {
-                  filename = formData.name;
-                }
-              }
+              const filename =
+                (itemDataResponse as File).name || "formData.zip";
               const storageName = common.generateResourceStorageFilename(
                 itemTemplate.itemId,
                 filename,

--- a/packages/simple-types/src/simple-types.ts
+++ b/packages/simple-types/src/simple-types.ts
@@ -157,9 +157,16 @@ export function convertItemToTemplate(
             form.convertItemToTemplate(itemTemplate);
 
             if (itemDataResponse) {
+              let filename = "formData.zip";
+              if (typeof File !== "undefined") {
+                const formData: File = itemDataResponse as File;
+                if (formData.name) {
+                  filename = formData.name;
+                }
+              }
               const storageName = common.generateResourceStorageFilename(
                 itemTemplate.itemId,
-                "formData",
+                filename,
                 "info_form"
               );
               itemTemplate.resources.push(

--- a/packages/simple-types/test/simple-types.test.ts
+++ b/packages/simple-types/test/simple-types.test.ts
@@ -46,6 +46,8 @@ const MOCK_USER_SESSION = new UserSession({
   portal: "https://myorg.maps.arcgis.com/sharing/rest"
 });
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000; // default is 5000 ms
+
 const noResourcesResponse: any = {
   total: 0,
   start: 1,
@@ -1358,80 +1360,6 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
         done();
       }, done.fail);
     });
-
-    if (typeof window !== "undefined") {
-      // Blobs are only available in the browser
-      it("should catch wrapup errors", done => {
-        const itemTemplate: IItemTemplate = mockItems.getItemTemplate();
-        itemTemplate.item = mockItems.getAGOLItem("Form", null);
-        itemTemplate.itemId = itemTemplate.item.id;
-        itemTemplate.item.thumbnail = null;
-        const blob = new Blob(["abc", "def", "ghi"], { type: "text/xml" });
-
-        fetchMock
-          .post(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/" +
-              itemTemplate.itemId +
-              "/data",
-            blob
-          )
-          .post(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/" +
-              itemTemplate.itemId +
-              "/resources",
-            noResourcesResponse
-          )
-          .post(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/" +
-              itemTemplate.itemId +
-              "/info/metadata/metadata.xml",
-            {
-              error: {
-                code: 400,
-                messageCode: "CONT_0036",
-                message: "Item info file does not exist or is inaccessible.",
-                details: ["Error getting Item Info from DataStore"]
-              }
-            }
-          )
-          .post(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/users/" +
-              MOCK_USER_SESSION.username +
-              "/items/" +
-              itemTemplate.itemId +
-              "/addResources",
-            {
-              error: {
-                code: 400,
-                messageCode: "CONT_0036",
-                message: "Item info file does not exist or is inaccessible.",
-                details: ["Error getting Item Info from DataStore"]
-              }
-            }
-          )
-          .get(
-            "https://myorg.maps.arcgis.com/sharing/rest/content/items/" +
-              itemTemplate.itemId +
-              "/relatedItems?f=json&num=1000&relationshipType=Survey2Service&token=fake-token",
-            create404Error()
-          );
-
-        convertItemToTemplate(
-          itemTemplate.item.id,
-          itemTemplate.item,
-          MOCK_USER_SESSION
-        ).then(
-          () => done.fail,
-          response => {
-            expect(response.error.code).toEqual(400);
-            expect(response.error.message).toEqual(
-              "Item info file does not exist or is inaccessible."
-            );
-            done();
-          }
-        );
-      });
-    }
   });
 
   describe("createItemFromTemplate", () => {

--- a/packages/simple-types/test/simple-types.test.ts
+++ b/packages/simple-types/test/simple-types.test.ts
@@ -753,12 +753,14 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
         }, done.fail);
       });
 
-      it("should handle form item type", done => {
+      it("should handle form item type with default filename", done => {
         const itemTemplate: IItemTemplate = mockItems.getItemTemplate();
         itemTemplate.itemId = "frm1234567890";
         itemTemplate.item = mockItems.getAGOLItem("Form", null);
         itemTemplate.item.thumbnail = null;
-        const blob = new Blob(["abc", "def", "ghi"], { type: "text/xml" });
+        const blob = new Blob(["abc", "def", "ghi"], {
+          type: "application/zip"
+        });
 
         const expectedTemplate: any = {
           itemId: "frm1234567890",
@@ -780,7 +782,7 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
             url: ""
           },
           data: null,
-          resources: ["frm1234567890_info_form/formData"],
+          resources: ["frm1234567890_info_form/formData.zip"],
           dependencies: ["srv1234567890"],
           properties: {},
           estimatedDeploymentCostFactor: 2
@@ -909,9 +911,7 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
           done();
         }, done.fail);
       });
-    }
 
-    if (typeof window !== "undefined") {
       // Blobs are only available in the browser
       it("should handle web mapping applications", done => {
         const itemTemplate: IItemTemplate = mockItems.getItemTemplate();
@@ -1027,7 +1027,9 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
         itemTemplate.item = mockItems.getAGOLItem("Form", null);
         itemTemplate.itemId = itemTemplate.item.id;
         itemTemplate.item.thumbnail = null;
-        const blob = new Blob(["abc", "def", "ghi"], { type: "text/xml" });
+        const blob = new Blob(["abc", "def", "ghi"], {
+          type: "application/zip"
+        });
 
         fetchMock
           .post(


### PR DESCRIPTION
background: integration test was failing because form data wasn't preserving|using extension on blob filename. Without the extension, addResources rejects the add with the misleading message "File type not allowed for addResources", even if the blob had an accepted MIME type.