### PR TITLE
add some error logging to the console

### DIFF
--- a/packages/common/src/generalHelpers.ts
+++ b/packages/common/src/generalHelpers.ts
@@ -364,7 +364,7 @@ export function deleteProps(obj: any, props: string[]): void {
  */
 export function fail(e?: any): any {
   if (e) {
-    return { success: false, error: e.error || e };
+    return { success: false, error: e.response?.error || e.error || e };
   } else {
     return { success: false };
   }

--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -173,13 +173,16 @@ export function _addContentToSolution(
 
       if (status === common.EItemProgressStatus.Failed) {
         solutionTemplates.some(t => {
+          /* istanbul ignore else */
           if (t.itemId === itemId) {
-            if (t.properties?.error) {
+            /* istanbul ignore else */
+            if (common.getProp(t, "properties.error")) {
               let error = t.properties.error;
               try {
                 // parse for better console logging if we can
                 error = JSON.parse(error);
               } catch (e) {
+                /* istanbul ignore next */
                 // do nothing and show the error as is
               }
               console.error(error);

--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -101,6 +101,7 @@ export function createSolution(
             if (createOptions.progressCallback) {
               createOptions.progressCallback(1);
             }
+            console.error(error);
             reject(error);
           }
         );
@@ -171,6 +172,21 @@ export function _addContentToSolution(
       }
 
       if (status === common.EItemProgressStatus.Failed) {
+        solutionTemplates.some(t => {
+          if (t.itemId === itemId) {
+            if (t.properties?.error) {
+              let error = t.properties.error;
+              try {
+                // parse for better console logging if we can
+                error = JSON.parse(error);
+              } catch (e) {
+                // do nothing and show the error as is
+              }
+              console.error(error);
+            }
+            return true;
+          }
+        });
         common.removeTemplate(solutionTemplates, itemId);
         if (failedItemIds.indexOf(itemId) < 0) {
           failedItemIds.push(itemId);

--- a/packages/creator/test/createItemTemplate.test.ts
+++ b/packages/creator/test/createItemTemplate.test.ts
@@ -296,8 +296,12 @@ describe("Module `createItemTemplate`", () => {
               itemId
             );
             expect(createdTemplate.properties.error).not.toBeUndefined();
-            expect(createdTemplate.properties.error).toEqual(
-              '{"success":false}'
+            const parsedError: any = JSON.parse(
+              createdTemplate.properties.error
+            );
+            expect(parsedError.success).toBeFalse();
+            expect(parsedError.error.message).toEqual(
+              "Item does not have a file."
             );
             done();
           });

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -858,42 +858,44 @@ describe("Module `creator`", () => {
         .then(() => done());
     });
 
-    it("_addContentToSolution item progress callback with failed item", done => {
-      const solutionId = "sln1234567890";
-      const itemIds = ["map1234567890"];
+    if (typeof window !== "undefined") {
+      it("_addContentToSolution item progress callback with failed item", done => {
+        const solutionId = "sln1234567890";
+        const itemIds = ["map1234567890"];
 
-      staticRelatedItemsMocks.fetchMockRelatedItems("map1234567890", {
-        total: 0,
-        relatedItems: []
+        staticRelatedItemsMocks.fetchMockRelatedItems("map1234567890", {
+          total: 0,
+          relatedItems: []
+        });
+
+        fetchMock
+          .get(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/items/map1234567890?f=json&token=fake-token",
+            mockItems.getAGOLItem("Web Map")
+          )
+          .post(
+            "https://myorg.maps.arcgis.com/sharing/rest/content/items/map1234567890/data",
+            mockItems.getAGOLItemData("Web Map")
+          )
+          .post(
+            "https://services123.arcgis.com/org1234567890/arcgis/rest/services/ROWPermits_publiccomment/FeatureServer/0",
+            mockItems.get400FailureResponse()
+          );
+        // tslint:disable-next-line: no-floating-promises
+        creator
+          ._addContentToSolution(solutionId, itemIds, MOCK_USER_SESSION, {})
+          .then(
+            () => done.fail(),
+            e => {
+              expect(e.success).toBeFalse();
+              expect(e.error).toEqual(
+                "One or more items cannot be converted into templates"
+              );
+              done();
+            }
+          );
       });
-
-      fetchMock
-        .get(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/map1234567890?f=json&token=fake-token",
-          mockItems.getAGOLItem("Web Map")
-        )
-        .post(
-          "https://myorg.maps.arcgis.com/sharing/rest/content/items/map1234567890/data",
-          mockItems.getAGOLItemData("Web Map")
-        )
-        .post(
-          "https://services123.arcgis.com/org1234567890/arcgis/rest/services/ROWPermits_publiccomment/FeatureServer/0",
-          mockItems.get400FailureResponse()
-        );
-      // tslint:disable-next-line: no-floating-promises
-      creator
-        ._addContentToSolution(solutionId, itemIds, MOCK_USER_SESSION, {})
-        .then(
-          () => done.fail(),
-          e => {
-            expect(e.success).toBeFalse();
-            expect(e.error).toEqual(
-              "One or more items cannot be converted into templates"
-            );
-            done();
-          }
-        );
-    });
+    }
   });
 
   describe("_createSolutionFromItemIds", () => {

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -334,7 +334,10 @@ export function deploySolutionItems(
           }
         });
       },
-      e => reject(common.fail(e))
+      e => {
+        console.error(e);
+        reject(common.fail(e));
+      }
     );
   });
 }

--- a/packages/simple-types/src/simple-types.ts
+++ b/packages/simple-types/src/simple-types.ts
@@ -171,11 +171,9 @@ export function convertItemToTemplate(
 
         wrapupPromise.then(
           () => {
-            webappPromise.then(resolve, err =>
-              reject(common.fail(err.response))
-            );
+            webappPromise.then(resolve, err => reject(common.fail(err)));
           },
-          err => reject(common.fail(err.response))
+          err => reject(common.fail(err))
         );
       },
       error => {


### PR DESCRIPTION
#307

Thought these main entry points for create and deploy would be nice spots for some error logs to come through. 

In regards to the extra handeling in the callback for failed. Seems like this is a good spot to get a more detailed message about the failure before the template is removed. 

So for the case of a web map that fails to create because one of it's layers have been deleted we get a message about the FS with the invalid url and we also get the webmap item id from the main create entry point error.