### PR TITLE
Schema Versioning take two...

### DIFF
--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -47,6 +47,7 @@ const copyright = `/* @preserve
  */
 const moduleName = "arcgisSolution";
 const arcgisRestModuleName = 'arcgisRest'
+const hubModuleName = 'arcgisHub'
 
 /**
  * Now we need to discover all the `@esri/solution-*` package names so we can create
@@ -66,6 +67,9 @@ const packageNames = fs
 const arcgisRestJsPackageNames = Object.keys(pkg.dependencies)
   .filter(key => /@esri\/arcgis-rest/.test(key));
 
+const hubJsPackageNames = Object.keys(pkg.dependencies)
+  .filter(key => /@esri\/hub-/.test(key));
+
 /**
  * Rollup will use this map to determine where to lookup modules on the global
  * window object when neither AMD or CommonJS is being used. This configuration
@@ -83,6 +87,11 @@ const globals = packageNames.reduce((globals, p) => {
 */
 arcgisRestJsPackageNames.reduce((globals, p) => {
   globals[p] = arcgisRestModuleName;
+  return globals;
+}, globals);
+
+hubJsPackageNames.reduce((globals, p) => {
+  globals[p] = hubModuleName;
   return globals;
 }, globals);
 


### PR DESCRIPTION
I was only able to repro the circular dependency issue - and I *believe* marking the `arcgisHub` package as external for the umd build will address this.

@MikeTschudi can you pull this and try a build on your system and let me know if things work for you?

This is my output for the umd build of common...

```
(base) ➜  solution.js git:(f/268-solution-schema-versioning) ✗ npm run build

> @esri/solution.js@0.9.2 build /Users/dbouwman/projects/solution.js
> lerna run build

lerna notice cli v3.20.2
lerna info Executing command in 9 packages: "npm run build"
lerna info run Ran npm script 'build' in '@esri/solution-common' in 16.1s:

> @esri/solution-common@0.9.2 build /Users/dbouwman/projects/solution.js/packages/common
> npm run build:node && npm run build:umd && npm run build:esm


> @esri/solution-common@0.9.2 build:node /Users/dbouwman/projects/solution.js/packages/common
> tsc -p ./tsconfig.json --module commonjs --outDir ./dist/node


> @esri/solution-common@0.9.2 build:umd /Users/dbouwman/projects/solution.js/packages/common
> rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js

┌───────────────────────────────────────────────┐
│                                               │
│   Destination: ./dist/umd/common.umd.min.js   │
│   Bundle Size:  77.33 KB                      │
│   Minified Size:  83.49 KB                    │
│   Gzipped Size:  23.41 KB                     │
│                                               │
└───────────────────────────────────────────────┘

> @esri/solution-common@0.9.2 build:esm /Users/dbouwman/projects/solution.js/packages/common
> tsc -p ./tsconfig.json --module esnext --outDir ./dist/esm --declaration
```
