### PR TITLE
[DNM] Allow Solution Model or Id to be passed into deploySolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,23 @@
       "integrity": "sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==",
       "dev": true
     },
+    "@esri/hub-common": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.7.5.tgz",
+      "integrity": "sha512-UQR5/WzQN+vgqx4eiX81+uKXfEi13dj/2vgoccLw4vwahiHEs6t4YYx4UGyfmXDqJlXJDCMIjBCetltsw/fy1g==",
+      "requires": {
+        "fetch-blob": "github:node-fetch/fetch-blob#master",
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -2843,6 +2860,46 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2937,6 +2994,19 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
+    },
+    "@types/sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-v2TkYHkts4VXshMkcmot/H+ERZ2SevKa10saGaJPGCJ8vh3lKrC4u663zYEeRZxep+VbG6YRDtQ6gVqw9dYzPA==",
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
     },
     "@zkochan/cmd-shim": {
       "version": "3.1.0",
@@ -8300,6 +8370,10 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "github:node-fetch/fetch-blob#4a46def45247e7e1fac18b9e399e0969b2c4a962",
+      "from": "github:node-fetch/fetch-blob#master"
+    },
     "fetch-mock": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.7.3.tgz",
@@ -12187,6 +12261,11 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+    },
     "karma": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
@@ -12981,8 +13060,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -13791,6 +13869,33 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -21552,6 +21657,40 @@
         }
       }
     },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -22908,8 +23047,7 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tslint": {
       "version": "5.20.1",
@@ -23053,6 +23191,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -91,20 +91,13 @@
       "dev": true
     },
     "@esri/hub-common": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.7.5.tgz",
-      "integrity": "sha512-UQR5/WzQN+vgqx4eiX81+uKXfEi13dj/2vgoccLw4vwahiHEs6t4YYx4UGyfmXDqJlXJDCMIjBCetltsw/fy1g==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.7.6.tgz",
+      "integrity": "sha512-bcQ6Kd9JgXn6aUcbF909ljRieDx0shUmbVA+fZuQGmOXqw53irJ19iVTSHJVk/qkM6vI1fxUUhMiuOoFUIC8jg==",
       "requires": {
         "fetch-blob": "github:node-fetch/fetch-blob#master",
         "node-fetch": "^2.6.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        }
       }
     },
     "@evocateur/libnpmaccess": {
@@ -1119,12 +1112,6 @@
         "whatwg-url": "^7.0.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
         "whatwg-url": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
@@ -2276,12 +2263,6 @@
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
           "dev": true
         },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
         "universal-user-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
@@ -2329,9 +2310,9 @@
       }
     },
     "@octokit/types": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.12.1.tgz",
-      "integrity": "sha512-LRLR1tjbcCfAmUElvTmMvLEzstpx6Xt/aQVTg2xvd+kHA2Ekp1eWl5t+gU7bcwjXHYEAzh4hH4WH+kS3vh+wRw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.12.2.tgz",
+      "integrity": "sha512-1GHLI/Jll3j6F0GbYyZPFTcHZMGjAiRfkTEoRUyaVVk2IWbDdwEiClAJvXzfXCDayuGSNCqAUH8lpjZtqW9GDw==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -2366,14 +2347,14 @@
       }
     },
     "@rollup/pluginutils": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.9.tgz",
-      "integrity": "sha512-TLZavlfPAZYI7v33wQh4mTP6zojne14yok3DNSLcjoG/Hirxfkonn6icP5rrNWRn8nZsirJBFFpijVOJzkUHDg==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.10.tgz",
+      "integrity": "sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
-        "micromatch": "^4.0.2"
+        "picomatch": "^2.2.2"
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -2438,6 +2419,15 @@
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
           "dev": true
         },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
         "dir-glob": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2459,6 +2449,15 @@
             "merge2": "^1.3.0",
             "micromatch": "^4.0.2",
             "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
           }
         },
         "fs-extra": {
@@ -2513,6 +2512,12 @@
           "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
         },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -2522,10 +2527,20 @@
             "graceful-fs": "^4.1.6"
           }
         },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+          "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
           "dev": true
         },
         "path-type": {
@@ -2539,6 +2554,15 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         }
       }
     },
@@ -2864,6 +2888,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
       "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -2872,6 +2897,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -2880,6 +2906,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
       "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
         "@sinonjs/samsam": "^5.0.2"
@@ -2889,6 +2916,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
       "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -2898,7 +2926,8 @@
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -2999,6 +3028,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.0.tgz",
       "integrity": "sha512-v2TkYHkts4VXshMkcmot/H+ERZ2SevKa10saGaJPGCJ8vh3lKrC4u663zYEeRZxep+VbG6YRDtQ6gVqw9dYzPA==",
+      "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -3006,7 +3036,8 @@
     "@types/sinonjs__fake-timers": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
     },
     "@zkochan/cmd-shim": {
       "version": "3.1.0",
@@ -3269,99 +3300,6 @@
         "normalize-path": "^2.1.1"
       },
       "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -3369,16 +3307,6 @@
           "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
           }
         }
       }
@@ -3472,6 +3400,12 @@
       "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -3556,15 +3490,17 @@
       },
       "dependencies": {
         "util": {
-          "version": "0.12.2",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
-          "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "is-arguments": "^1.0.4",
             "is-generator-function": "^1.0.7",
-            "safe-buffer": "^5.1.2"
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
           }
         }
       }
@@ -3630,6 +3566,15 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
       "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -4751,12 +4696,32 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "brorand": {
@@ -4829,63 +4794,11 @@
         "yargs": "6.4.0"
       },
       "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
         },
         "find-up": {
           "version": "1.1.2",
@@ -4908,26 +4821,6 @@
             "universalify": "^0.1.0"
           }
         },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "load-json-file": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -4939,27 +4832,6 @@
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0",
             "strip-bom": "^2.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
           }
         },
         "parse-json": {
@@ -5025,16 +4897,6 @@
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
           }
         },
         "yargs": {
@@ -5404,9 +5266,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001045",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001045.tgz",
-      "integrity": "sha512-Y8o2Iz1KPcD6FjySbk1sPpvJqchgxk/iow0DABpGyzA1UeQAuxh63Xh0Enj5/BrsYbXtCN32JmR4ZxQTCQ6E6A==",
+      "version": "1.0.30001050",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001050.tgz",
+      "integrity": "sha512-OvGZqalCwmapci76ISq5q4kuAskb1ebqF3FEQBv1LE1kWht0pojlDDqzFlmk5jgYkuZN7MNZ1n+ULwe/7MaDNQ==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -5492,75 +5354,6 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "chownr": {
@@ -7467,9 +7260,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.414",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.414.tgz",
-      "integrity": "sha512-UfxhIvED++qLwWrAq9uYVcqF8FdeV9sU2S7qhiHYFODxzXRrd1GZRl/PjITHsTEejgibcWDraD8TQqoHb1aCBQ==",
+      "version": "1.3.427",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.427.tgz",
+      "integrity": "sha512-/rG5G7Opcw68/Yrb4qYkz07h3bESVRJjUl4X/FrKLXzoUJleKm6D7K7rTTz8V5LUWnd+BbTOyxJX2XprRqHD8A==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7744,9 +7537,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
-      "integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
+      "integrity": "sha512-hQBkDf2iO4Nv0CNHpCuSBeaSrveU6nThVxFGTrq/eDlV716UQk09zChaJae4mZRsos1x4YLY2TaH3LHUae3ZmQ==",
       "dev": true
     },
     "err-code": {
@@ -8233,111 +8026,6 @@
         "is-glob": "^4.0.0",
         "merge2": "^1.2.3",
         "micromatch": "^3.1.10"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
@@ -8458,12 +8146,26 @@
       "dev": true
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "to-regex-range": "^5.0.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "finalhandler": {
@@ -8643,111 +8345,6 @@
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "flatted": {
@@ -8806,6 +8403,12 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -10474,9 +10077,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "gzip-size": {
@@ -10622,26 +10225,6 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -10654,13 +10237,33 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
       }
     },
     "hash.js": {
@@ -11601,6 +11204,12 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -11709,10 +11318,24 @@
       "dev": true
     },
     "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "is-number-like": {
       "version": "1.0.8",
@@ -11781,9 +11404,9 @@
       "dev": true
     },
     "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
     },
     "is-property": {
@@ -11858,6 +11481,18 @@
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -11935,6 +11570,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isomorphic-form-data": {
@@ -12264,7 +11910,8 @@
     "just-extend": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
     },
     "karma": {
       "version": "4.4.1",
@@ -12316,10 +11963,19 @@
           "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
           "dev": true
         },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
         "chokidar": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
@@ -12329,7 +11985,7 @@
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.3.0"
+            "readdirp": "~3.4.0"
           }
         },
         "colors": {
@@ -12337,6 +11993,15 @@
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
         },
         "fsevents": {
           "version": "2.1.3",
@@ -12363,19 +12028,25 @@
             "binary-extensions": "^2.0.0"
           }
         },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+          "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
           "dev": true
         },
         "readdirp": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
           "dev": true,
           "requires": {
-            "picomatch": "^2.0.7"
+            "picomatch": "^2.2.1"
           }
         },
         "source-map": {
@@ -12383,6 +12054,15 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         }
       }
     },
@@ -12428,10 +12108,13 @@
       },
       "dependencies": {
         "is-wsl": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
-          "dev": true
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
         }
       }
     },
@@ -12618,15 +12301,17 @@
           }
         },
         "util": {
-          "version": "0.12.2",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
-          "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+          "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "is-arguments": "^1.0.4",
             "is-generator-function": "^1.0.7",
-            "safe-buffer": "^5.1.2"
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
           }
         }
       }
@@ -13060,7 +12745,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -13583,13 +13269,24 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -13609,16 +13306,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -13874,6 +13571,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
       "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
@@ -13885,12 +13583,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -13907,13 +13607,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-fetch-npm": {
       "version": "2.0.4",
@@ -14073,9 +13769,9 @@
       }
     },
     "node-sass": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.0.tgz",
+      "integrity": "sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -18185,10 +17881,20 @@
           "dev": true,
           "optional": true
         },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
         "chokidar": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18199,7 +17905,7 @@
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.3.0"
+            "readdirp": "~3.4.0"
           }
         },
         "commander": {
@@ -18207,6 +17913,16 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
           "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
           "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
         },
         "fsevents": {
           "version": "2.1.3",
@@ -18235,14 +17951,31 @@
             "binary-extensions": "^2.0.0"
           }
         },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true,
+          "optional": true
+        },
         "readdirp": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "picomatch": "^2.0.7"
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -18436,10 +18169,19 @@
           "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
           "dev": true
         },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
         "chokidar": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
@@ -18449,7 +18191,7 @@
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.3.0"
+            "readdirp": "~3.4.0"
           }
         },
         "cross-spawn": {
@@ -18461,6 +18203,15 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
           }
         },
         "fsevents": {
@@ -18500,6 +18251,12 @@
             "binary-extensions": "^2.0.0"
           }
         },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -18507,12 +18264,12 @@
           "dev": true
         },
         "readdirp": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
           "dev": true,
           "requires": {
-            "picomatch": "^2.0.7"
+            "picomatch": "^2.2.1"
           }
         },
         "shebang-command": {
@@ -18537,6 +18294,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
           }
         },
         "which": {
@@ -19206,9 +18972,9 @@
       }
     },
     "portfinder": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -19697,111 +19463,6 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
       }
     },
     "rechoir": {
@@ -20482,9 +20143,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
-          "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -20620,13 +20281,10 @@
       }
     },
     "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "run-parallel": {
       "version": "1.1.9",
@@ -20679,9 +20337,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.6.tgz",
+      "integrity": "sha512-MKuEYXFSGuRSi8FZ3A7imN1CeVn9Gpw0/SFJKdL1ejXJneI9a5rwlEZrKejhEFAA3O6yr3eIyl/WuvASvlT36g==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -21661,6 +21319,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
       "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.2",
         "@sinonjs/fake-timers": "^6.0.1",
@@ -21674,17 +21333,20 @@
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -22704,14 +22366,6 @@
         "node-fetch": "^2.2.0",
         "stream-events": "^1.0.5",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        }
       }
     },
     "temp": {
@@ -22773,9 +22427,9 @@
       }
     },
     "terser": {
-      "version": "4.6.11",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
-      "integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+      "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -22790,9 +22444,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
-          "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -22919,12 +22573,13 @@
       }
     },
     "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^7.0.0"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "toidentifier": {
@@ -23008,9 +22663,9 @@
       }
     },
     "ts-node": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.9.0.tgz",
-      "integrity": "sha512-rwkXfOs9zmoHrV8xE++dmNd6ZIS+nmHHCxcV53ekGJrxFLMbp+pizpPS07ARvhwneCIECPppOwbZHvw9sQtU4w==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -23033,9 +22688,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
-          "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -23195,7 +22850,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",
@@ -23265,9 +22921,9 @@
           "dev": true
         },
         "shelljs": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-          "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+          "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
           "dev": true,
           "requires": {
             "glob": "^7.0.0",
@@ -23314,9 +22970,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
-      "integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.2.tgz",
+      "integrity": "sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -23752,6 +23408,20 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,16 +90,6 @@
       "integrity": "sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==",
       "dev": true
     },
-    "@esri/hub-common": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.7.6.tgz",
-      "integrity": "sha512-bcQ6Kd9JgXn6aUcbF909ljRieDx0shUmbVA+fZuQGmOXqw53irJ19iVTSHJVk/qkM6vI1fxUUhMiuOoFUIC8jg==",
-      "requires": {
-        "fetch-blob": "github:node-fetch/fetch-blob#master",
-        "node-fetch": "^2.6.0",
-        "tslib": "^1.11.1"
-      }
-    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -8058,10 +8048,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fetch-blob": {
-      "version": "github:node-fetch/fetch-blob#4a46def45247e7e1fac18b9e399e0969b2c4a962",
-      "from": "github:node-fetch/fetch-blob#master"
-    },
     "fetch-mock": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.7.3.tgz",
@@ -13609,7 +13595,8 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-fetch-npm": {
       "version": "2.0.4",
@@ -22702,7 +22689,8 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
     },
     "tslint": {
       "version": "5.20.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "sinon": "^9.0.2"
   },
   "dependencies": {
-    "@esri/hub-common": "^3.7.5",
     "es6-promise": "^4.2.1",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "es6-promise": "^4.2.1",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0"
-
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -69,12 +69,16 @@
     "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.15.0",
     "typescript": "^3.8.3",
-    "uuid": "^3.3.3"
+    "uuid": "^3.3.3",
+    "@types/sinon": "^9.0.0",
+    "sinon": "^9.0.2"
   },
   "dependencies": {
+    "@esri/hub-common": "^3.7.5",
     "es6-promise": "^4.2.1",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0"
+
   },
   "lint-staged": {
     "*.ts": [

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -14,53 +14,53 @@
 			}
 		},
 		"@esri/arcgis-rest-auth": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.11.0.tgz",
-			"integrity": "sha512-T4OnGmw5OIOEx9N0y1HeIpyU8cNc/UZKSwPWiH9yt8i2CNko5FS7F3uO4VoLgmarrVnc3v59FpT1ZctwIuTKeA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.12.1.tgz",
+			"integrity": "sha512-watQZnzH988a7A0o17ywZBeNnUClu66mg6CEnTRx8wCf/B7r5wI6CXXwvnN+1uP0azFAb/66x12NVTFsN3mz6g==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.11.0",
+				"@esri/arcgis-rest-types": "^2.12.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-feature-layer": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.11.0.tgz",
-			"integrity": "sha512-zYjX7R79+TO0jvV9aAEWmJedHHj/KoDZllxZ+UdxLz+eef0bvXq5L8udw8E3GWsLHsNWq8cDU91wH012qYQynw==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.12.1.tgz",
+			"integrity": "sha512-MTtAyJZ71Rp57IZjUe3jTPFXtfa3pVgWlUwNnZVTz/wFyIjnd5DKHt7N9GnMQAblyhCy2MR25bNbQSMyyaiIAw==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.11.0",
+				"@esri/arcgis-rest-types": "^2.12.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.11.0.tgz",
-			"integrity": "sha512-bqs8TYkqZvtH7RbQy8F6Qk5K2EmQb1lTrS0KZ3snOdyeUYhV+DR7QEw1chiTtNRVoeZwX3hB0xTz8E67Ddmi1A==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.12.1.tgz",
+			"integrity": "sha512-hsJqmrfUa0B6sQBKpTqZicPOK72ZTX0b5Has4tfR2Pw0KtrCSlm29jdxVH1udP9Unf9XCiq89epZ0BBQvvk0CQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.11.0",
+				"@esri/arcgis-rest-types": "^2.12.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.11.0.tgz",
-			"integrity": "sha512-cIot16FUYc0coR2cSRTxqsOsfUZOL9U9br1PlCB+T95/HbCDJrL4dnA19wdiXLIfPunt1Xr7yr547PYPAZXU3w==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.12.1.tgz",
+			"integrity": "sha512-r/fF/go2ZBFjvBtKYjQ/+JxCcftzZ67fSiXrKSQoK7e+Eie7B3VmnGu/z7ziBPX5ssI+WfWwibFrNwVVFrBuQQ==",
 			"requires": {
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-service-admin": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.11.0.tgz",
-			"integrity": "sha512-7cUs3CI93fuahCPT+aWX7oqi2B+X0ls8JeAwaVLT/+8T6bYI+AHuzAGNysb6b+gQyEAoyogltPDaYjxXZb0KrA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.12.1.tgz",
+			"integrity": "sha512-6+pPC2ajh1AD05ss+PJu9RWMl1sRCWL++6umjkshCW5ny2OvxeuaaavRABOiKRLwUi7TfVc3nfQQzyVKN1iN5A==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.11.0",
+				"@esri/arcgis-rest-types": "^2.12.1",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.11.0.tgz",
-			"integrity": "sha512-4rbvFWxXHgJO/ePYdQ6razw7D8xU8ktVwJ8Fhk58GoRJr+5R99i/YtmGunk/TAEAssssaAt11W5WoQqVNoEAMA=="
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.12.1.tgz",
+			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ=="
 		},
 		"@types/adlib": {
 			"version": "3.0.1",
@@ -88,9 +88,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/creator/package-lock.json
+++ b/packages/creator/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -39,6 +39,16 @@
 			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ==",
 			"dev": true
 		},
+		"@esri/hub-common": {
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.7.6.tgz",
+			"integrity": "sha512-bcQ6Kd9JgXn6aUcbF909ljRieDx0shUmbVA+fZuQGmOXqw53irJ19iVTSHJVk/qkM6vI1fxUUhMiuOoFUIC8jg==",
+			"requires": {
+				"fetch-blob": "github:node-fetch/fetch-blob#master",
+				"node-fetch": "^2.6.0",
+				"tslib": "^1.11.1"
+			}
+		},
 		"@types/estree": {
 			"version": "0.0.44",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
@@ -56,6 +66,30 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
 			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
 			"dev": true
+		},
+		"adlib": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.4.tgz",
+			"integrity": "sha512-Xcr/XU4dfy8L7cdk7068oYoUEVqrryRoRwazP0VPzCiMmT651g6H0/z14xzRHbVGJr5HWisYyqi6ktgITufYAQ==",
+			"dev": true,
+			"requires": {
+				"esm": "^3.2.25"
+			}
+		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+			"dev": true
+		},
+		"fetch-blob": {
+			"version": "github:node-fetch/fetch-blob#4a46def45247e7e1fac18b9e399e0969b2c4a962",
+			"from": "github:node-fetch/fetch-blob#master"
+		},
+		"node-fetch": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"rollup": {
 			"version": "1.32.1",

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -4,6 +4,37 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@esri/arcgis-rest-auth": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.12.1.tgz",
+			"integrity": "sha512-watQZnzH988a7A0o17ywZBeNnUClu66mg6CEnTRx8wCf/B7r5wI6CXXwvnN+1uP0azFAb/66x12NVTFsN3mz6g==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.12.1",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-portal": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.12.1.tgz",
+			"integrity": "sha512-hsJqmrfUa0B6sQBKpTqZicPOK72ZTX0b5Has4tfR2Pw0KtrCSlm29jdxVH1udP9Unf9XCiq89epZ0BBQvvk0CQ==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.12.1",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-request": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.12.1.tgz",
+			"integrity": "sha512-r/fF/go2ZBFjvBtKYjQ/+JxCcftzZ67fSiXrKSQoK7e+Eie7B3VmnGu/z7ziBPX5ssI+WfWwibFrNwVVFrBuQQ==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.12.1.tgz",
+			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ=="
+		},
 		"@types/estree": {
 			"version": "0.0.44",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
@@ -11,9 +42,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -23,10 +23,12 @@
     "@esri/arcgis-rest-portal": "^2.11.0",
     "@esri/arcgis-rest-request": "^2.11.0",
     "@esri/arcgis-rest-types": "^2.11.0",
+    "adlib": "^3.0.4",
     "rollup": "^1.22.0",
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@esri/hub-common": "^3.7.5",
     "@esri/solution-common": "^0.9.2",
     "@esri/solution-feature-layer": "^0.9.2",
     "@esri/solution-file": "^0.9.2",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -17,6 +17,10 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@esri/arcgis-rest-auth": "^2.11.0",
+    "@esri/arcgis-rest-portal": "^2.11.0",
+    "@esri/arcgis-rest-request": "^2.11.0",
+    "@esri/arcgis-rest-types": "^2.11.0",
     "@esri/solution-common": "^0.9.2",
     "@esri/solution-feature-layer": "^0.9.2",
     "@esri/solution-file": "^0.9.2",

--- a/packages/deployer/src/deploySolutionFromTemplate.ts
+++ b/packages/deployer/src/deploySolutionFromTemplate.ts
@@ -1,0 +1,362 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from "@esri/solution-common";
+import * as deployItems from "./deploySolutionItems";
+
+// NOTE: Moved to separate file to allow stubbing in main deploySolution tests
+
+export function _deploySolutionFromTemplate(
+  templateSolutionId: string,
+  solutionTemplateBase: any,
+  solutionTemplateData: any,
+  solutionTemplateMetadata: File,
+  authentication: common.UserSession,
+  options: common.IDeploySolutionOptions
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Replacement dictionary and high-level deployment ids for cleanup
+    const templateDictionary = options.templateDictionary ?? {};
+    let deployedFolderId: string;
+    let deployedSolutionId: string;
+
+    ["title", "snippet", "description", "tags", "thumbnailurl"].forEach(
+      property => {
+        if (options[property]) {
+          solutionTemplateBase[property] = options[property];
+        }
+      }
+    );
+
+    if (options.additionalTypeKeywords) {
+      solutionTemplateBase.typeKeywords = [].concat(
+        solutionTemplateBase.typeKeywords,
+        options.additionalTypeKeywords
+      );
+    }
+
+    // Get information about deployment environment
+    Promise.all([
+      common.getPortal("", authentication), // determine if we are deploying to portal
+      common.getUser(authentication), // find out about the user
+      common.getFoldersAndGroups(authentication) // get all folders so that we can create a unique one, and all groups
+    ])
+      .then(responses => {
+        const [
+          portalResponse,
+          userResponse,
+          foldersAndGroupsResponse
+        ] = responses;
+
+        // Initialize replacement dictionary
+        // swap user defined params before we start...no need to wait
+        if (solutionTemplateData.params) {
+          templateDictionary.params = solutionTemplateData.params;
+          solutionTemplateData.templates = solutionTemplateData.templates.map(
+            (template: any) => {
+              return common.replaceInTemplate(template, templateDictionary);
+            }
+          );
+        }
+
+        // update template items with source-itemId type keyword
+        solutionTemplateData.templates = solutionTemplateData.templates.map(
+          (template: any) => {
+            const sourceId: string = "source-" + template.itemId;
+            /* istanbul ignore else */
+            if (template.item) {
+              /* istanbul ignore else */
+              if (template.item!.typeKeywords) {
+                template.item!.typeKeywords!.push(sourceId);
+              }
+              /* istanbul ignore else */
+              if (
+                template.item!.tags &&
+                common.getProp(template, "item.type") === "Group"
+              ) {
+                template.item!.tags!.push(sourceId);
+              }
+            }
+            return template;
+          }
+        );
+
+        templateDictionary.isPortal = portalResponse.isPortal;
+        templateDictionary.organization = Object.assign(
+          templateDictionary.organization || {},
+          portalResponse
+        );
+
+        // As of Spring 2020, only HTTPS (see
+        // https://www.esri.com/arcgis-blog/products/product/administration/2019-arcgis-transport-security-improvements/)
+        const scheme: string = "https"; // portalResponse.allSSL ? "https" : "http";
+        const urlKey: string = common.getProp(portalResponse, "urlKey");
+        const customBaseUrl: string = common.getProp(
+          portalResponse,
+          "customBaseUrl"
+        );
+        templateDictionary.portalBaseUrl =
+          urlKey && customBaseUrl
+            ? `${scheme}://${urlKey}.${customBaseUrl}`
+            : authentication.portal;
+
+        templateDictionary.user = userResponse;
+        templateDictionary.user.folders = foldersAndGroupsResponse.folders;
+        templateDictionary.user.groups = foldersAndGroupsResponse.groups;
+
+        // Create a folder to hold the deployed solution. We use the solution name, appending a sequential
+        // suffix if the folder exists, e.g.,
+        //  * Manage Right of Way Activities
+        //  * Manage Right of Way Activities 1
+        //  * Manage Right of Way Activities 2
+        const folderPromise = common.createUniqueFolder(
+          solutionTemplateBase.title,
+          templateDictionary,
+          authentication
+        );
+
+        // Apply the portal extents to the solution
+        const portalExtent: any = portalResponse.defaultExtent;
+        const extentsPromise = common.convertExtent(
+          portalExtent,
+          { wkid: 4326 },
+          portalResponse.helperServices.geometry.url,
+          authentication
+        );
+
+        // Await completion of async actions: folder creation & extents conversion
+        return Promise.all([folderPromise, extentsPromise]);
+      })
+      .then(responses => {
+        const [folderResponse, wgs84Extent] = responses;
+        deployedFolderId = folderResponse.folder.id;
+        templateDictionary.folderId = deployedFolderId;
+        templateDictionary.solutionItemExtent =
+          wgs84Extent.xmin +
+          "," +
+          wgs84Extent.ymin +
+          "," +
+          wgs84Extent.xmax +
+          "," +
+          wgs84Extent.ymax;
+
+        // Create a deployed Solution item
+        const createSolutionItemBase = {
+          ...common.sanitizeJSONAndReportChanges(solutionTemplateBase),
+          type: "Solution",
+          typeKeywords: ["Solution"]
+        };
+
+        if (options.additionalTypeKeywords) {
+          createSolutionItemBase.typeKeywords = ["Solution"].concat(
+            options.additionalTypeKeywords
+          );
+        }
+
+        return common.createItemWithData(
+          createSolutionItemBase,
+          {},
+          authentication,
+          deployedFolderId
+        );
+      })
+      .then(createSolutionResponse => {
+        deployedSolutionId = createSolutionResponse.id;
+
+        templateDictionary.solutionItemId = deployedSolutionId;
+        solutionTemplateBase.id = deployedSolutionId;
+
+        return common.addTokenToUrl(options.thumbnailurl, authentication);
+      })
+      .then(updatedThumbnailUrl => {
+        /* istanbul ignore else */
+        if (updatedThumbnailUrl) {
+          solutionTemplateBase.thumbnailurl = common.appendQueryParam(
+            updatedThumbnailUrl,
+            "w=400"
+          );
+        }
+
+        solutionTemplateBase.tryitUrl = _checkedReplaceAll(
+          solutionTemplateBase.tryitUrl,
+          templateSolutionId,
+          deployedSolutionId
+        );
+        solutionTemplateBase.url = _checkedReplaceAll(
+          solutionTemplateBase.url,
+          templateSolutionId,
+          deployedSolutionId
+        );
+
+        // Handle the contained item templates
+        return deployItems.deploySolutionItems(
+          authentication.portal,
+          templateSolutionId,
+          solutionTemplateData.templates,
+          authentication,
+          templateDictionary,
+          authentication,
+          options
+        );
+      })
+      .then(clonedSolutionsResponse => {
+        solutionTemplateData.templates = solutionTemplateData.templates.map(
+          (itemTemplate: common.IItemTemplate) => {
+            // Update ids present in template dictionary
+            const itemId = common.getProp(
+              templateDictionary,
+              itemTemplate.itemId + ".itemId"
+            );
+            /* istanbul ignore else */
+            if (itemId) {
+              itemTemplate.itemId = itemId;
+            }
+            itemTemplate.dependencies = itemTemplate.dependencies.map(id =>
+              _getNewItemId(id, templateDictionary)
+            );
+            return itemTemplate;
+          }
+        );
+
+        return deployItems.postProcessDependencies(
+          solutionTemplateData.templates,
+          clonedSolutionsResponse,
+          authentication,
+          templateDictionary
+        );
+      })
+      .then(() => {
+        // Update solution item using internal representation & and the updated data JSON
+        solutionTemplateBase.typeKeywords = [].concat(
+          solutionTemplateBase.typeKeywords,
+          ["Deployed"]
+        );
+        const iTemplateKeyword = solutionTemplateBase.typeKeywords.indexOf(
+          "Template"
+        );
+        /* istanbul ignore else */
+        if (iTemplateKeyword >= 0) {
+          solutionTemplateBase.typeKeywords.splice(iTemplateKeyword, 1);
+        }
+
+        solutionTemplateData.templates = solutionTemplateData.templates.map(
+          (itemTemplate: common.IItemTemplate) =>
+            _purgeTemplateProperties(itemTemplate)
+        );
+
+        solutionTemplateData.templates = _updateGroupReferences(
+          solutionTemplateData.templates,
+          templateDictionary
+        );
+
+        // Update solution items data using template dictionary, and then update the
+        // itemId & dependencies in each item template
+        solutionTemplateBase.data = common.replaceInTemplate(
+          solutionTemplateData,
+          templateDictionary
+        );
+
+        // Pass metadata in via params because item property is serialized, which discards a File
+        return common.updateItem(
+          solutionTemplateBase,
+          authentication,
+          deployedFolderId,
+          { metadata: solutionTemplateMetadata }
+        );
+      })
+      .then(
+        () => resolve(solutionTemplateBase.id),
+        error => {
+          // Cleanup solution folder and deployed solution item
+          const cleanupPromises = [] as Array<Promise<any>>;
+          if (deployedFolderId) {
+            cleanupPromises.push(
+              common.removeFolder(deployedFolderId, authentication)
+            );
+          }
+          if (deployedSolutionId) {
+            cleanupPromises.push(
+              common.removeItem(deployedSolutionId, authentication)
+            );
+          }
+          Promise.all(cleanupPromises).then(
+            () => reject(error),
+            () => reject(error)
+          );
+        }
+      );
+  });
+}
+
+export function _checkedReplaceAll(
+  template: string,
+  oldValue: string,
+  newValue: string
+): string {
+  let newTemplate;
+  if (template && template.indexOf(oldValue) > -1) {
+    const re = new RegExp(oldValue, "g");
+    newTemplate = template.replace(re, newValue);
+  } else {
+    newTemplate = template;
+  }
+  return newTemplate;
+}
+
+export function _updateGroupReferences(
+  itemTemplates: any[],
+  templateDictionary: any
+): any[] {
+  const groupIds = itemTemplates.reduce(
+    (result: string[], t: common.IItemTemplate) => {
+      if (t.type === "Group") {
+        result.push(t.itemId);
+      }
+      return result;
+    },
+    []
+  );
+
+  Object.keys(templateDictionary).forEach(k => {
+    const newId: string = templateDictionary[k].itemId;
+    if (groupIds.indexOf(newId) > -1) {
+      itemTemplates.forEach(t => {
+        t.groups = t.groups.map((id: string) => (id === k ? newId : id));
+      });
+    }
+  });
+  return itemTemplates;
+}
+
+export function _purgeTemplateProperties(itemTemplate: any): any {
+  const retainProps: string[] = ["itemId", "type", "dependencies", "groups"];
+  const deleteProps: string[] = Object.keys(itemTemplate).filter(
+    k => retainProps.indexOf(k) < 0
+  );
+  common.deleteProps(itemTemplate, deleteProps);
+  return itemTemplate;
+}
+
+/**
+ * Returns a match of a supplied id with the suffix ".itemId" in the template dictionary.
+ *
+ * @param id Id to look for
+ * @param templateDictionary Hash mapping property names to replacement values
+ * @return Match in template dictionary or original id
+ */
+export function _getNewItemId(id: string, templateDictionary: any): string {
+  return common.getProp(templateDictionary, id + ".itemId") ?? id;
+}

--- a/packages/deployer/src/deployer.ts
+++ b/packages/deployer/src/deployer.ts
@@ -21,458 +21,93 @@
  */
 
 import * as common from "@esri/solution-common";
-import * as deployItems from "./deploySolutionItems";
 
-//#region Entry point ----------------------------------------------------------------------------------------------- //
+import { _deploySolutionFromTemplate } from "./deploySolutionFromTemplate";
+import {
+  _getSolutionTemplateItem,
+  isSolutionTemplateItem,
+  _updateDeployOptions
+} from "./deployerUtils";
+import { IModel } from "@esri/hub-common";
 
+/**
+ * Deploy a Solution
+ * Pass in either the item id or an IModel (`{item:{}, model:{}}`)
+ * of a Solution Template, and this will generate the Solution
+ * @param maybeModel Item Id or IModel
+ * @param authentication UserSession
+ * @param options object
+ */
 export function deploySolution(
-  templateSolutionId: string,
+  maybeModel: string | IModel,
   authentication: common.UserSession,
   options?: common.IDeploySolutionOptions
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    if (!templateSolutionId) {
-      reject(common.fail("The Solution Template id is missing"));
-    }
+  // if we are not passed the maybeModel, reject
+  if (!maybeModel) {
+    return Promise.reject(common.fail("The Solution Template id is missing"));
+  }
+  let deployOptions: common.IDeploySolutionOptions = options || {};
+  /* istanbul ignore else */
+  if (deployOptions.progressCallback) {
+    deployOptions.progressCallback(1); // let the caller know that we've started
+  }
+  // deal with maybe getting an item or an id
+  return _getSolutionTemplateItem(maybeModel, authentication)
+    .then(model => {
+      if (!isSolutionTemplateItem(model.item)) {
+        return Promise.reject(
+          common.fail(`${model.item.id} is not a Solution Template`)
+        );
+      } else {
+        // fetch the metadata and pass the item & data forward
+        return Promise.all([
+          Promise.resolve(model.item),
+          Promise.resolve(model.data),
+          common.getItemMetadataAsFile(model.item.id, authentication)
+        ]);
+      }
+    })
+    .then(responses => {
+      // extract responses
+      const [itemBase, itemData, itemMetadata] = responses;
+      // sanitize all the things
+      const sanitizer = new common.Sanitizer();
+      const item = common.sanitizeJSONAndReportChanges(itemBase, sanitizer);
+      // TODO: we should delegate data sanization to the type-specific modules
+      const data = common.sanitizeJSONAndReportChanges(itemData, sanitizer);
+      // apply item props to deployOptions
+      deployOptions = _updateDeployOptions(deployOptions, item, authentication);
+      // Clone before mutating? This was messing me up in some testing...
+      common.deleteItemProps(item);
 
-    const deployOptions: common.IDeploySolutionOptions = options || {};
-    /* istanbul ignore else */
-    if (deployOptions.progressCallback) {
-      deployOptions.progressCallback(1); // let the caller know that we've started
-    }
-
-    // Fetch solution item's info
-    Promise.all([
-      common.getItemBase(templateSolutionId, authentication),
-      common.getItemDataAsJson(templateSolutionId, authentication),
-      common.getItemMetadataAsFile(templateSolutionId, authentication)
-    ]).then(
-      responses => {
-        const [itemBase, itemData, itemMetadata] = responses;
-
-        if (
-          itemBase.type !== "Solution" ||
-          itemBase.typeKeywords.indexOf("Solution") < 0 ||
-          itemBase.typeKeywords.indexOf("Template") < 0
-        ) {
-          reject(
-            common.fail(templateSolutionId + " is not a Solution Template")
-          );
-        } else {
-          deployOptions.jobId = deployOptions.jobId ?? templateSolutionId;
-          deployOptions.title = deployOptions.title ?? itemBase.title;
-          deployOptions.snippet = deployOptions.snippet ?? itemBase.snippet;
-          deployOptions.description =
-            deployOptions.description ?? itemBase.description;
-          deployOptions.tags = deployOptions.tags ?? itemBase.tags;
-          deployOptions.thumbnailurl = common.getItemThumbnailUrl(
-            templateSolutionId,
-            itemBase.thumbnail,
-            false,
-            authentication
-          );
-
-          common.deleteItemProps(itemBase);
-
-          // Sanitize individual parts of deployOptions because sanitizer gets rid of progress callback
-          const sanitizer = new common.Sanitizer();
-          deployOptions.title = common.sanitizeJSONAndReportChanges(
-            deployOptions.title,
-            sanitizer
-          );
-          deployOptions.snippet = common.sanitizeJSONAndReportChanges(
-            deployOptions.snippet,
-            sanitizer
-          );
-          deployOptions.description = common.sanitizeJSONAndReportChanges(
-            deployOptions.description,
-            sanitizer
-          );
-
-          _deploySolutionFromTemplate(
-            templateSolutionId,
-            common.sanitizeJSONAndReportChanges(itemBase, sanitizer),
-            common.sanitizeJSONAndReportChanges(itemData, sanitizer),
-            itemMetadata,
-            authentication,
-            deployOptions
-          ).then(
-            createdSolutionId => {
-              /* istanbul ignore else */
-              if (deployOptions.progressCallback) {
-                deployOptions.progressCallback(100); // we're done
-              }
-              resolve(createdSolutionId);
-            },
-            error => {
-              // Error deploying solution
-              /* istanbul ignore else */
-              if (deployOptions.progressCallback) {
-                deployOptions.progressCallback(1);
-              }
-              reject(error);
-            }
-          );
+      return _deploySolutionFromTemplate(
+        item.id,
+        item,
+        data,
+        itemMetadata,
+        authentication,
+        deployOptions
+      );
+    })
+    .then(
+      createdSolutionId => {
+        /* istanbul ignore else */
+        if (deployOptions.progressCallback) {
+          deployOptions.progressCallback(100); // we're done
         }
+        return createdSolutionId;
       },
       error => {
-        // Error fetching solution
+        // Error deploying solution
         /* istanbul ignore else */
         if (deployOptions.progressCallback) {
           deployOptions.progressCallback(1);
         }
-        reject(error);
+        return Promise.reject(error);
       }
-    );
-  });
+    )
+    .catch(ex => {
+      throw ex;
+    });
 }
-
-//#endregion ---------------------------------------------------------------------------------------------------------//
-
-//#region Supporting routines --------------------------------------------------------------------------------------- //
-
-export function _deploySolutionFromTemplate(
-  templateSolutionId: string,
-  solutionTemplateBase: any,
-  solutionTemplateData: any,
-  solutionTemplateMetadata: File,
-  authentication: common.UserSession,
-  options: common.IDeploySolutionOptions
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    // Replacement dictionary and high-level deployment ids for cleanup
-    const templateDictionary = options.templateDictionary ?? {};
-    let deployedFolderId: string;
-    let deployedSolutionId: string;
-
-    ["title", "snippet", "description", "tags", "thumbnailurl"].forEach(
-      property => {
-        if (options[property]) {
-          solutionTemplateBase[property] = options[property];
-        }
-      }
-    );
-
-    if (options.additionalTypeKeywords) {
-      solutionTemplateBase.typeKeywords = [].concat(
-        solutionTemplateBase.typeKeywords,
-        options.additionalTypeKeywords
-      );
-    }
-
-    // Get information about deployment environment
-    Promise.all([
-      common.getPortal("", authentication), // determine if we are deploying to portal
-      common.getUser(authentication), // find out about the user
-      common.getFoldersAndGroups(authentication) // get all folders so that we can create a unique one, and all groups
-    ])
-      .then(responses => {
-        const [
-          portalResponse,
-          userResponse,
-          foldersAndGroupsResponse
-        ] = responses;
-
-        // Initialize replacement dictionary
-        // swap user defined params before we start...no need to wait
-        if (solutionTemplateData.params) {
-          templateDictionary.params = solutionTemplateData.params;
-          solutionTemplateData.templates = solutionTemplateData.templates.map(
-            (template: any) => {
-              return common.replaceInTemplate(template, templateDictionary);
-            }
-          );
-        }
-
-        // update template items with source-itemId type keyword
-        solutionTemplateData.templates = solutionTemplateData.templates.map(
-          (template: any) => {
-            const sourceId: string = "source-" + template.itemId;
-            /* istanbul ignore else */
-            if (template.item) {
-              /* istanbul ignore else */
-              if (template.item!.typeKeywords) {
-                template.item!.typeKeywords!.push(sourceId);
-              }
-              /* istanbul ignore else */
-              if (
-                template.item!.tags &&
-                common.getProp(template, "item.type") === "Group"
-              ) {
-                template.item!.tags!.push(sourceId);
-              }
-            }
-            return template;
-          }
-        );
-
-        templateDictionary.isPortal = portalResponse.isPortal;
-        templateDictionary.organization = Object.assign(
-          templateDictionary.organization || {},
-          portalResponse
-        );
-
-        // As of Spring 2020, only HTTPS (see
-        // https://www.esri.com/arcgis-blog/products/product/administration/2019-arcgis-transport-security-improvements/)
-        const scheme: string = "https"; // portalResponse.allSSL ? "https" : "http";
-        const urlKey: string = common.getProp(portalResponse, "urlKey");
-        const customBaseUrl: string = common.getProp(
-          portalResponse,
-          "customBaseUrl"
-        );
-        templateDictionary.portalBaseUrl =
-          urlKey && customBaseUrl
-            ? `${scheme}://${urlKey}.${customBaseUrl}`
-            : authentication.portal;
-
-        templateDictionary.user = userResponse;
-        templateDictionary.user.folders = foldersAndGroupsResponse.folders;
-        templateDictionary.user.groups = foldersAndGroupsResponse.groups;
-
-        // Create a folder to hold the deployed solution. We use the solution name, appending a sequential
-        // suffix if the folder exists, e.g.,
-        //  * Manage Right of Way Activities
-        //  * Manage Right of Way Activities 1
-        //  * Manage Right of Way Activities 2
-        const folderPromise = common.createUniqueFolder(
-          solutionTemplateBase.title,
-          templateDictionary,
-          authentication
-        );
-
-        // Apply the portal extents to the solution
-        const portalExtent: any = portalResponse.defaultExtent;
-        const extentsPromise = common.convertExtent(
-          portalExtent,
-          { wkid: 4326 },
-          portalResponse.helperServices.geometry.url,
-          authentication
-        );
-
-        // Await completion of async actions: folder creation & extents conversion
-        return Promise.all([folderPromise, extentsPromise]);
-      })
-      .then(responses => {
-        const [folderResponse, wgs84Extent] = responses;
-        deployedFolderId = folderResponse.folder.id;
-        templateDictionary.folderId = deployedFolderId;
-        templateDictionary.solutionItemExtent =
-          wgs84Extent.xmin +
-          "," +
-          wgs84Extent.ymin +
-          "," +
-          wgs84Extent.xmax +
-          "," +
-          wgs84Extent.ymax;
-
-        // Create a deployed Solution item
-        const createSolutionItemBase = {
-          ...common.sanitizeJSONAndReportChanges(solutionTemplateBase),
-          type: "Solution",
-          typeKeywords: ["Solution"]
-        };
-
-        if (options.additionalTypeKeywords) {
-          createSolutionItemBase.typeKeywords = ["Solution"].concat(
-            options.additionalTypeKeywords
-          );
-        }
-
-        return common.createItemWithData(
-          createSolutionItemBase,
-          {},
-          authentication,
-          deployedFolderId
-        );
-      })
-      .then(createSolutionResponse => {
-        deployedSolutionId = createSolutionResponse.id;
-
-        templateDictionary.solutionItemId = deployedSolutionId;
-        solutionTemplateBase.id = deployedSolutionId;
-
-        return common.addTokenToUrl(options.thumbnailurl, authentication);
-      })
-      .then(updatedThumbnailUrl => {
-        /* istanbul ignore else */
-        if (updatedThumbnailUrl) {
-          solutionTemplateBase.thumbnailurl = common.appendQueryParam(
-            updatedThumbnailUrl,
-            "w=400"
-          );
-        }
-
-        solutionTemplateBase.tryitUrl = _checkedReplaceAll(
-          solutionTemplateBase.tryitUrl,
-          templateSolutionId,
-          deployedSolutionId
-        );
-        solutionTemplateBase.url = _checkedReplaceAll(
-          solutionTemplateBase.url,
-          templateSolutionId,
-          deployedSolutionId
-        );
-
-        // Handle the contained item templates
-        return deployItems.deploySolutionItems(
-          authentication.portal,
-          templateSolutionId,
-          solutionTemplateData.templates,
-          authentication,
-          templateDictionary,
-          authentication,
-          options
-        );
-      })
-      .then(clonedSolutionsResponse => {
-        solutionTemplateData.templates = solutionTemplateData.templates.map(
-          (itemTemplate: common.IItemTemplate) => {
-            // Update ids present in template dictionary
-            const itemId = common.getProp(
-              templateDictionary,
-              itemTemplate.itemId + ".itemId"
-            );
-            /* istanbul ignore else */
-            if (itemId) {
-              itemTemplate.itemId = itemId;
-            }
-            itemTemplate.dependencies = itemTemplate.dependencies.map(id =>
-              _getNewItemId(id, templateDictionary)
-            );
-            return itemTemplate;
-          }
-        );
-
-        return deployItems.postProcessDependencies(
-          solutionTemplateData.templates,
-          clonedSolutionsResponse,
-          authentication,
-          templateDictionary
-        );
-      })
-      .then(() => {
-        // Update solution item using internal representation & and the updated data JSON
-        solutionTemplateBase.typeKeywords = [].concat(
-          solutionTemplateBase.typeKeywords,
-          ["Deployed"]
-        );
-        const iTemplateKeyword = solutionTemplateBase.typeKeywords.indexOf(
-          "Template"
-        );
-        /* istanbul ignore else */
-        if (iTemplateKeyword >= 0) {
-          solutionTemplateBase.typeKeywords.splice(iTemplateKeyword, 1);
-        }
-
-        solutionTemplateData.templates = solutionTemplateData.templates.map(
-          (itemTemplate: common.IItemTemplate) =>
-            _purgeTemplateProperties(itemTemplate)
-        );
-
-        solutionTemplateData.templates = _updateGroupReferences(
-          solutionTemplateData.templates,
-          templateDictionary
-        );
-
-        // Update solution items data using template dictionary, and then update the
-        // itemId & dependencies in each item template
-        solutionTemplateBase.data = common.replaceInTemplate(
-          solutionTemplateData,
-          templateDictionary
-        );
-
-        // Pass metadata in via params because item property is serialized, which discards a File
-        return common.updateItem(
-          solutionTemplateBase,
-          authentication,
-          deployedFolderId,
-          { metadata: solutionTemplateMetadata }
-        );
-      })
-      .then(
-        () => resolve(solutionTemplateBase.id),
-        error => {
-          // Cleanup solution folder and deployed solution item
-          const cleanupPromises = [] as Array<Promise<any>>;
-          if (deployedFolderId) {
-            cleanupPromises.push(
-              common.removeFolder(deployedFolderId, authentication)
-            );
-          }
-          if (deployedSolutionId) {
-            cleanupPromises.push(
-              common.removeItem(deployedSolutionId, authentication)
-            );
-          }
-          Promise.all(cleanupPromises).then(
-            () => reject(error),
-            () => reject(error)
-          );
-        }
-      );
-  });
-}
-
-// ------------------------------------------------------------------------------------------------------------------ //
-
-/**
- * Returns a match of a supplied id with the suffix ".itemId" in the template dictionary.
- *
- * @param id Id to look for
- * @param templateDictionary Hash mapping property names to replacement values
- * @return Match in template dictionary or original id
- */
-export function _getNewItemId(id: string, templateDictionary: any): string {
-  return common.getProp(templateDictionary, id + ".itemId") ?? id;
-}
-
-export function _checkedReplaceAll(
-  template: string,
-  oldValue: string,
-  newValue: string
-): string {
-  let newTemplate;
-  if (template && template.indexOf(oldValue) > -1) {
-    const re = new RegExp(oldValue, "g");
-    newTemplate = template.replace(re, newValue);
-  } else {
-    newTemplate = template;
-  }
-  return newTemplate;
-}
-
-export function _purgeTemplateProperties(itemTemplate: any): any {
-  const retainProps: string[] = ["itemId", "type", "dependencies", "groups"];
-  const deleteProps: string[] = Object.keys(itemTemplate).filter(
-    k => retainProps.indexOf(k) < 0
-  );
-  common.deleteProps(itemTemplate, deleteProps);
-  return itemTemplate;
-}
-
-export function _updateGroupReferences(
-  itemTemplates: any[],
-  templateDictionary: any
-): any[] {
-  const groupIds = itemTemplates.reduce(
-    (result: string[], t: common.IItemTemplate) => {
-      if (t.type === "Group") {
-        result.push(t.itemId);
-      }
-      return result;
-    },
-    []
-  );
-
-  Object.keys(templateDictionary).forEach(k => {
-    const newId: string = templateDictionary[k].itemId;
-    if (groupIds.indexOf(newId) > -1) {
-      itemTemplates.forEach(t => {
-        t.groups = t.groups.map((id: string) => (id === k ? newId : id));
-      });
-    }
-  });
-  return itemTemplates;
-}
-
-//#endregion ---------------------------------------------------------------------------------------------------------//

--- a/packages/deployer/src/deployerUtils.ts
+++ b/packages/deployer/src/deployerUtils.ts
@@ -1,0 +1,119 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from "@esri/solution-common";
+
+/**
+ * Given an itemId or an object, either fetch the item or
+ * resolve using the object, if it is structured as expected
+ * @param idOrObject string || object like `{item:{...}, data: {...}}`
+ * @param authentication UserSession
+ */
+export function _getSolutionTemplateItem(
+  idOrObject: any,
+  authentication: common.UserSession
+): Promise<any> {
+  if (typeof idOrObject === "string") {
+    // get the item + data
+    return Promise.all([
+      common.getItemBase(idOrObject, authentication),
+      common.getItemDataAsJson(idOrObject, authentication)
+    ]).then(([item, data]) => {
+      // format into a model
+      return {
+        item,
+        data
+      };
+    });
+  } else {
+    // check if it is a "Model"
+    if (_isModel(idOrObject)) {
+      return Promise.resolve(idOrObject);
+    } else {
+      return Promise.reject(
+        common.fail(
+          `_getSolutionTemplateItem must be passed an item id or a model object`
+        )
+      );
+    }
+  }
+}
+
+/**
+ * Update the Deploy Options with information from the
+ * Solution Template item
+ * @param deployOptions
+ * @param item
+ * @param authentication
+ */
+export function _updateDeployOptions(
+  deployOptions: any,
+  item: common.IItem,
+  authentication: common.UserSession
+): any {
+  // TODO: Move into a fn
+  deployOptions.jobId = deployOptions.jobId ?? item.id;
+  deployOptions.title = deployOptions.title ?? item.title;
+  deployOptions.snippet = deployOptions.snippet ?? item.snippet;
+  deployOptions.description = deployOptions.description ?? item.description;
+  deployOptions.tags = deployOptions.tags ?? item.tags;
+  // add the thumbnail url
+  deployOptions.thumbnailurl = common.getItemThumbnailUrl(
+    item.id,
+    item.thumbnail,
+    false,
+    authentication
+  );
+
+  return deployOptions;
+}
+
+/**
+ * Check if an object is an Model
+ * @param obj any object
+ */
+export function _isModel(obj: any): boolean {
+  let result = false as boolean;
+  // TODO Hoist into common?
+  const isNotStringOrArray = (v: any): boolean =>
+    v != null &&
+    typeof v !== "string" &&
+    !Array.isArray(v) &&
+    typeof v === "object";
+
+  if (isNotStringOrArray(obj)) {
+    result = ["item", "data"].reduce((acc, prop) => {
+      if (acc) {
+        acc = isNotStringOrArray(obj[prop]);
+      }
+      return acc;
+    }, true as boolean);
+  }
+  return result;
+}
+
+/**
+ * Does the item have the correct type and keywords
+ * to be a Solution Template item?
+ * @param item IItem
+ */
+export function isSolutionTemplateItem(item: common.IItem): boolean {
+  return (
+    item.type === "Solution" &&
+    item.typeKeywords.indexOf("Solution") > -1 &&
+    item.typeKeywords.indexOf("Template") > -1
+  );
+}

--- a/packages/deployer/src/index.ts
+++ b/packages/deployer/src/index.ts
@@ -22,3 +22,4 @@
 
 export * from "./deployer";
 export * from "./deploySolutionItems";
+export * from "./deployerUtils";

--- a/packages/deployer/test/deploySolutionFromTemplate.test.ts
+++ b/packages/deployer/test/deploySolutionFromTemplate.test.ts
@@ -1,0 +1,111 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  _getNewItemId,
+  _checkedReplaceAll,
+  _updateGroupReferences
+} from "../src/deploySolutionFromTemplate";
+
+describe("Module `deploySolutionFromTemplate`", () => {
+  describe("_getNewItemId", () => {
+    it("handles id not found in template dictionary", () => {
+      const sourceId = "itm1234567890";
+      const templateDictionary = {};
+      const actualResult = _getNewItemId(sourceId, templateDictionary);
+      expect(actualResult).toEqual(sourceId);
+    });
+  });
+
+  describe("_checkedReplaceAll", () => {
+    it("_checkedReplaceAll no template", () => {
+      const template: string = null;
+      const oldValue = "onm";
+      const newValue = "ONM";
+      const expectedResult = template;
+
+      const actualResult = _checkedReplaceAll(template, oldValue, newValue);
+      expect(actualResult).toEqual(expectedResult);
+    });
+
+    it("_checkedReplaceAll no matches", () => {
+      const template = "abcdefghijklmnopqrstuvwxyz";
+      const oldValue = "onm";
+      const newValue = "ONM";
+      const expectedResult = template;
+
+      const actualResult = _checkedReplaceAll(template, oldValue, newValue);
+      expect(actualResult).toEqual(expectedResult);
+    });
+
+    it("_checkedReplaceAll one match", () => {
+      const template = "abcdefghijklmnopqrstuvwxyz";
+      const oldValue = "mno";
+      const newValue = "MNO";
+      const expectedResult = "abcdefghijklMNOpqrstuvwxyz";
+
+      const actualResult = _checkedReplaceAll(template, oldValue, newValue);
+      expect(actualResult).toEqual(expectedResult);
+    });
+
+    it("_checkedReplaceAll two matches", () => {
+      const template = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
+      const oldValue = "mno";
+      const newValue = "MNO";
+      const expectedResult =
+        "abcdefghijklMNOpqrstuvwxyzabcdefghijklMNOpqrstuvwxyz";
+
+      const actualResult = _checkedReplaceAll(template, oldValue, newValue);
+      expect(actualResult).toEqual(expectedResult);
+    });
+  });
+
+  describe("_updateGroupReferences", () => {
+    it("replaces group references", () => {
+      const itemTemplates = [
+        {
+          type: "Group",
+          itemId: "xyz",
+          groups: ["abc", "ghi"]
+        },
+        {
+          type: "Group",
+          itemId: "def",
+          groups: ["abc", "ghi"]
+        }
+      ];
+      const templateDictionary = {
+        abc: {
+          itemId: "xyz"
+        }
+      };
+
+      const actual = _updateGroupReferences(itemTemplates, templateDictionary);
+      expect(actual).toEqual([
+        {
+          type: "Group",
+          itemId: "xyz",
+          groups: ["xyz", "ghi"]
+        },
+        {
+          type: "Group",
+          itemId: "def",
+          groups: ["xyz", "ghi"]
+        }
+      ]);
+    });
+  });
+});

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -18,20 +18,25 @@
  * Provides tests for functions involving the deployment of a Solution.
  */
 
-import * as utils from "../../common/test/mocks/utils";
+import * as testUtils from "../../common/test/mocks/utils";
 import * as mockItems from "../../common/test/mocks/agolItems";
 import * as fetchMock from "fetch-mock";
 import * as templates from "../../common/test/mocks/templates";
 import * as common from "@esri/solution-common";
+import * as deployUtils from "../src/deployerUtils";
 import * as deployer from "../src/deployer";
 import * as deployItems from "../src/deploySolutionItems";
+import * as sinon from "sinon";
+import * as deploySolutionFromTemplate from "../src/deploySolutionFromTemplate";
+import { cloneObject } from "@esri/hub-common";
+import M from "minimatch";
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
 let MOCK_USER_SESSION: common.UserSession;
 
 beforeEach(() => {
-  MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+  MOCK_USER_SESSION = testUtils.createRuntimeMockUserSession();
 });
 
 afterEach(() => {
@@ -50,20 +55,129 @@ const projectedGeometries: any[] = [
 ];
 
 describe("Module `deployer`", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+  describe("deploy solution orchestration", () => {
+    it("should reject if no maybeModel passed", done => {
+      return deployer
+        .deploySolution(null, MOCK_USER_SESSION)
+        .then(_ => {
+          fail("deploySolution should reject if passed null");
+        })
+        .catch(ex => {
+          expect(ex).toEqual({
+            success: false,
+            error: "The Solution Template id is missing"
+          });
+          done();
+        });
+    });
+    describe("happy pathing", () => {
+      // declare things we want in the `it` fns
+      let itemInfo: any;
+      let solTmplStub: any;
+      let metaStub: any;
+      let deployFnStub: any;
+      // setup the stubs in before each... ensures they are clean each time
+      beforeEach(() => {
+        itemInfo = cloneObject(templates.getSolutionTemplateItem([]));
+        solTmplStub = sinon
+          .stub(deployUtils, "_getSolutionTemplateItem")
+          .callsFake((idOrObj, auth) => {
+            return Promise.resolve({
+              item: itemInfo.item,
+              data: itemInfo.data
+            });
+          });
+        // create a fake file
+        const xmlFile = new File(["xml"], "metadata.xml", {
+          type: "application/xml"
+        });
+        metaStub = sinon
+          .stub(common, "getItemMetadataAsFile")
+          .resolves(xmlFile);
+
+        deployFnStub = sinon
+          .stub(deploySolutionFromTemplate, "_deploySolutionFromTemplate")
+          .resolves("3ef");
+      });
+
+      it("ensure main fns are called using stubs", done => {
+        // this test assumes all is good and simply checks that
+        // the expected delegation occurs
+        return deployer
+          .deploySolution(itemInfo.item.id, MOCK_USER_SESSION)
+          .then(() => {
+            expect(solTmplStub.calledOnce).toBe(
+              true,
+              "_getSolutionTemplateItem should be called"
+            );
+            expect(metaStub.calledOnce).toBe(
+              true,
+              "getItemMetadataAsFile should be called once"
+            );
+            expect(deployFnStub.calledOnce).toBe(
+              true,
+              "_deploySolutionFromTemplate should be called once"
+            );
+            // TODO: verify inputs to deployFn
+            done();
+          })
+          .catch(err => {
+            fail(err.error);
+          });
+      });
+      it("calls progress callback if passed", done => {
+        // create options hash w/ progress callback
+        const opts = {
+          progressCallback: (pct: number) => pct
+        };
+
+        // create stub...
+        const pgStub = sinon.stub(opts, "progressCallback");
+        return deployer
+          .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, opts)
+          .then(() => {
+            expect(solTmplStub.calledOnce).toBe(
+              true,
+              "_getSolutionTemplateItem should be called"
+            );
+            expect(metaStub.calledOnce).toBe(
+              true,
+              "getItemMetadataAsFile should be called once"
+            );
+            expect(deployFnStub.calledOnce).toBe(
+              true,
+              "_deploySolutionFromTemplate should be called once"
+            );
+            // TODO: verify inputs to deployFn
+            expect(pgStub.calledTwice).toBe(
+              true,
+              "progressCallback should be called twice"
+            );
+            done();
+          })
+          .catch(err => {
+            fail(err.error);
+          });
+      });
+    });
+  });
   describe("deploySolution", () => {
     // Blobs are only available in the browser
     if (typeof window !== "undefined") {
       it("reports an error if the solution id is not supplied", done => {
-        deployer.deploySolution(null, MOCK_USER_SESSION).then(
-          () => done.fail(),
-          err => {
+        return deployer
+          .deploySolution(null, MOCK_USER_SESSION)
+          .then(() => done.fail())
+          .catch(err => {
             expect(err).toEqual({
               success: false,
               error: "The Solution Template id is missing"
             });
             done();
-          }
-        );
+          });
       });
 
       it("can deploy webmap with dependencies", done => {
@@ -73,7 +187,7 @@ describe("Module `deployer`", () => {
         groupTemplate.itemId = groupId;
         groupTemplate.item.id = "{{" + groupId + ".itemId}}";
 
-        const user: any = utils.getContentUser();
+        const user: any = testUtils.getContentUser();
         user.groups = [];
 
         // get templates
@@ -149,122 +263,124 @@ describe("Module `deployer`", () => {
         const expectedMap: any = mockItems.getTrimmedAGOLItem(
           mockItems.getAGOLItem(
             "Web Map",
-            utils.PORTAL_SUBSET.portalUrl +
+            testUtils.PORTAL_SUBSET.portalUrl +
               "/home/webmap/viewer.html?webmap=map1234567890"
           )
         );
         expectedMap.extent = "-88.226,41.708,-88.009,41.844";
         expectedMap.thumbnail =
-          utils.ORG_URL +
+          testUtils.ORG_URL +
           "/sharing/rest/content/items/map1234567890/info/thumbnail/ago_downloaded.png";
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
             itemInfo.data
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
             mockItems.get400Failure()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/map1234567890?f=json&token=fake-token",
             mockItems.getAGOLItem(
               "Web Map",
-              utils.PORTAL_SUBSET.portalUrl +
+              testUtils.PORTAL_SUBSET.portalUrl +
                 "/home/webmap/viewer.html?webmap=map1234567890"
             )
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
             user
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/groups/" +
               newGroupId +
               "?f=json&token=fake-token",
             mockItems.getAGOLGroup(newGroupId)
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/info",
-            utils.UTILITY_SERVER_INFO
+            testUtils.UTILITY_SERVER_INFO
           )
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
-          .post(geometryServer + "/project", utils.getProjectResponse())
+          .post(geometryServer + "/project", testUtils.getProjectResponse())
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               id: "map1234567890",
               folder: "44468da125a64526b359b70d8ba4a9dd"
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/community/createGroup",
-            utils.getCreateGroupResponse(newGroupId)
+            testUtils.PORTAL_SUBSET.restUrl + "/community/createGroup",
+            testUtils.getCreateGroupResponse(newGroupId)
           )
-          .post(utils.PORTAL_SUBSET.restUrl + "/search", { results: [] })
+          .post(testUtils.PORTAL_SUBSET.restUrl + "/search", { results: [] })
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/map1234567890/share",
-            utils.getShareResponse("map1234567890")
+            testUtils.getShareResponse("map1234567890")
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createService",
-            utils.getCreateServiceResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createService",
+            testUtils.getCreateServiceResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/move",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               itemId: "svc1234567890",
               owner: "casey",
               folder: "44468da125a64526b359b70d8ba4a9dd"
@@ -272,44 +388,49 @@ describe("Module `deployer`", () => {
           )
           .post(
             featureServerAdminUrl + "/addToDefinition",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               layers: [{ name: "ROW Permits", id: 0 }],
               tables: [{ name: "ROW Permit Comment", id: 1 }]
             })
           )
           .post(featureServerAdminUrl + "/0?f=json", layer)
           .post(featureServerAdminUrl + "/1?f=json", table)
-          .post(featureServerAdminUrl + "/refresh", utils.getSuccessResponse())
+          .post(
+            featureServerAdminUrl + "/refresh",
+            testUtils.getSuccessResponse()
+          )
           .post(
             featureServerAdminUrl + "/0/updateDefinition",
-            utils.getSuccessResponse()
+            testUtils.getSuccessResponse()
           )
           .post(
             featureServerAdminUrl + "/1/updateDefinition",
-            utils.getSuccessResponse()
+            testUtils.getSuccessResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/update",
-            utils.getSuccessResponse({ id: "svc1234567890" })
+            testUtils.getSuccessResponse({ id: "svc1234567890" })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/map1234567890/update",
-            utils.getSuccessResponse({ id: "map1234567890" })
+            testUtils.getSuccessResponse({ id: "map1234567890" })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/items/svc1234567890/data",
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/items/svc1234567890/data",
             {}
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/items/map1234567890/data",
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/items/map1234567890/data",
             {}
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/sln1234567890/addResources",
-            utils.getSuccessResponse({ id: "sln1234567890" })
+            testUtils.getSuccessResponse({ id: "sln1234567890" })
           );
         // tslint:disable-next-line: no-empty
         spyOn(console, "log").and.callFake(() => {});
@@ -323,7 +444,7 @@ describe("Module `deployer`", () => {
         const expectedTemplate: any = {
           organization: portalsSelfResponse,
           portalBaseUrl: "https://myorg.maps.arcgis.com",
-          user: Object.assign({ folders: [] }, utils.getUserResponse()),
+          user: Object.assign({ folders: [] }, testUtils.getUserResponse()),
           solutionItemExtent: "-88.226,41.708,-88.009,41.844", // [[xmin, ymin], [xmax, ymax]]
           folderId: "a4468da125a64526b359b70d8ba4a9dd",
           isPortal: false,
@@ -454,7 +575,7 @@ describe("Module `deployer`", () => {
 
         const options: common.IDeploySolutionOptions = {
           templateDictionary: templateDictionary,
-          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK,
+          progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK,
           consoleProgress: true
         };
         deployer
@@ -480,7 +601,7 @@ describe("Module `deployer`", () => {
                 .toBeTrue();
 
               const updateCalls: any[] = fetchMock.calls(
-                utils.PORTAL_SUBSET.restUrl +
+                testUtils.PORTAL_SUBSET.restUrl +
                   "/content/users/casey/items/map1234567890/update"
               );
 
@@ -490,7 +611,7 @@ describe("Module `deployer`", () => {
                 .toBeTruthy();
 
               // Repeat with progress callback
-              options.progressCallback = utils.SOLUTION_PROGRESS_CALLBACK;
+              options.progressCallback = testUtils.SOLUTION_PROGRESS_CALLBACK;
               options.templateDictionary = {};
               deployer
                 .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
@@ -510,10 +631,10 @@ describe("Module `deployer`", () => {
           title: "Election Management",
           description: "",
           url:
-            utils.PORTAL_SUBSET.portalUrl +
+            testUtils.PORTAL_SUBSET.portalUrl +
             "/home/item.html?id=c38e59126368495694ca23b7ccacefba",
           thumbnailurl:
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
             "/content/items/c38e59126368495694ca23b7ccacefba/info/thumbnail/ago_downloaded_orig.png",
           tryitUrl: "",
           created: 1578000306000,
@@ -677,130 +798,135 @@ describe("Module `deployer`", () => {
 
         const folderId: string = "bd610311e0e84e41b96f54df2da54f82";
         const imageUrl: string =
-          utils.PORTAL_SUBSET.restUrl +
+          testUtils.PORTAL_SUBSET.restUrl +
           "/content/items/c38e59126368495694ca23b7ccacefba/resources/cc2ccab401af4828a25cc6eaeb59fb69_info_thumbnail/thumbnail1552919935720.png";
         const imageUrl2: string =
-          utils.PORTAL_SUBSET.restUrl +
+          testUtils.PORTAL_SUBSET.restUrl +
           "/content/items/c38e59126368495694ca23b7ccacefba/resources/47bb15c2df2b466da05577776e82d044_info_thumbnail/thumbnail1552923181520.png";
         const expectedImage = mockItems.getAnImageResponse();
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/c38e59126368495694ca23b7ccacefba/data",
             solutionResponse
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/c38e59126368495694ca23b7ccacefba/info/metadata/metadata.xml",
-            utils.getSampleMetadataAsFile(),
+            testUtils.getSampleMetadataAsFile(),
             { sendAsJson: false }
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/c38e59126368495694ca23b7ccacefba?f=json&token=fake-token",
             itemInfoCard
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/org1234567890?f=json&token=fake-token",
-            utils.getPortalsSelfResponse()
+            testUtils.getPortalsSelfResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
-            utils.getPortalsSelfResponse()
+            testUtils.getPortalsSelfResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
             []
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse(folderId)
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse(folderId)
           )
           .post(imageUrl, expectedImage)
           .post(imageUrl2, expectedImage)
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
-            utils.getProjectResponse()
+            testUtils.getProjectResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/" +
               folderId +
               "/addItem",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               id: "57a059ec717c4b1282705132fd4720a0",
               folder: folderId
             }),
             { overwriteRoutes: false }
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/" +
               folderId +
               "/addItem",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               id: "82601685fd3c444397d252116d7a3dc0",
               folder: folderId
             }),
             { overwriteRoutes: false }
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/community/createGroup",
-            utils.getSuccessResponse({
+            testUtils.PORTAL_SUBSET.restUrl + "/community/createGroup",
+            testUtils.getSuccessResponse({
               group: { id: "987eaa6a496546a58f04796266589ec5" }
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/groups/987eaa6a496546a58f04796266589ec5/update",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               groupId: "987eaa6a496546a58f04796266589ec5"
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/57a059ec717c4b1282705132fd4720a0/update",
-            utils.getSuccessResponse({ id: "57a059ec717c4b1282705132fd4720a0" })
+            testUtils.getSuccessResponse({
+              id: "57a059ec717c4b1282705132fd4720a0"
+            })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/82601685fd3c444397d252116d7a3dc0/update",
-            utils.getSuccessResponse({ id: "82601685fd3c444397d252116d7a3dc0" })
+            testUtils.getSuccessResponse({
+              id: "82601685fd3c444397d252116d7a3dc0"
+            })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/bd610311e0e84e41b96f54df2da54f82/delete",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               folder: { username: "casey", id: folderId }
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/57a059ec717c4b1282705132fd4720a0/delete",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               itemId: "57a059ec717c4b1282705132fd4720a0"
             })
           );
@@ -826,80 +952,81 @@ describe("Module `deployer`", () => {
           templates.getItemTemplate("Feature Service")
         ]);
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
             itemInfo.data
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
             mockItems.get400Failure()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
-            utils.getContentUser()
+            testUtils.getContentUser()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/info",
-            utils.UTILITY_SERVER_INFO
+            testUtils.UTILITY_SERVER_INFO
           )
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
-          .post(geometryServer + "/project", utils.getProjectResponse())
+          .post(geometryServer + "/project", testUtils.getProjectResponse())
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
             mockItems.get200Failure()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/delete",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               folder: {
                 username: "casey",
                 id: "a4468da125a64526b359b70d8ba4a9dd"
@@ -923,55 +1050,56 @@ describe("Module `deployer`", () => {
           templates.getItemTemplate("Feature Service")
         ]);
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
-            utils.getContentUser()
+            testUtils.getContentUser()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
             mockItems.get400Failure()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
@@ -979,7 +1107,7 @@ describe("Module `deployer`", () => {
           );
 
         const options: common.IDeploySolutionOptions = {
-          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
+          progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK
         };
         deployer
           .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
@@ -999,61 +1127,62 @@ describe("Module `deployer`", () => {
           templates.getItemTemplate("Feature Service")
         ]);
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
             itemInfo.data
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
-            utils.getContentUser()
+            testUtils.getContentUser()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/info",
-            utils.UTILITY_SERVER_INFO
+            testUtils.UTILITY_SERVER_INFO
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
@@ -1061,12 +1190,12 @@ describe("Module `deployer`", () => {
           )
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
           .post(geometryServer + "/project", mockItems.get400Failure());
 
         const options: common.IDeploySolutionOptions = {
-          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
+          progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK
         };
         deployer
           .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
@@ -1127,88 +1256,90 @@ describe("Module `deployer`", () => {
           true
         );
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         portalsSelfResponse.urlKey = null;
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
             itemInfo.data
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
             mockItems.get400Failure()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
-            utils.getContentUser()
+            testUtils.getContentUser()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/info",
-            utils.UTILITY_SERVER_INFO
+            testUtils.UTILITY_SERVER_INFO
           )
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
-          .post(geometryServer + "/project", utils.getProjectResponse())
+          .post(geometryServer + "/project", testUtils.getProjectResponse())
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               id: "map1234567890",
               folder: "44468da125a64526b359b70d8ba4a9dd"
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createService",
-            utils.getCreateServiceResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createService",
+            testUtils.getCreateServiceResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/move",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               itemId: "svc1234567890",
               owner: "casey",
               folder: "44468da125a64526b359b70d8ba4a9dd"
@@ -1216,40 +1347,44 @@ describe("Module `deployer`", () => {
           )
           .post(
             featureServerAdminUrl + "/addToDefinition",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               layers: [{ name: "ROW Permits", id: 0 }],
               tables: [{ name: "ROW Permit Comment", id: 1 }]
             })
           )
           .post(featureServerAdminUrl + "/0?f=json", layer)
           .post(featureServerAdminUrl + "/1?f=json", table)
-          .post(featureServerAdminUrl + "/refresh", utils.getSuccessResponse())
+          .post(
+            featureServerAdminUrl + "/refresh",
+            testUtils.getSuccessResponse()
+          )
           .post(
             featureServerAdminUrl + "/0/updateDefinition",
-            utils.getSuccessResponse()
+            testUtils.getSuccessResponse()
           )
           .post(
             featureServerAdminUrl + "/1/updateDefinition",
-            utils.getSuccessResponse()
+            testUtils.getSuccessResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/update",
-            utils.getSuccessResponse({ id: "svc1234567890" })
+            testUtils.getSuccessResponse({ id: "svc1234567890" })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/items/svc1234567890/data",
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/items/svc1234567890/data",
             {}
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/map1234567890/update",
             mockItems.get400Failure()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/delete",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               folder: {
                 username: "casey",
                 id: "a4468da125a64526b359b70d8ba4a9dd"
@@ -1257,9 +1392,9 @@ describe("Module `deployer`", () => {
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/map1234567890/delete",
-            utils.getSuccessResponse({ itemId: "map1234567890" })
+            testUtils.getSuccessResponse({ itemId: "map1234567890" })
           );
 
         const options: common.IDeploySolutionOptions = {
@@ -1270,7 +1405,7 @@ describe("Module `deployer`", () => {
           thumbnailurl: "a thumbnailurl",
           templateDictionary: null,
           additionalTypeKeywords: ["UnitTest"],
-          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
+          progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK
         };
         deployer
           .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
@@ -1331,87 +1466,89 @@ describe("Module `deployer`", () => {
           true
         );
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
             itemInfo.data
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
             mockItems.get400Failure()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
-            utils.getContentUser()
+            testUtils.getContentUser()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-            utils.getCreateFolderResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/info",
-            utils.UTILITY_SERVER_INFO
+            testUtils.UTILITY_SERVER_INFO
           )
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
-          .post(geometryServer + "/project", utils.getProjectResponse())
+          .post(geometryServer + "/project", testUtils.getProjectResponse())
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               id: "map1234567890",
               folder: "44468da125a64526b359b70d8ba4a9dd"
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createService",
-            utils.getCreateServiceResponse()
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createService",
+            testUtils.getCreateServiceResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/move",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               itemId: "svc1234567890",
               owner: "casey",
               folder: "44468da125a64526b359b70d8ba4a9dd"
@@ -1419,41 +1556,44 @@ describe("Module `deployer`", () => {
           )
           .post(
             featureServerAdminUrl + "/addToDefinition",
-            utils.getSuccessResponse({
+            testUtils.getSuccessResponse({
               layers: [{ name: "ROW Permits", id: 0 }],
               tables: [{ name: "ROW Permit Comment", id: 1 }]
             })
           )
           .post(featureServerAdminUrl + "/0?f=json", layer)
           .post(featureServerAdminUrl + "/1?f=json", table)
-          .post(featureServerAdminUrl + "/refresh", utils.getSuccessResponse())
+          .post(
+            featureServerAdminUrl + "/refresh",
+            testUtils.getSuccessResponse()
+          )
           .post(
             featureServerAdminUrl + "/0/updateDefinition",
-            utils.getSuccessResponse()
+            testUtils.getSuccessResponse()
           )
           .post(
             featureServerAdminUrl + "/1/updateDefinition",
-            utils.getSuccessResponse()
+            testUtils.getSuccessResponse()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/update",
             mockItems.get400Failure()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/svc1234567890/delete",
-            utils.getSuccessResponse({ itemId: "svc1234567890" })
+            testUtils.getSuccessResponse({ itemId: "svc1234567890" })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/groups/svc1234567890/delete",
-            utils.getSuccessResponse({ groupId: "svc1234567890" })
+            testUtils.getSuccessResponse({ groupId: "svc1234567890" })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/delete",
-            utils.getFailureResponse({
+            testUtils.getFailureResponse({
               folder: {
                 username: "casey",
                 id: "a4468da125a64526b359b70d8ba4a9dd"
@@ -1461,13 +1601,13 @@ describe("Module `deployer`", () => {
             })
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey/items/map1234567890/delete",
-            utils.getSuccessResponse({ itemId: "map1234567890" })
+            testUtils.getSuccessResponse({ itemId: "map1234567890" })
           );
 
         const options: common.IDeploySolutionOptions = {
-          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
+          progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK
         };
         deployer
           .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
@@ -1487,21 +1627,21 @@ describe("Module `deployer`", () => {
           templates.getItemTemplate("Feature Service")
         ]);
 
-        const communitySelfResponse: any = utils.getUserResponse();
-        const portalsSelfResponse: any = utils.getPortalsSelfResponse();
+        const communitySelfResponse: any = testUtils.getUserResponse();
+        const portalsSelfResponse: any = testUtils.getPortalsSelfResponse();
         const geometryServer: string =
           portalsSelfResponse.helperServices.geometry.url;
 
         fetchMock
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "?f=json&token=fake-token",
             itemInfo.item
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/data",
@@ -1510,54 +1650,55 @@ describe("Module `deployer`", () => {
           .post(geometryServer + "/findTransformations/rest/info", "{}")
           .post(
             geometryServer + "/findTransformations",
-            utils.getTransformationsResponse()
+            testUtils.getTransformationsResponse()
           )
           .post(geometryServer + "/project", {
             geometries: projectedGeometries
           })
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/self?f=json&token=fake-token",
             communitySelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/self?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/portals/abCDefG123456?f=json&token=fake-token",
             portalsSelfResponse
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/community/users/casey?f=json&token=fake-token",
-            utils.getUserResponse()
+            testUtils.getUserResponse()
           )
           .get(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/users/casey?f=json&token=fake-token",
-            utils.getContentUser()
+            testUtils.getContentUser()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl +
+            testUtils.PORTAL_SUBSET.restUrl +
               "/content/items/" +
               itemInfo.item.id +
               "/info/metadata/metadata.xml",
             mockItems.get400Failure()
           )
           .post(
-            utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
             mockItems.get400Failure()
           )
           .post(
             "https://utility.arcgisonline.com/arcgis/rest/info",
-            utils.UTILITY_SERVER_INFO
+            testUtils.UTILITY_SERVER_INFO
           );
 
         const options: common.IDeploySolutionOptions = {
-          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
+          progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK
         };
         deployer
           .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
@@ -1571,112 +1712,5 @@ describe("Module `deployer`", () => {
           );
       });
     }
-  });
-
-  describe("_getNewItemId", () => {
-    it("handles id not found in template dictionary", () => {
-      const sourceId = "itm1234567890";
-      const templateDictionary = {};
-      const actualResult = deployer._getNewItemId(sourceId, templateDictionary);
-      expect(actualResult).toEqual(sourceId);
-    });
-  });
-
-  describe("_checkedReplaceAll", () => {
-    it("_checkedReplaceAll no template", () => {
-      const template: string = null;
-      const oldValue = "onm";
-      const newValue = "ONM";
-      const expectedResult = template;
-
-      const actualResult = deployer._checkedReplaceAll(
-        template,
-        oldValue,
-        newValue
-      );
-      expect(actualResult).toEqual(expectedResult);
-    });
-
-    it("_checkedReplaceAll no matches", () => {
-      const template = "abcdefghijklmnopqrstuvwxyz";
-      const oldValue = "onm";
-      const newValue = "ONM";
-      const expectedResult = template;
-
-      const actualResult = deployer._checkedReplaceAll(
-        template,
-        oldValue,
-        newValue
-      );
-      expect(actualResult).toEqual(expectedResult);
-    });
-
-    it("_checkedReplaceAll one match", () => {
-      const template = "abcdefghijklmnopqrstuvwxyz";
-      const oldValue = "mno";
-      const newValue = "MNO";
-      const expectedResult = "abcdefghijklMNOpqrstuvwxyz";
-
-      const actualResult = deployer._checkedReplaceAll(
-        template,
-        oldValue,
-        newValue
-      );
-      expect(actualResult).toEqual(expectedResult);
-    });
-
-    it("_checkedReplaceAll two matches", () => {
-      const template = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
-      const oldValue = "mno";
-      const newValue = "MNO";
-      const expectedResult =
-        "abcdefghijklMNOpqrstuvwxyzabcdefghijklMNOpqrstuvwxyz";
-
-      const actualResult = deployer._checkedReplaceAll(
-        template,
-        oldValue,
-        newValue
-      );
-      expect(actualResult).toEqual(expectedResult);
-    });
-  });
-
-  describe("_updateGroupReferences", () => {
-    it("replaces group references", () => {
-      const itemTemplates = [
-        {
-          type: "Group",
-          itemId: "xyz",
-          groups: ["abc", "ghi"]
-        },
-        {
-          type: "Group",
-          itemId: "def",
-          groups: ["abc", "ghi"]
-        }
-      ];
-      const templateDictionary = {
-        abc: {
-          itemId: "xyz"
-        }
-      };
-
-      const actual = deployer._updateGroupReferences(
-        itemTemplates,
-        templateDictionary
-      );
-      expect(actual).toEqual([
-        {
-          type: "Group",
-          itemId: "xyz",
-          groups: ["xyz", "ghi"]
-        },
-        {
-          type: "Group",
-          itemId: "def",
-          groups: ["xyz", "ghi"]
-        }
-      ]);
-    });
   });
 });

--- a/packages/deployer/test/deployerUtils.test.ts
+++ b/packages/deployer/test/deployerUtils.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
   MOCK_USER_SESSION = testUtils.createRuntimeMockUserSession();
 });
 
-describe("Module: `_deployerUtils", () => {
+describe("Module: `_deployerUtils`", () => {
   describe("_isModel", () => {
     it("returns true if the object is Modelish", () => {
       expect(_isModel({})).toBe(false);

--- a/packages/deployer/test/deployerUtils.test.ts
+++ b/packages/deployer/test/deployerUtils.test.ts
@@ -1,0 +1,125 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  _isModel,
+  isSolutionTemplateItem,
+  _getSolutionTemplateItem
+} from "../src/deployerUtils";
+import * as sinon from "sinon";
+import * as common from "@esri/solution-common";
+import * as testUtils from "@esri/solution-common/test/mocks/utils";
+
+let MOCK_USER_SESSION: common.UserSession;
+
+beforeEach(() => {
+  MOCK_USER_SESSION = testUtils.createRuntimeMockUserSession();
+});
+
+describe("Module: `_deployerUtils", () => {
+  describe("_isModel", () => {
+    it("returns true if the object is Modelish", () => {
+      expect(_isModel({})).toBe(false);
+      expect(_isModel("3ef")).toBe(false);
+      expect(_isModel([])).toBe(false);
+      expect(_isModel({ item: [], data: {} })).toBe(false);
+      expect(_isModel({ item: {}, data: [] })).toBe(false);
+      expect(_isModel({ item: {} })).toBe(false);
+      expect(_isModel({ item: {}, data: {} })).toBe(true);
+    });
+  });
+  describe("isSolutionTemplateItem", () => {
+    it("returns true if correct item type and keywords", () => {
+      const i = {
+        type: "Solution",
+        typeKeywords: ["Solution", "Template"]
+      } as common.IItem;
+      expect(isSolutionTemplateItem(i)).toBe(true);
+    });
+    it("returns false if missing item type or keywords", () => {
+      const i = {
+        type: "Solution",
+        typeKeywords: ["Solution"]
+      } as common.IItem;
+      expect(isSolutionTemplateItem(i)).toBe(false);
+    });
+  });
+  describe("getSolutionTemplateItem", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+    it("fetches item and data if passed an id", done => {
+      const getItemSpy = sinon.stub(common, "getItemBase").callsFake(
+        (
+          itemId: string,
+          authentication: common.UserSession
+        ): Promise<common.IItem> => {
+          return Promise.resolve({
+            id: "bc3"
+          } as common.IItem);
+        }
+      );
+      const getItemDataSpy = sinon.stub(common, "getItemDataAsJson").callsFake(
+        (itemId: string, authentication: common.UserSession): Promise<any> => {
+          return Promise.resolve({
+            templates: []
+          });
+        }
+      );
+      return _getSolutionTemplateItem("bc3", MOCK_USER_SESSION)
+        .then(result => {
+          expect(result.item.id).toBe("bc3");
+          expect(result.data.templates).toBeDefined();
+          expect(getItemSpy.calledOnceWith("bc3", MOCK_USER_SESSION)).toBe(
+            true
+          );
+          expect(getItemDataSpy.calledOnceWith("bc3", MOCK_USER_SESSION)).toBe(
+            true
+          );
+          done();
+        })
+        .catch(_ => {
+          fail("getSolutionTemplateItem should fetch if passed a string");
+        });
+    });
+    it("resolves with a model if passed on", done => {
+      return _getSolutionTemplateItem(
+        { item: { id: "bc3" }, data: {} },
+        MOCK_USER_SESSION
+      )
+        .then(result => {
+          expect(result.item.id).toBe("bc3");
+          done();
+        })
+        .catch(_ => {
+          fail("getSolutionTemplateItem should resolve with model passed in");
+        });
+    });
+    it("rejects if object is not modelish", done => {
+      return _getSolutionTemplateItem(
+        { item: { id: "bc3" }, foo: "bar" },
+        MOCK_USER_SESSION
+      )
+        .then(_ => {
+          fail("getSolutionTemplateItem should reject with model passed in");
+        })
+        .catch(ex => {
+          expect(ex.error).toContain("getSolutionTemplateItem");
+          done();
+        });
+    });
+  });
+});

--- a/packages/feature-layer/package-lock.json
+++ b/packages/feature-layer/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/file/package-lock.json
+++ b/packages/file/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/group/package-lock.json
+++ b/packages/group/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/simple-types/package-lock.json
+++ b/packages/simple-types/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/storymap/package-lock.json
+++ b/packages/storymap/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/viewer/package-lock.json
+++ b/packages/viewer/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-			"integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+			"version": "13.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
 			"dev": true
 		},
 		"acorn": {


### PR DESCRIPTION
Addresses #305 but even if ya'll happy with it, pls do not merge it yet :)

**Note**: this spiraled a bit, and I'm not at all fixed on the naming anything changed in this, or location of the additional util fn's I created... so ya'll likely have better ideas where some of this stuff should live or what it should be named.

### Description

Changes the `solutionItemId: string` param of `deploySolution(...)` to `maybeModel: string| IModel`, and handles both cases.

Adds `_getSolutionTemplateItem(..)` that takes the `maybeModel` and either fetches the item + data if it's a string, or returns the passed in model, if it's an `IModel`.

This PR also refactors `deploySolution(...)` to use a flat promise chain, and hoists out much the between-steps logic into helpers in `deployerUtils`. 

### Adding Sinon
Since I was working in the main entry-point for deploying a solution, I wanted to be able to test the "orchestration" that happens inside that function, vs the whole chain of things that happen when it calls out to other fns. To that end, I brought in Sinon to give us a mock/stub system.
In order to make this work, I had to move `_deploySolutionFromTemplate` into it's own .ts file.
In `deployer.ts` I imported just the function a la

```
import { _deploySolutionFromTemplate } from "./deploySolutionFromTemplate";
```

Then in the `deployer.test.ts` I imported the same thing via 

```
import * as deploySolutionFromTemplate from "../src/deploySolutionFromTemplate";
```

Which then allows...
```
// in deployer.test.ts
...
     deployFnStub = sinon
          .stub(deploySolutionFromTemplate, "_deploySolutionFromTemplate")
          .resolves("3ef");
...
     expect(deployFnStub.calledOnce).toBe(
              true,
              "_deploySolutionFromTemplate should be called once"
            );
```

I did the same thing with the `_getSolutionTemplateItem`, and `getItemMetadataAsFile` fns allowing us verify the "orchestration" of `deploySolution(...)` without also mocking all the calls down the entire stack. 

That said, all the old tests are still present and running as well (heroic fetch-mocking btw!)

There is a lot of things moved in this, but we're still at 100% coverage. 

If you want, I can walk ya'll thru this on Monday. 

