### PR TITLE
Changed group thumbnail handling

### DIFF
--- a/packages/common/src/restHelpersGet.ts
+++ b/packages/common/src/restHelpersGet.ts
@@ -191,6 +191,30 @@ export function getBlobCheckForError(
   });
 }
 
+/**
+ * Extracts the text in a url between the last forward slash and the beginning of the url's parameters.
+ *
+ * @param url URL to work with
+ * @return Text extracted; empty if url ends with a forward slash or has a "?" immediately after the last
+ * forward slash
+ */
+export function getFilenameFromUrl(url: string): string {
+  if (!url) {
+    return "";
+  }
+
+  let iParamsStart = url.indexOf("?");
+  /* istanbul ignore else */
+  if (iParamsStart < 0) {
+    iParamsStart = url.length;
+  }
+  const iFilenameStart = url.lastIndexOf("/", iParamsStart) + 1;
+
+  return iFilenameStart < iParamsStart
+    ? url.substring(iFilenameStart, iParamsStart)
+    : "";
+}
+
 export function getInfoFiles(
   itemId: string,
   infoFilenames: string[],

--- a/packages/common/test/restHelpersGet.test.ts
+++ b/packages/common/test/restHelpersGet.test.ts
@@ -289,6 +289,39 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
     }
   });
 
+  describe("getFilenameFromUrl", () => {
+    it("extract name from url without query params", () => {
+      const url = "https://myorg.arcgis.com//resources/image.png";
+      const expectedFilename = "image.png";
+      expect(restHelpersGet.getFilenameFromUrl(url)).toEqual(expectedFilename);
+    });
+
+    it("extract name from url with query params", () => {
+      const url =
+        "https://myorg.arcgis.com//resources/image.png?w=400&token=fake-token";
+      const expectedFilename = "image.png";
+      expect(restHelpersGet.getFilenameFromUrl(url)).toEqual(expectedFilename);
+    });
+
+    it("handles missing name in url without query params", () => {
+      const url = "https://myorg.arcgis.com//resources/";
+      const expectedFilename = "";
+      expect(restHelpersGet.getFilenameFromUrl(url)).toEqual(expectedFilename);
+    });
+
+    it("handles missing name in url with query params", () => {
+      const url = "https://myorg.arcgis.com//resources/?w=400&token=fake-token";
+      const expectedFilename = "";
+      expect(restHelpersGet.getFilenameFromUrl(url)).toEqual(expectedFilename);
+    });
+
+    it("handles empty url", () => {
+      const url = "";
+      const expectedFilename = "";
+      expect(restHelpersGet.getFilenameFromUrl(url)).toEqual(expectedFilename);
+    });
+  });
+
   describe("getInfoFiles", () => {
     if (typeof window !== "undefined") {
       it("gets info files", done => {

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -95,6 +95,11 @@ export function createItemFromTemplate(
       templateDictionary
     );
 
+    // Remove not-useful properties
+    delete newItemTemplate.item.id;
+    delete newItemTemplate.item.created;
+    delete newItemTemplate.item.modified;
+
     // handle group
     const title: string = common.getUniqueTitle(
       newItemTemplate.item.title || "",
@@ -102,55 +107,37 @@ export function createItemFromTemplate(
       "user.groups"
     );
 
-    // Set the item title with a valid name for the ORG
-    newItemTemplate.item.title = title;
-    newItemTemplate.item.access = "private";
-    common.createGroup(newItemTemplate.item, destinationAuthentication).then(
-      createResponse => {
-        if (createResponse.success) {
-          // Interrupt process if progress callback returns `false`
-          if (
-            !itemProgressCallback(
-              createResponse.group.id,
-              common.EItemProgressStatus.Created,
-              template.estimatedDeploymentCostFactor / 2,
-              createResponse.group.id
-            )
-          ) {
-            itemProgressCallback(
-              createResponse.group.id,
-              common.EItemProgressStatus.Cancelled,
-              0
-            );
-            // tslint:disable-next-line: no-floating-promises
-            common
-              .removeGroup(createResponse.group.id, destinationAuthentication)
-              .then(
-                () => resolve(_generateEmptyCreationResponse(template.type)),
-                () => resolve(_generateEmptyCreationResponse(template.type))
-              );
-          } else {
-            newItemTemplate.itemId = createResponse.group.id;
-            templateDictionary[template.itemId] = {
-              itemId: createResponse.group.id
-            };
+    // Group uses `thumbnail` instead of `thumbnailurl`, and it has to be an actual file
+    let thumbnailBlobDef = Promise.resolve(null);
+    if (newItemTemplate.item.thumbnailurl) {
+      thumbnailBlobDef = new Promise(resolveThumb => {
+        common
+          .getBlobAsFile(
+            newItemTemplate.item.thumbnailurl,
+            common.getFilenameFromUrl(newItemTemplate.item.thumbnailurl),
+            destinationAuthentication
+          )
+          .then(resolveThumb, () => resolveThumb(null));
+      });
+    }
 
-            // Update the template again now that we have the new item id
-            newItemTemplate = common.replaceInTemplate(
-              newItemTemplate,
-              templateDictionary
-            );
+    thumbnailBlobDef.then(thumbnailBlob => {
+      delete newItemTemplate.item.thumbnailurl;
+      newItemTemplate.item.thumbnail = thumbnailBlob;
 
-            // Update the template dictionary with the new id
-            templateDictionary[template.itemId].itemId =
-              createResponse.group.id;
-
+      // Set the item title with a valid name for the ORG
+      newItemTemplate.item.title = title;
+      newItemTemplate.item.access = "private";
+      common.createGroup(newItemTemplate.item, destinationAuthentication).then(
+        createResponse => {
+          if (createResponse.success) {
             // Interrupt process if progress callback returns `false`
             if (
               !itemProgressCallback(
                 createResponse.group.id,
-                common.EItemProgressStatus.Finished,
-                template.estimatedDeploymentCostFactor / 2
+                common.EItemProgressStatus.Created,
+                template.estimatedDeploymentCostFactor / 2,
+                createResponse.group.id
               )
             ) {
               itemProgressCallback(
@@ -166,14 +153,63 @@ export function createItemFromTemplate(
                   () => resolve(_generateEmptyCreationResponse(template.type))
                 );
             } else {
-              resolve({
-                id: createResponse.group.id,
-                type: newItemTemplate.type,
-                postProcess: false
-              });
+              newItemTemplate.itemId = createResponse.group.id;
+              templateDictionary[template.itemId] = {
+                itemId: createResponse.group.id
+              };
+
+              // Update the template again now that we have the new item id
+              newItemTemplate = common.replaceInTemplate(
+                newItemTemplate,
+                templateDictionary
+              );
+
+              // Update the template dictionary with the new id
+              templateDictionary[template.itemId].itemId =
+                createResponse.group.id;
+
+              // Interrupt process if progress callback returns `false`
+              if (
+                !itemProgressCallback(
+                  createResponse.group.id,
+                  common.EItemProgressStatus.Finished,
+                  template.estimatedDeploymentCostFactor / 2
+                )
+              ) {
+                itemProgressCallback(
+                  createResponse.group.id,
+                  common.EItemProgressStatus.Cancelled,
+                  0
+                );
+                // tslint:disable-next-line: no-floating-promises
+                common
+                  .removeGroup(
+                    createResponse.group.id,
+                    destinationAuthentication
+                  )
+                  .then(
+                    () =>
+                      resolve(_generateEmptyCreationResponse(template.type)),
+                    () => resolve(_generateEmptyCreationResponse(template.type))
+                  );
+              } else {
+                resolve({
+                  id: createResponse.group.id,
+                  type: newItemTemplate.type,
+                  postProcess: false
+                });
+              }
             }
+          } else {
+            itemProgressCallback(
+              template.itemId,
+              common.EItemProgressStatus.Failed,
+              0
+            );
+            resolve(_generateEmptyCreationResponse(template.type)); // fails to create item
           }
-        } else {
+        },
+        () => {
           itemProgressCallback(
             template.itemId,
             common.EItemProgressStatus.Failed,
@@ -181,16 +217,8 @@ export function createItemFromTemplate(
           );
           resolve(_generateEmptyCreationResponse(template.type)); // fails to create item
         }
-      },
-      () => {
-        itemProgressCallback(
-          template.itemId,
-          common.EItemProgressStatus.Failed,
-          0
-        );
-        resolve(_generateEmptyCreationResponse(template.type)); // fails to create item
-      }
-    );
+      );
+    });
   });
 }
 

--- a/packages/group/test/group.test.ts
+++ b/packages/group/test/group.test.ts
@@ -650,16 +650,25 @@ describe("Module `group`: manages the creation and deployment of groups", () => 
       itemTemplate.itemId = itemId;
       itemTemplate.type = "Group";
       itemTemplate.item.title = "Dam Inspection Assignments";
+      itemTemplate.item.thumbnailurl =
+        "abc9cab401af4828a25cc6eaeb59fb69_info_thumbnail/ago_downloaded.png";
 
       const expected: any = { user };
       expected[itemId] = {
         itemId: newItemID
       };
 
-      fetchMock.post(utils.PORTAL_SUBSET.restUrl + "/community/createGroup", {
-        success: true,
-        group: { id: newItemID }
-      });
+      fetchMock
+        .get(
+          utils.PORTAL_SUBSET.restUrl +
+            "/content/items/abc9cab401af4828a25cc6eaeb59fb69/resources/" +
+            itemTemplate.item.thumbnail,
+          utils.getSampleImage()
+        )
+        .post(utils.PORTAL_SUBSET.restUrl + "/community/createGroup", {
+          success: true,
+          group: { id: newItemID }
+        });
       // tslint:disable-next-line: no-floating-promises
       group
         .createItemFromTemplate(

--- a/packages/group/test/group.test.ts
+++ b/packages/group/test/group.test.ts
@@ -650,25 +650,16 @@ describe("Module `group`: manages the creation and deployment of groups", () => 
       itemTemplate.itemId = itemId;
       itemTemplate.type = "Group";
       itemTemplate.item.title = "Dam Inspection Assignments";
-      itemTemplate.item.thumbnailurl =
-        "abc9cab401af4828a25cc6eaeb59fb69_info_thumbnail/ago_downloaded.png";
 
       const expected: any = { user };
       expected[itemId] = {
         itemId: newItemID
       };
 
-      fetchMock
-        .get(
-          utils.PORTAL_SUBSET.restUrl +
-            "/content/items/abc9cab401af4828a25cc6eaeb59fb69/resources/" +
-            itemTemplate.item.thumbnail,
-          utils.getSampleImage()
-        )
-        .post(utils.PORTAL_SUBSET.restUrl + "/community/createGroup", {
-          success: true,
-          group: { id: newItemID }
-        });
+      fetchMock.post(utils.PORTAL_SUBSET.restUrl + "/community/createGroup", {
+        success: true,
+        group: { id: newItemID }
+      });
       // tslint:disable-next-line: no-floating-promises
       group
         .createItemFromTemplate(
@@ -687,6 +678,58 @@ describe("Module `group`: manages the creation and deployment of groups", () => 
           done();
         });
     });
+
+    if (typeof window !== "undefined") {
+      it("should create group with thumbnail", done => {
+        const itemId: string = "abc9cab401af4828a25cc6eaeb59fb69";
+        const newItemID: string = "abc8cab401af4828a25cc6eaeb59fb69";
+        const user: any = {
+          groups: []
+        };
+        const templateDictionary: any = { user };
+
+        const itemTemplate: common.IItemTemplate = templates.getItemTemplateSkeleton();
+        itemTemplate.itemId = itemId;
+        itemTemplate.type = "Group";
+        itemTemplate.item.title = "Dam Inspection Assignments";
+        itemTemplate.item.thumbnailurl =
+          "abc9cab401af4828a25cc6eaeb59fb69_info_thumbnail/ago_downloaded.png";
+
+        const expected: any = { user };
+        expected[itemId] = {
+          itemId: newItemID
+        };
+
+        fetchMock
+          .get(
+            utils.PORTAL_SUBSET.restUrl +
+              "/content/items/abc9cab401af4828a25cc6eaeb59fb69/resources/" +
+              itemTemplate.item.thumbnail,
+            utils.getSampleImage()
+          )
+          .post(utils.PORTAL_SUBSET.restUrl + "/community/createGroup", {
+            success: true,
+            group: { id: newItemID }
+          });
+        // tslint:disable-next-line: no-floating-promises
+        group
+          .createItemFromTemplate(
+            itemTemplate,
+            templateDictionary,
+            MOCK_USER_SESSION,
+            utils.ITEM_PROGRESS_CALLBACK
+          )
+          .then(response => {
+            expect(response).toEqual({
+              id: newItemID,
+              type: itemTemplate.type,
+              postProcess: false
+            });
+            expect(templateDictionary).toEqual(expected);
+            done();
+          });
+      });
+    }
 
     it("should handle success === false on create group", done => {
       const itemId: string = "abc9cab401af4828a25cc6eaeb59fb69";


### PR DESCRIPTION
It appears that group thumbnails have to be handled differently than item thumbnails: one has to send the actual thumbnail [(Group parameters' `thumbnail`)](https://developers.arcgis.com/rest/users-groups-and-items/common-parameters.htm) rather than a URL to a thumbnail. #283