### PR TITLE
Add solution schemaVersion, migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased][HEAD]
 
+### Added
+- solution schema versioning
+
+### Changed
+### Fixed
+### Removed
+
+### Breaking
+
 ## [0.9.2] - April 14th 2020
 
 ## [0.9.1] - April 13th 2020

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -62,6 +62,27 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.12.1.tgz",
 			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ=="
 		},
+		"@esri/hub-common": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.8.0.tgz",
+			"integrity": "sha512-XQ4oL+Dcd8IMkB8Pv1wRtsvFEZdUD2wSxfBsQ1wOkv8fzsBJyGyEd87JTgJtX8p0dUVYN4QS91GzkFFn4YF02g==",
+			"requires": {
+				"adlib": "3.0.5",
+				"fetch-blob": "github:node-fetch/fetch-blob#master",
+				"node-fetch": "^2.6.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"adlib": {
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.5.tgz",
+					"integrity": "sha512-+9lYo3Hm1UYJn3RxVp+SLBuOCh1pt5RiuW8KXGtgqycALaKvZRWAvxnBIyHDkcfEk4RieZ55svJPl4sHKhKlkQ==",
+					"requires": {
+						"esm": "^3.2.25"
+					}
+				}
+			}
+		},
 		"@types/adlib": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
@@ -122,10 +143,19 @@
 			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
 			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
 		},
+		"fetch-blob": {
+			"version": "github:node-fetch/fetch-blob#4a46def45247e7e1fac18b9e399e0969b2c4a962",
+			"from": "github:node-fetch/fetch-blob#master"
+		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"node-fetch": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"rollup": {
 			"version": "1.32.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@esri/hub-common": "^3.7.5",
     "@esri/arcgis-html-sanitizer": "^2.2.0",
     "@esri/arcgis-rest-auth": "^2.11.0",
     "@esri/arcgis-rest-feature-layer": "^2.11.0",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,3 +31,4 @@ export * from "./resourceHelpers";
 export * from "./restHelpers";
 export * from "./restHelpersGet";
 export * from "./templatization";
+export * from "./migrator";

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -396,6 +396,10 @@ export interface IItemTemplate {
    * function calls made during while deploying it
    */
   estimatedDeploymentCostFactor: number;
+  /**
+   * Allow for adhoc properties
+   */
+  [propName: string]: any;
 }
 
 /**
@@ -564,6 +568,11 @@ export interface ISolutionItemProperties {
    * Id linking instances of Solution, e.g., "726a641112464ad7b98bc924f2ab361a"
    */
   id: string;
+
+  /**
+   * Solution schema version
+   */
+  schemaVersion?: number;
 }
 
 /**

--- a/packages/common/src/migrations/is-legacy-solution.ts
+++ b/packages/common/src/migrations/is-legacy-solution.ts
@@ -1,0 +1,38 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp } from "../generalHelpers";
+
+/**
+ * Determine if the Solution is a legacy item created by Hub
+ * vs one that is 100% compatible with Solution.js
+ * @param model ISolutionModel
+ */
+export function _isLegacySolution(model: ISolutionItem): boolean {
+  let result = false;
+  // if it does not have the `Template` keyword BUT does have `hubSolutionTemplate` it is legacy
+  const keywords = getProp(model, "item.typeKeywords") || [];
+  if (!keywords.includes("Template")) {
+    if (
+      keywords.includes("hubSolutionTemplate") &&
+      keywords.includes("solutionTemplate")
+    ) {
+      result = true;
+    }
+  }
+  return result;
+}

--- a/packages/common/src/migrations/upgrade-three-dot-zero.ts
+++ b/packages/common/src/migrations/upgrade-three-dot-zero.ts
@@ -1,0 +1,37 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp, cloneObject } from "../generalHelpers";
+
+/**
+ * Apply the initial schema
+ * If the item was created by Solution.js, this will stamp it
+ * with the initial Solution.js schama version number (3)
+ * If it is a legacy hub solution, it will apply the transforms
+ * @param model ISolutionItem
+ */
+export function _upgradeThreeDotZero(model: ISolutionItem): ISolutionItem {
+  if (getProp(model, "item.properties.schemaVersion") >= 3) {
+    return model;
+  } else {
+    // TODO: Implement the logic to upgrade 2.3+ to 3.0
+    // At this point we know that the resources array on the templates will need to
+    // be modified, but we expect other things as well. Once Hub team starts integrating
+    // more deeply we can write this set of transforms
+    return cloneObject(model);
+  }
+}

--- a/packages/common/src/migrations/upgrade-two-dot-three.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-three.ts
@@ -1,0 +1,48 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp } from "../generalHelpers";
+import { cloneObject } from "@esri/hub-common";
+
+export function _upgradeTwoDotThree(model: ISolutionItem) {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.3) {
+    return model;
+  }
+
+  const clone = cloneObject(model);
+
+  // rename template.resources => template.assets
+  // this has landed in Hub, so we have actual items like this :(
+  // we will have another schema upgrade that will re-create the
+  // resources array
+  clone.data.templates = clone.data.templates.map(tmpl => {
+    if (tmpl.resources) {
+      tmpl.assets = tmpl.resources.map(r => {
+        return {
+          name: r,
+          type: "resource"
+        };
+      });
+      delete tmpl.resources;
+    } else {
+      tmpl.assets = [];
+    }
+    return tmpl;
+  });
+  clone.item.properties.schemaVersion = 2.3;
+  return clone;
+}

--- a/packages/common/src/migrations/upgrade-two-dot-two.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-two.ts
@@ -1,0 +1,55 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem, ISolutionItemData } from "../interfaces";
+import { getProp } from "../generalHelpers";
+import { deepStringReplace, cloneObject } from "@esri/hub-common";
+
+export function _upgradeTwoDotTwo(model: ISolutionItem): ISolutionItem {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.2) {
+    return model;
+  }
+
+  const clone = cloneObject(model);
+  // NOTE: Not all of these have closing `}}` and that is intentional
+  const swaps = [
+    { src: "{{solution.name}}", val: "{{solution.title}}" },
+    { src: "{{initiative.name}}", val: "{{solution.title}}" },
+    { src: "{{initiative.title}}", val: "{{solution.title}}" },
+    { src: "{{initiative.extent}}", val: "{{organization.defaultExtentBBox}}" },
+    {
+      src: "{{initiative.collaborationGroupId",
+      val: "{{teams.collaborationGroupId"
+    },
+    { src: "{{initiative.openDataGroupId", val: "{{teams.contentGroupId" },
+    { src: "{{initiative.contentGroupId", val: "{{teams.contentGroupId" },
+    { src: "{{initiative.followersGroupId", val: "{{teams.followersGroupId" },
+    { src: "{{collaborationGroupId", val: "{{teams.collaborationGroupId" },
+    { src: "{{contentGroupId", val: "{{teams.contentGroupId" },
+    { src: "{{followersGroupId", val: "{{teams.followersGroupId" },
+    { src: "{{initiative.id", val: "{{initiative.item.id" },
+    { src: "{{organization.portalBaseUrl", val: "{{portalBaseUrl" }
+  ];
+  swaps.forEach(swap => {
+    clone.data = deepStringReplace(
+      clone.data,
+      swap.src,
+      swap.val
+    ) as ISolutionItemData;
+  });
+  clone.item.properties.schemaVersion = 2.2;
+  return clone;
+}

--- a/packages/common/src/migrator.ts
+++ b/packages/common/src/migrator.ts
@@ -1,0 +1,65 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "./interfaces";
+import { getProp } from "./generalHelpers";
+import { _isLegacySolution } from "./migrations/is-legacy-solution";
+import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
+import { _upgradeTwoDotTwo } from "./migrations/upgrade-two-dot-two";
+import { _upgradeTwoDotThree } from "./migrations/upgrade-two-dot-three";
+import { ensureProp } from "@esri/hub-common";
+
+// Starting at 3.0 because Hub has been versioning Solution items up to 2.x
+export const CURRENT_SCHEMA_VERSION = 3.0;
+
+/**
+ * Apply schema migrations to a Solution item
+ * This system allows the schema of the Solution item to change over time
+ * while abstracting those changes into a single set of functional transforms
+ * @param model ISolutionItem
+ */
+export function migrateSchema(model: ISolutionItem): ISolutionItem {
+  // ensure properties
+  if (!getProp(model, "item.properties")) {
+    model.item.properties = {};
+  }
+
+  const modelVersion = getProp(model, "item.properties.schemaVersion");
+  // if it's already on the current version, return it
+  if (modelVersion === CURRENT_SCHEMA_VERSION) {
+    return model;
+  } else {
+    // check if this is a legacy solution created by Hub
+    const isLegacy = _isLegacySolution(model);
+    // if this is a Solution.js "native" item, it is already at 3.0
+    if (!modelVersion && !isLegacy) {
+      // bump it up to 3.0
+      model.item.properties.schemaVersion = CURRENT_SCHEMA_VERSION;
+    } else {
+      // Hub created a set of Solution items that are not 100% compatible
+      // with the Solution.js deployer.
+      // The schemaVersion of these items is 2.1 - prior to that we used
+      // Web Mapping Application items, which are deprecated
+      if (modelVersion >= 2.1 && modelVersion < 3) {
+        model = _upgradeTwoDotTwo(model);
+        model = _upgradeTwoDotThree(model);
+        model = _upgradeThreeDotZero(model);
+      }
+      // When we need to apply schema upgrades 3.0+ we add those here...
+    }
+    return model;
+  }
+}

--- a/packages/common/test/migrations/is-legacy-solution.test.ts
+++ b/packages/common/test/migrations/is-legacy-solution.test.ts
@@ -1,0 +1,59 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _isLegacySolution } from "../../src/migrations/is-legacy-solution";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("isLegacySolution", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.1
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns false for a Solution", () => {
+    const m = cloneObject(defaultModel);
+    expect(_isLegacySolution(m)).toBe(
+      false,
+      "should return false for Solution"
+    );
+  });
+  it("returns false for an item that lacks keywords", () => {
+    const m = cloneObject(defaultModel);
+    delete m.item.typeKeywords;
+    expect(_isLegacySolution(m)).toBe(
+      false,
+      "should return false for model w/o keywords"
+    );
+  });
+  it("returns true for a hub solution", () => {
+    const m = cloneObject(defaultModel);
+    m.item.typeKeywords = ["hubSolutionTemplate", "solutionTemplate"];
+    expect(_isLegacySolution(m)).toBe(
+      true,
+      "should return true for hub solution"
+    );
+  });
+});

--- a/packages/common/test/migrations/upgrade-three-dot-zero.test.ts
+++ b/packages/common/test/migrations/upgrade-three-dot-zero.test.ts
@@ -1,0 +1,48 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _upgradeThreeDotZero } from "../../src/migrations/upgrade-three-dot-zero";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 3.0 ::", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 3.0
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 3", () => {
+    const m = cloneObject(defaultModel);
+    const chk = _upgradeThreeDotZero(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+
+  it("replaces old tokens with new ones", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.3;
+    const chk = _upgradeThreeDotZero(m);
+    expect(chk).not.toBe(m, "should not return the exact same object");
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-three.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-three.test.ts
@@ -1,0 +1,59 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _upgradeTwoDotThree } from "../../src/migrations/upgrade-two-dot-three";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 2.3 ::", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.1
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [
+        {
+          item: {},
+          resources: ["foo.jpg"]
+        },
+        {
+          item: {}
+        }
+      ] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 2.3", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.3;
+    const chk = _upgradeTwoDotThree(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+
+  it("swaps resources to assets", () => {
+    const m = cloneObject(defaultModel);
+    const chk = _upgradeTwoDotThree(m);
+    expect(chk).not.toBe(m, "should not return the exact same object");
+    const tmpl = chk.data.templates[0];
+    expect(tmpl.assets.length).toBe(1, "should add assets array");
+    expect(tmpl.resources).not.toBeDefined("should remove resources array");
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-two.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-two.test.ts
@@ -1,0 +1,56 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _upgradeTwoDotTwo } from "../../src/migrations/upgrade-two-dot-two";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 2.2 ::", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.1
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 2.2", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.3;
+    const chk = _upgradeTwoDotTwo(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+
+  it("replaces old tokens with new ones", () => {
+    const m = cloneObject(defaultModel);
+    // add something with one of the old tags into the .data
+    m.data.metadata.chk = {
+      solName: "{{solution.name}}"
+    };
+    const chk = _upgradeTwoDotTwo(m);
+    expect(chk).not.toBe(m, "should not return the exact same object");
+    expect(chk.data.metadata.chk.solName).toBe(
+      "{{solution.title}}",
+      "should do a swap"
+    );
+  });
+});

--- a/packages/common/test/migrator.test.ts
+++ b/packages/common/test/migrator.test.ts
@@ -1,0 +1,90 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { migrateSchema, CURRENT_SCHEMA_VERSION } from "../src/migrator";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../src/interfaces";
+import * as firstUpgrade from "../src/migrations/upgrade-two-dot-two";
+import * as secondUpgrade from "../src/migrations/upgrade-two-dot-three";
+import * as thirdUpgrade from "../src/migrations/upgrade-three-dot-zero";
+
+describe("Schema Migrator", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: CURRENT_SCHEMA_VERSION
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+  it("returns model if current schema", () => {
+    const m = cloneObject(defaultModel);
+    const chk = migrateSchema(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+  it("stomps on current schema if not legacy", () => {
+    const m = cloneObject(defaultModel);
+    // kill the schema version
+    delete m.item.properties.schemaVersion;
+    const chk = migrateSchema(m);
+    expect(chk).toBe(m, "should return the exact same object");
+    expect(chk.item.properties.schemaVersion).toBe(
+      3,
+      "should upgrade to 3 if no schema"
+    );
+  });
+  it("upgrades legacy Solutions", () => {
+    const m = cloneObject(defaultModel);
+    // kill the schema version
+    m.item.properties.schemaVersion = 2.1;
+    m.item.typeKeywords = ["hubSolutionTemplate", "solutionTemplate"];
+    const sp1 = spyOn(firstUpgrade, "_upgradeTwoDotTwo").and.callFake(model => {
+      return cloneObject(model);
+    });
+    const sp2 = spyOn(secondUpgrade, "_upgradeTwoDotThree").and.callFake(
+      model => {
+        return cloneObject(model);
+      }
+    );
+    const sp3 = spyOn(thirdUpgrade, "_upgradeThreeDotZero").and.callFake(
+      model => {
+        return cloneObject(model);
+      }
+    );
+    const chk = migrateSchema(m);
+    expect(sp1.calls.count()).toBe(1, "should call first upgrade");
+    expect(sp2.calls.count()).toBe(1, "should call second upgrade");
+    expect(sp3.calls.count()).toBe(1, "should call second upgrade");
+    expect(chk).not.toBe(m, "should not return the exact same object");
+    // since the upgrades are all spies, we don't make assertions on the schemaVersion
+  });
+  it("does nothing if v3.1", () => {
+    // this test will go away once we have a 3.0 -> 3.1 migration but it covers an `else` case
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 3.1;
+    const chk = migrateSchema(m);
+    expect(chk).toBe(m, "should return the exact same object");
+    expect(chk.item.properties.schemaVersion).toBe(
+      3.1,
+      "should not change version"
+    );
+  });
+});

--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -372,7 +372,8 @@ export function _getDeploymentProperties(
 ): common.ISolutionItemProperties {
   return {
     version: _getDeploymentProperty("deploy.version.", tags) ?? "1.0",
-    id: _getDeploymentProperty("deploy.id.", tags) ?? common.createPseudoGUID()
+    id: _getDeploymentProperty("deploy.id.", tags) ?? common.createPseudoGUID(),
+    schemaVersion: common.CURRENT_SCHEMA_VERSION
   } as common.ISolutionItemProperties;
 }
 

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -937,7 +937,7 @@ describe("Module `creator`", () => {
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
             "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
-              "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%7D" +
+              "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
               "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate" +
               "&text=%7B%22metadata%22%3A%7B%7D%2C%22templates%22%3A%5B%5D%7D&token=fake-token"
           );
@@ -995,7 +995,7 @@ describe("Module `creator`", () => {
                 encodeURIComponent(options.snippet) +
                 "&description=" +
                 encodeURIComponent(options.description) +
-                "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%7D" +
+                "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
                 "&thumbnailurl=" +
                 encodeURIComponent(options.thumbnailurl) +
                 "&tags=" +
@@ -1161,7 +1161,7 @@ describe("Module `creator`", () => {
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
             "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
-              "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%7D" +
+              "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
               "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate" +
               "&text=%7B%22metadata%22%3A%7B%7D%2C%22templates%22%3A%5B%5D%7D&token=fake-token"
           );
@@ -1184,7 +1184,8 @@ describe("Module `creator`", () => {
       );
       expect(properties).toEqual({
         version: "12.3",
-        id: "abc"
+        id: "abc",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
       });
     });
 
@@ -1196,7 +1197,8 @@ describe("Module `creator`", () => {
       );
       expect(properties).toEqual({
         version: "12.3",
-        id: "guid"
+        id: "guid",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
       });
     });
 
@@ -1207,7 +1209,8 @@ describe("Module `creator`", () => {
       );
       expect(properties).toEqual({
         version: "1.0",
-        id: "abc"
+        id: "abc",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
       });
     });
 
@@ -1219,7 +1222,8 @@ describe("Module `creator`", () => {
       );
       expect(properties).toEqual({
         version: "1.0",
-        id: "guid"
+        id: "guid",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
       });
     });
   });

--- a/packages/deployer/src/deployerUtils.ts
+++ b/packages/deployer/src/deployerUtils.ts
@@ -32,11 +32,11 @@ export function _getSolutionTemplateItem(
       common.getItemBase(idOrObject, authentication),
       common.getItemDataAsJson(idOrObject, authentication)
     ]).then(([item, data]) => {
-      // format into a model
-      return {
+      // format into a model and migrate the schema
+      return common.migrateSchema({
         item,
         data
-      };
+      });
     });
   } else {
     // check if it is a "Model"


### PR DESCRIPTION
This is just setting up the schema versioning system.

Adds `item.properties.schemaVersion` and runs migrations if needed.

Currently it just stamps schemaVersion as 3 unless the app encounters a solution w/ Hub specific typeKeywords - which it should not b/c the hub specific items lack the `Template` keyword.

It is one connected into the main workflows in `deployer` - but ideally we'd have a fn `getSolutionItem(...): Promise<ISolutionItem>`, put the migration in there and have everything use that fn.



