### PR TITLE
F/268 solution schema versioning (Take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased][HEAD]
 
+### Added
+- solution schema versioning
+
+### Changed
+### Fixed
+### Removed
+
+### Breaking
+
 ## [0.9.2] - April 14th 2020
 
 ## [0.9.1] - April 13th 2020

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "clean": "npm run clean:src && npm run clean:dist",
     "clean:src": "rm -rf packages/*/{src,test}/*.{d.ts,js,js.map} && rm -rf packages/*/{src,test}/**/*.{d.ts,js,js.map}",
     "clean:dist": "rm -rf packages/*/dist/ && rm -rf packages/*/.rpt2_cache",
+    "deepclean": "rm -rf ./node_modules && rm -rf packages/*/node_modules && npm run clean && npm i",
     "lint": "tslint --project tsconfig.json --exclude '**/*.d.ts'",
     "lint:fix": "tslint --project tsconfig.json --exclude '**/*.d.ts' --fix",
     "prettify": "prettier --write --parser typescript --tab-width 2 --use-tabs false \"packages/**/+(src|test)/**/*.ts\"",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -63,24 +63,14 @@
 			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ=="
 		},
 		"@esri/hub-common": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.8.0.tgz",
-			"integrity": "sha512-XQ4oL+Dcd8IMkB8Pv1wRtsvFEZdUD2wSxfBsQ1wOkv8fzsBJyGyEd87JTgJtX8p0dUVYN4QS91GzkFFn4YF02g==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.9.2.tgz",
+			"integrity": "sha512-Ip/iEGLg2g5CYJ1f7Cn0wmByNVgouJbBe8ndjVYHtLLo5SIdr6JbAwJrXpDvCb8gZwtHoccdPSS71WPsNEvxfw==",
 			"requires": {
 				"adlib": "3.0.5",
 				"fetch-blob": "github:node-fetch/fetch-blob#master",
 				"node-fetch": "^2.6.0",
 				"tslib": "^1.11.1"
-			},
-			"dependencies": {
-				"adlib": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.5.tgz",
-					"integrity": "sha512-+9lYo3Hm1UYJn3RxVp+SLBuOCh1pt5RiuW8KXGtgqycALaKvZRWAvxnBIyHDkcfEk4RieZ55svJPl4sHKhKlkQ==",
-					"requires": {
-						"esm": "^3.2.25"
-					}
-				}
 			}
 		},
 		"@types/adlib": {

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -14,53 +14,53 @@
 			}
 		},
 		"@esri/arcgis-rest-auth": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.12.1.tgz",
-			"integrity": "sha512-watQZnzH988a7A0o17ywZBeNnUClu66mg6CEnTRx8wCf/B7r5wI6CXXwvnN+1uP0azFAb/66x12NVTFsN3mz6g==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.13.0.tgz",
+			"integrity": "sha512-FZKpJyEC/NSWlcxYVp2tAj5RMXkQ+3MCfsSHD4VnlgMBDPUBJo27L2zUrGb65qnpn5SKWciwAvYOuMQXfYXbjQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.12.1",
+				"@esri/arcgis-rest-types": "^2.13.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-feature-layer": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.12.1.tgz",
-			"integrity": "sha512-MTtAyJZ71Rp57IZjUe3jTPFXtfa3pVgWlUwNnZVTz/wFyIjnd5DKHt7N9GnMQAblyhCy2MR25bNbQSMyyaiIAw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.13.0.tgz",
+			"integrity": "sha512-qv3N8sHBO9EJJJEZUryQeQYsLx+Jte47TEkJlSTfZ/+uEh9yNNfieFoB0SckAD/xbrD3kso5903aVLpCbeodSA==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.12.1",
+				"@esri/arcgis-rest-types": "^2.13.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.12.1.tgz",
-			"integrity": "sha512-hsJqmrfUa0B6sQBKpTqZicPOK72ZTX0b5Has4tfR2Pw0KtrCSlm29jdxVH1udP9Unf9XCiq89epZ0BBQvvk0CQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.13.0.tgz",
+			"integrity": "sha512-zdj7NV/TfrihH+jrM45ZvKg4HpCTXFTqa7tkTsHnhwTCSRFYGYehJ0LiPiQ0Bj31rUwQipZBWMJO1iqwa5jZXg==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.12.1",
+				"@esri/arcgis-rest-types": "^2.13.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.12.1.tgz",
-			"integrity": "sha512-r/fF/go2ZBFjvBtKYjQ/+JxCcftzZ67fSiXrKSQoK7e+Eie7B3VmnGu/z7ziBPX5ssI+WfWwibFrNwVVFrBuQQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.13.0.tgz",
+			"integrity": "sha512-mLQci+lPwLIbjxCPoJrixiaYNX831FnsF3rcPfSD1MrDAMY4UuS8YaluFAo3zyYVq+sgWEXB3Bgu9E/WCyMAjw==",
 			"requires": {
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-service-admin": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.12.1.tgz",
-			"integrity": "sha512-6+pPC2ajh1AD05ss+PJu9RWMl1sRCWL++6umjkshCW5ny2OvxeuaaavRABOiKRLwUi7TfVc3nfQQzyVKN1iN5A==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.13.0.tgz",
+			"integrity": "sha512-6Zu2As6bc+FOkj0xLXHUeCRJnkfBm+gOXXt2d6LDzKaw+cm74RoEh3m78zTDMDQWAOz4h0QHqI4iQVWhZNZZhQ==",
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.12.1",
+				"@esri/arcgis-rest-types": "^2.13.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.12.1.tgz",
-			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ=="
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.13.0.tgz",
+			"integrity": "sha512-yZ82iG7+bbkP9UBmXiiDvV0v7n5CfjICTZlSwxJ55V1eKve65idOZdf+EsSKZIuAdv+wbEJ328CzGdE5cMnl+g=="
 		},
 		"@esri/hub-common": {
 			"version": "3.9.2",
@@ -105,9 +105,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+			"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
 			"dev": true
 		},
 		"adlib": {

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -62,6 +62,27 @@
 			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.12.1.tgz",
 			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ=="
 		},
+		"@esri/hub-common": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.8.0.tgz",
+			"integrity": "sha512-XQ4oL+Dcd8IMkB8Pv1wRtsvFEZdUD2wSxfBsQ1wOkv8fzsBJyGyEd87JTgJtX8p0dUVYN4QS91GzkFFn4YF02g==",
+			"requires": {
+				"adlib": "3.0.5",
+				"fetch-blob": "github:node-fetch/fetch-blob#master",
+				"node-fetch": "^2.6.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"adlib": {
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.5.tgz",
+					"integrity": "sha512-+9lYo3Hm1UYJn3RxVp+SLBuOCh1pt5RiuW8KXGtgqycALaKvZRWAvxnBIyHDkcfEk4RieZ55svJPl4sHKhKlkQ==",
+					"requires": {
+						"esm": "^3.2.25"
+					}
+				}
+			}
+		},
 		"@types/adlib": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
@@ -122,10 +143,19 @@
 			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
 			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
 		},
+		"fetch-blob": {
+			"version": "github:node-fetch/fetch-blob#4a46def45247e7e1fac18b9e399e0969b2c4a962",
+			"from": "github:node-fetch/fetch-blob#master"
+		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"node-fetch": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"rollup": {
 			"version": "1.32.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@esri/hub-common": "^3.7.5",
+    "@esri/hub-common": "^3.9.2",
     "@esri/arcgis-html-sanitizer": "^2.2.0",
     "@esri/arcgis-rest-auth": "^2.11.0",
     "@esri/arcgis-rest-feature-layer": "^2.11.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@esri/hub-common": "^3.7.5",
     "@esri/arcgis-html-sanitizer": "^2.2.0",
     "@esri/arcgis-rest-auth": "^2.11.0",
     "@esri/arcgis-rest-feature-layer": "^2.11.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -31,6 +31,9 @@
     "tslib": "^1.10.0",
     "xss": "^1.0.6"
   },
+  "peerDependencies": {
+    
+  },
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:node && npm run build:umd && npm run build:esm",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,3 +31,4 @@ export * from "./resourceHelpers";
 export * from "./restHelpers";
 export * from "./restHelpersGet";
 export * from "./templatization";
+export * from "./migrator";

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -397,6 +397,10 @@ export interface IItemTemplate {
    * function calls made during while deploying it
    */
   estimatedDeploymentCostFactor: number;
+  /**
+   * Allow for adhoc properties
+   */
+  [propName: string]: any;
 }
 
 /**

--- a/packages/common/src/migrations/is-legacy-solution.ts
+++ b/packages/common/src/migrations/is-legacy-solution.ts
@@ -1,0 +1,38 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp } from "../generalHelpers";
+
+/**
+ * Determine if the Solution is a legacy item created by Hub
+ * vs one that is 100% compatible with Solution.js
+ * @param model ISolutionModel
+ */
+export function _isLegacySolution(model: ISolutionItem): boolean {
+  let result = false;
+  // if it does not have the `Template` keyword BUT does have `hubSolutionTemplate` it is legacy
+  const keywords = getProp(model, "item.typeKeywords") || [];
+  if (!keywords.includes("Template")) {
+    if (
+      keywords.includes("hubSolutionTemplate") &&
+      keywords.includes("solutionTemplate")
+    ) {
+      result = true;
+    }
+  }
+  return result;
+}

--- a/packages/common/src/migrations/upgrade-three-dot-zero.ts
+++ b/packages/common/src/migrations/upgrade-three-dot-zero.ts
@@ -1,0 +1,37 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp, cloneObject } from "../generalHelpers";
+
+/**
+ * Apply the initial schema
+ * If the item was created by Solution.js, this will stamp it
+ * with the initial Solution.js schama version number (3)
+ * If it is a legacy hub solution, it will apply the transforms
+ * @param model ISolutionItem
+ */
+export function _upgradeThreeDotZero(model: ISolutionItem): ISolutionItem {
+  if (getProp(model, "item.properties.schemaVersion") >= 3) {
+    return model;
+  } else {
+    // TODO: Implement the logic to upgrade 2.3+ to 3.0
+    // At this point we know that the resources array on the templates will need to
+    // be modified, but we expect other things as well. Once Hub team starts integrating
+    // more deeply we can write this set of transforms
+    return cloneObject(model);
+  }
+}

--- a/packages/common/src/migrations/upgrade-two-dot-three.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-three.ts
@@ -1,0 +1,48 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp } from "../generalHelpers";
+import { cloneObject } from "@esri/hub-common";
+
+export function _upgradeTwoDotThree(model: ISolutionItem) {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.3) {
+    return model;
+  }
+
+  const clone = cloneObject(model);
+
+  // rename template.resources => template.assets
+  // this has landed in Hub, so we have actual items like this :(
+  // we will have another schema upgrade that will re-create the
+  // resources array
+  clone.data.templates = clone.data.templates.map(tmpl => {
+    if (tmpl.resources) {
+      tmpl.assets = tmpl.resources.map(r => {
+        return {
+          name: r,
+          type: "resource"
+        };
+      });
+      delete tmpl.resources;
+    } else {
+      tmpl.assets = [];
+    }
+    return tmpl;
+  });
+  clone.item.properties.schemaVersion = 2.3;
+  return clone;
+}

--- a/packages/common/src/migrations/upgrade-two-dot-two.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-two.ts
@@ -1,0 +1,55 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem, ISolutionItemData } from "../interfaces";
+import { getProp } from "../generalHelpers";
+import { deepStringReplace, cloneObject } from "@esri/hub-common";
+
+export function _upgradeTwoDotTwo(model: ISolutionItem): ISolutionItem {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.2) {
+    return model;
+  }
+
+  const clone = cloneObject(model);
+  // NOTE: Not all of these have closing `}}` and that is intentional
+  const swaps = [
+    { src: "{{solution.name}}", val: "{{solution.title}}" },
+    { src: "{{initiative.name}}", val: "{{solution.title}}" },
+    { src: "{{initiative.title}}", val: "{{solution.title}}" },
+    { src: "{{initiative.extent}}", val: "{{organization.defaultExtentBBox}}" },
+    {
+      src: "{{initiative.collaborationGroupId",
+      val: "{{teams.collaborationGroupId"
+    },
+    { src: "{{initiative.openDataGroupId", val: "{{teams.contentGroupId" },
+    { src: "{{initiative.contentGroupId", val: "{{teams.contentGroupId" },
+    { src: "{{initiative.followersGroupId", val: "{{teams.followersGroupId" },
+    { src: "{{collaborationGroupId", val: "{{teams.collaborationGroupId" },
+    { src: "{{contentGroupId", val: "{{teams.contentGroupId" },
+    { src: "{{followersGroupId", val: "{{teams.followersGroupId" },
+    { src: "{{initiative.id", val: "{{initiative.item.id" },
+    { src: "{{organization.portalBaseUrl", val: "{{portalBaseUrl" }
+  ];
+  swaps.forEach(swap => {
+    clone.data = deepStringReplace(
+      clone.data,
+      swap.src,
+      swap.val
+    ) as ISolutionItemData;
+  });
+  clone.item.properties.schemaVersion = 2.2;
+  return clone;
+}

--- a/packages/common/src/migrator.ts
+++ b/packages/common/src/migrator.ts
@@ -15,12 +15,11 @@
  */
 
 import { ISolutionItem } from "./interfaces";
-import { getProp } from "./generalHelpers";
 import { _isLegacySolution } from "./migrations/is-legacy-solution";
 import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
 import { _upgradeTwoDotTwo } from "./migrations/upgrade-two-dot-two";
 import { _upgradeTwoDotThree } from "./migrations/upgrade-two-dot-three";
-import { ensureProp } from "@esri/hub-common";
+import { getProp } from "@esri/hub-common";
 
 // Starting at 3.0 because Hub has been versioning Solution items up to 2.x
 export const CURRENT_SCHEMA_VERSION = 3.0;

--- a/packages/common/src/migrator.ts
+++ b/packages/common/src/migrator.ts
@@ -1,0 +1,65 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "./interfaces";
+import { getProp } from "./generalHelpers";
+import { _isLegacySolution } from "./migrations/is-legacy-solution";
+import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
+import { _upgradeTwoDotTwo } from "./migrations/upgrade-two-dot-two";
+import { _upgradeTwoDotThree } from "./migrations/upgrade-two-dot-three";
+import { ensureProp } from "@esri/hub-common";
+
+// Starting at 3.0 because Hub has been versioning Solution items up to 2.x
+export const CURRENT_SCHEMA_VERSION = 3.0;
+
+/**
+ * Apply schema migrations to a Solution item
+ * This system allows the schema of the Solution item to change over time
+ * while abstracting those changes into a single set of functional transforms
+ * @param model ISolutionItem
+ */
+export function migrateSchema(model: ISolutionItem): ISolutionItem {
+  // ensure properties
+  if (!getProp(model, "item.properties")) {
+    model.item.properties = {};
+  }
+
+  const modelVersion = getProp(model, "item.properties.schemaVersion");
+  // if it's already on the current version, return it
+  if (modelVersion === CURRENT_SCHEMA_VERSION) {
+    return model;
+  } else {
+    // check if this is a legacy solution created by Hub
+    const isLegacy = _isLegacySolution(model);
+    // if this is a Solution.js "native" item, it is already at 3.0
+    if (!modelVersion && !isLegacy) {
+      // bump it up to 3.0
+      model.item.properties.schemaVersion = CURRENT_SCHEMA_VERSION;
+    } else {
+      // Hub created a set of Solution items that are not 100% compatible
+      // with the Solution.js deployer.
+      // The schemaVersion of these items is 2.1 - prior to that we used
+      // Web Mapping Application items, which are deprecated
+      if (modelVersion >= 2.1 && modelVersion < 3) {
+        model = _upgradeTwoDotTwo(model);
+        model = _upgradeTwoDotThree(model);
+        model = _upgradeThreeDotZero(model);
+      }
+      // When we need to apply schema upgrades 3.0+ we add those here...
+    }
+    return model;
+  }
+}

--- a/packages/common/test/libs.test.ts
+++ b/packages/common/test/libs.test.ts
@@ -217,11 +217,11 @@ describe("Module `arcgis-html-sanitizer`: ", () => {
     });
 
     it("tests XSS cases", () => {
-      console.log(
-        "Running " +
-          xssFilterEvasionTestCases.testCases.length +
-          " XSS test cases"
-      );
+      // console.log(
+      //   "Running " +
+      //     xssFilterEvasionTestCases.testCases.length +
+      //     " XSS test cases"
+      // );
       const sanitizer = new libs.Sanitizer();
 
       xssFilterEvasionTestCases.testCases.forEach(

--- a/packages/common/test/migrations/is-legacy-solution.test.ts
+++ b/packages/common/test/migrations/is-legacy-solution.test.ts
@@ -1,0 +1,59 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _isLegacySolution } from "../../src/migrations/is-legacy-solution";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("isLegacySolution", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.1
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns false for a Solution", () => {
+    const m = cloneObject(defaultModel);
+    expect(_isLegacySolution(m)).toBe(
+      false,
+      "should return false for Solution"
+    );
+  });
+  it("returns false for an item that lacks keywords", () => {
+    const m = cloneObject(defaultModel);
+    delete m.item.typeKeywords;
+    expect(_isLegacySolution(m)).toBe(
+      false,
+      "should return false for model w/o keywords"
+    );
+  });
+  it("returns true for a hub solution", () => {
+    const m = cloneObject(defaultModel);
+    m.item.typeKeywords = ["hubSolutionTemplate", "solutionTemplate"];
+    expect(_isLegacySolution(m)).toBe(
+      true,
+      "should return true for hub solution"
+    );
+  });
+});

--- a/packages/common/test/migrations/upgrade-three-dot-zero.test.ts
+++ b/packages/common/test/migrations/upgrade-three-dot-zero.test.ts
@@ -1,0 +1,48 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _upgradeThreeDotZero } from "../../src/migrations/upgrade-three-dot-zero";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 3.0 ::", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 3.0
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 3", () => {
+    const m = cloneObject(defaultModel);
+    const chk = _upgradeThreeDotZero(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+
+  it("replaces old tokens with new ones", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.3;
+    const chk = _upgradeThreeDotZero(m);
+    expect(chk).not.toBe(m, "should not return the exact same object");
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-three.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-three.test.ts
@@ -1,0 +1,59 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _upgradeTwoDotThree } from "../../src/migrations/upgrade-two-dot-three";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 2.3 ::", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.1
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [
+        {
+          item: {},
+          resources: ["foo.jpg"]
+        },
+        {
+          item: {}
+        }
+      ] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 2.3", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.3;
+    const chk = _upgradeTwoDotThree(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+
+  it("swaps resources to assets", () => {
+    const m = cloneObject(defaultModel);
+    const chk = _upgradeTwoDotThree(m);
+    expect(chk).not.toBe(m, "should not return the exact same object");
+    const tmpl = chk.data.templates[0];
+    expect(tmpl.assets.length).toBe(1, "should add assets array");
+    expect(tmpl.resources).not.toBeDefined("should remove resources array");
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-two.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-two.test.ts
@@ -1,0 +1,56 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _upgradeTwoDotTwo } from "../../src/migrations/upgrade-two-dot-two";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 2.2 ::", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.1
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 2.2", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.3;
+    const chk = _upgradeTwoDotTwo(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+
+  it("replaces old tokens with new ones", () => {
+    const m = cloneObject(defaultModel);
+    // add something with one of the old tags into the .data
+    m.data.metadata.chk = {
+      solName: "{{solution.name}}"
+    };
+    const chk = _upgradeTwoDotTwo(m);
+    expect(chk).not.toBe(m, "should not return the exact same object");
+    expect(chk.data.metadata.chk.solName).toBe(
+      "{{solution.title}}",
+      "should do a swap"
+    );
+  });
+});

--- a/packages/common/test/migrator.test.ts
+++ b/packages/common/test/migrator.test.ts
@@ -1,0 +1,90 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { migrateSchema, CURRENT_SCHEMA_VERSION } from "../src/migrator";
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../src/interfaces";
+import * as firstUpgrade from "../src/migrations/upgrade-two-dot-two";
+import * as secondUpgrade from "../src/migrations/upgrade-two-dot-three";
+import * as thirdUpgrade from "../src/migrations/upgrade-three-dot-zero";
+
+describe("Schema Migrator", () => {
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: CURRENT_SCHEMA_VERSION
+      }
+    },
+    data: {
+      metadata: {},
+      templates: [] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+  it("returns model if current schema", () => {
+    const m = cloneObject(defaultModel);
+    const chk = migrateSchema(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+  it("stomps on current schema if not legacy", () => {
+    const m = cloneObject(defaultModel);
+    // kill the schema version
+    delete m.item.properties.schemaVersion;
+    const chk = migrateSchema(m);
+    expect(chk).toBe(m, "should return the exact same object");
+    expect(chk.item.properties.schemaVersion).toBe(
+      3,
+      "should upgrade to 3 if no schema"
+    );
+  });
+  it("upgrades legacy Solutions", () => {
+    const m = cloneObject(defaultModel);
+    // kill the schema version
+    m.item.properties.schemaVersion = 2.1;
+    m.item.typeKeywords = ["hubSolutionTemplate", "solutionTemplate"];
+    const sp1 = spyOn(firstUpgrade, "_upgradeTwoDotTwo").and.callFake(model => {
+      return cloneObject(model);
+    });
+    const sp2 = spyOn(secondUpgrade, "_upgradeTwoDotThree").and.callFake(
+      model => {
+        return cloneObject(model);
+      }
+    );
+    const sp3 = spyOn(thirdUpgrade, "_upgradeThreeDotZero").and.callFake(
+      model => {
+        return cloneObject(model);
+      }
+    );
+    const chk = migrateSchema(m);
+    expect(sp1.calls.count()).toBe(1, "should call first upgrade");
+    expect(sp2.calls.count()).toBe(1, "should call second upgrade");
+    expect(sp3.calls.count()).toBe(1, "should call second upgrade");
+    expect(chk).not.toBe(m, "should not return the exact same object");
+    // since the upgrades are all spies, we don't make assertions on the schemaVersion
+  });
+  it("does nothing if v3.1", () => {
+    // this test will go away once we have a 3.0 -> 3.1 migration but it covers an `else` case
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 3.1;
+    const chk = migrateSchema(m);
+    expect(chk).toBe(m, "should return the exact same object");
+    expect(chk.item.properties.schemaVersion).toBe(
+      3.1,
+      "should not change version"
+    );
+  });
+});

--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -22,7 +22,6 @@
 
 import * as common from "@esri/solution-common";
 import * as createItemTemplate from "./createItemTemplate";
-import { CURRENT_SCHEMA_VERSION } from '@esri/solution-common';
 
 //#region Entry point ----------------------------------------------------------------------------------------------- //
 

--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -22,6 +22,7 @@
 
 import * as common from "@esri/solution-common";
 import * as createItemTemplate from "./createItemTemplate";
+import { CURRENT_SCHEMA_VERSION } from '@esri/solution-common';
 
 //#region Entry point ----------------------------------------------------------------------------------------------- //
 
@@ -319,7 +320,9 @@ export function _createSolutionItem(
       title: options?.title ?? common.createShortId(),
       snippet: options?.snippet ?? "",
       description: options?.description ?? "",
-      properties: {},
+      properties: {
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
+      },
       thumbnailurl: options?.thumbnailurl ?? "",
       tags: creationTags.filter(tag => !tag.startsWith("deploy.")),
       typeKeywords: ["Solution", "Template"].concat(

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -975,7 +975,9 @@ describe("Module `creator`", () => {
           const options: fetchMock.MockOptions = fetchMock.lastOptions(url);
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
-            "f=json&type=Solution&title=xfakeidx&snippet=&description=&properties=%7B%7D" +
+            "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
+              "&properties=" +
+              encodeURIComponent(JSON.stringify({ schemaVersion: 3 })) +
               "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate%2Csolutionid-guid%2Csolutionversion-1.0" +
               "&text=%7B%22metadata%22%3A%7B%7D%2C%22templates%22%3A%5B%5D%7D&token=fake-token"
           );
@@ -1033,12 +1035,9 @@ describe("Module `creator`", () => {
                 encodeURIComponent(options.snippet) +
                 "&description=" +
                 encodeURIComponent(options.description) +
-<<<<<<< HEAD
-                "&properties=%7B%7D&thumbnailurl=" +
-=======
-                "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
+                "&properties=" +
+                encodeURIComponent(JSON.stringify({ schemaVersion: 3 })) +
                 "&thumbnailurl=" +
->>>>>>> add solution schemaVersion, migrations
                 encodeURIComponent(options.thumbnailurl) +
                 "&tags=" +
                 options.tags.map(encodeURIComponent).join("%2C") +
@@ -1207,14 +1206,10 @@ describe("Module `creator`", () => {
           const options: fetchMock.MockOptions = fetchMock.lastOptions(url);
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
-<<<<<<< HEAD
-            "f=json&type=Solution&title=xfakeidx&snippet=&description=&properties=%7B%7D" +
-              "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate%2Csolutionid-guid%2Csolutionversion-1.0" +
-=======
             "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
-              "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
-              "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate" +
->>>>>>> add solution schemaVersion, migrations
+              "&properties=" +
+              encodeURIComponent(JSON.stringify({ schemaVersion: 3 })) +
+              "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate%2Csolutionid-guid%2Csolutionversion-1.0" +
               "&text=%7B%22metadata%22%3A%7B%7D%2C%22templates%22%3A%5B%5D%7D&token=fake-token"
           );
           done();
@@ -1231,72 +1226,28 @@ describe("Module `creator`", () => {
         "another_tag",
         "deploy.version.12.3"
       ];
-<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-abc", "solutionversion-12.3"]);
-=======
-      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
-        tags
-      );
-      expect(properties).toEqual({
-        version: "12.3",
-        id: "abc",
-        schemaVersion: common.CURRENT_SCHEMA_VERSION
-      });
->>>>>>> add solution schemaVersion, migrations
     });
 
     it("finds only version deployment property", () => {
       const tags = ["a_tag", "another_tag", "deploy.version.12.3"];
       spyOn(common, "createPseudoGUID").and.callFake(() => "guid");
-<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-guid", "solutionversion-12.3"]);
-=======
-      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
-        tags
-      );
-      expect(properties).toEqual({
-        version: "12.3",
-        id: "guid",
-        schemaVersion: common.CURRENT_SCHEMA_VERSION
-      });
->>>>>>> add solution schemaVersion, migrations
     });
 
     it("finds only id deployment property", () => {
       const tags = ["a_tag", "deploy.id.abc", "another_tag"];
-<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-abc", "solutionversion-1.0"]);
-=======
-      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
-        tags
-      );
-      expect(properties).toEqual({
-        version: "1.0",
-        id: "abc",
-        schemaVersion: common.CURRENT_SCHEMA_VERSION
-      });
->>>>>>> add solution schemaVersion, migrations
     });
 
     it("doesn't find either deployment property", () => {
       const tags = ["a_tag", "another_tag"];
       spyOn(common, "createPseudoGUID").and.callFake(() => "guid");
-<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-guid", "solutionversion-1.0"]);
-=======
-      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
-        tags
-      );
-      expect(properties).toEqual({
-        version: "1.0",
-        id: "guid",
-        schemaVersion: common.CURRENT_SCHEMA_VERSION
-      });
->>>>>>> add solution schemaVersion, migrations
     });
   });
 

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -1033,7 +1033,12 @@ describe("Module `creator`", () => {
                 encodeURIComponent(options.snippet) +
                 "&description=" +
                 encodeURIComponent(options.description) +
+<<<<<<< HEAD
                 "&properties=%7B%7D&thumbnailurl=" +
+=======
+                "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
+                "&thumbnailurl=" +
+>>>>>>> add solution schemaVersion, migrations
                 encodeURIComponent(options.thumbnailurl) +
                 "&tags=" +
                 options.tags.map(encodeURIComponent).join("%2C") +
@@ -1202,8 +1207,14 @@ describe("Module `creator`", () => {
           const options: fetchMock.MockOptions = fetchMock.lastOptions(url);
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
+<<<<<<< HEAD
             "f=json&type=Solution&title=xfakeidx&snippet=&description=&properties=%7B%7D" +
               "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate%2Csolutionid-guid%2Csolutionversion-1.0" +
+=======
+            "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
+              "&properties=%7B%22version%22%3A%221.0%22%2C%22id%22%3A%22guid%22%2C%22schemaVersion%22%3A3%7D" +
+              "&thumbnailurl=&tags=&typeKeywords=Solution%2CTemplate" +
+>>>>>>> add solution schemaVersion, migrations
               "&text=%7B%22metadata%22%3A%7B%7D%2C%22templates%22%3A%5B%5D%7D&token=fake-token"
           );
           done();
@@ -1220,28 +1231,72 @@ describe("Module `creator`", () => {
         "another_tag",
         "deploy.version.12.3"
       ];
+<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-abc", "solutionversion-12.3"]);
+=======
+      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
+        tags
+      );
+      expect(properties).toEqual({
+        version: "12.3",
+        id: "abc",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
+      });
+>>>>>>> add solution schemaVersion, migrations
     });
 
     it("finds only version deployment property", () => {
       const tags = ["a_tag", "another_tag", "deploy.version.12.3"];
       spyOn(common, "createPseudoGUID").and.callFake(() => "guid");
+<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-guid", "solutionversion-12.3"]);
+=======
+      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
+        tags
+      );
+      expect(properties).toEqual({
+        version: "12.3",
+        id: "guid",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
+      });
+>>>>>>> add solution schemaVersion, migrations
     });
 
     it("finds only id deployment property", () => {
       const tags = ["a_tag", "deploy.id.abc", "another_tag"];
+<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-abc", "solutionversion-1.0"]);
+=======
+      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
+        tags
+      );
+      expect(properties).toEqual({
+        version: "1.0",
+        id: "abc",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
+      });
+>>>>>>> add solution schemaVersion, migrations
     });
 
     it("doesn't find either deployment property", () => {
       const tags = ["a_tag", "another_tag"];
       spyOn(common, "createPseudoGUID").and.callFake(() => "guid");
+<<<<<<< HEAD
       const typeKeywords: string[] = creator._getDeploymentProperties(tags);
       expect(typeKeywords).toEqual(["solutionid-guid", "solutionversion-1.0"]);
+=======
+      const properties: common.ISolutionItemProperties = creator._getDeploymentProperties(
+        tags
+      );
+      expect(properties).toEqual({
+        version: "1.0",
+        id: "guid",
+        schemaVersion: common.CURRENT_SCHEMA_VERSION
+      });
+>>>>>>> add solution schemaVersion, migrations
     });
   });
 

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -5,44 +5,44 @@
 	"requires": true,
 	"dependencies": {
 		"@esri/arcgis-rest-auth": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.12.1.tgz",
-			"integrity": "sha512-watQZnzH988a7A0o17ywZBeNnUClu66mg6CEnTRx8wCf/B7r5wI6CXXwvnN+1uP0azFAb/66x12NVTFsN3mz6g==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.13.0.tgz",
+			"integrity": "sha512-FZKpJyEC/NSWlcxYVp2tAj5RMXkQ+3MCfsSHD4VnlgMBDPUBJo27L2zUrGb65qnpn5SKWciwAvYOuMQXfYXbjQ==",
 			"dev": true,
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.12.1",
+				"@esri/arcgis-rest-types": "^2.13.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-portal": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.12.1.tgz",
-			"integrity": "sha512-hsJqmrfUa0B6sQBKpTqZicPOK72ZTX0b5Has4tfR2Pw0KtrCSlm29jdxVH1udP9Unf9XCiq89epZ0BBQvvk0CQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.13.0.tgz",
+			"integrity": "sha512-zdj7NV/TfrihH+jrM45ZvKg4HpCTXFTqa7tkTsHnhwTCSRFYGYehJ0LiPiQ0Bj31rUwQipZBWMJO1iqwa5jZXg==",
 			"dev": true,
 			"requires": {
-				"@esri/arcgis-rest-types": "^2.12.1",
+				"@esri/arcgis-rest-types": "^2.13.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-request": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.12.1.tgz",
-			"integrity": "sha512-r/fF/go2ZBFjvBtKYjQ/+JxCcftzZ67fSiXrKSQoK7e+Eie7B3VmnGu/z7ziBPX5ssI+WfWwibFrNwVVFrBuQQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.13.0.tgz",
+			"integrity": "sha512-mLQci+lPwLIbjxCPoJrixiaYNX831FnsF3rcPfSD1MrDAMY4UuS8YaluFAo3zyYVq+sgWEXB3Bgu9E/WCyMAjw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
 		},
 		"@esri/arcgis-rest-types": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.12.1.tgz",
-			"integrity": "sha512-W4juRiFAP+MOJCwdQE2X6B5f51FaeR1de9LC9S0cDxuN0n5E166vKvADB1lpBnN296QnIcisMCU3lk0Rx2CFKQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.13.0.tgz",
+			"integrity": "sha512-yZ82iG7+bbkP9UBmXiiDvV0v7n5CfjICTZlSwxJ55V1eKve65idOZdf+EsSKZIuAdv+wbEJ328CzGdE5cMnl+g==",
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.8.0.tgz",
-			"integrity": "sha512-XQ4oL+Dcd8IMkB8Pv1wRtsvFEZdUD2wSxfBsQ1wOkv8fzsBJyGyEd87JTgJtX8p0dUVYN4QS91GzkFFn4YF02g==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-3.9.2.tgz",
+			"integrity": "sha512-Ip/iEGLg2g5CYJ1f7Cn0wmByNVgouJbBe8ndjVYHtLLo5SIdr6JbAwJrXpDvCb8gZwtHoccdPSS71WPsNEvxfw==",
 			"requires": {
 				"adlib": "3.0.5",
 				"fetch-blob": "github:node-fetch/fetch-blob#master",
@@ -63,9 +63,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+			"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
 			"dev": true
 		},
 		"adlib": {

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -28,7 +28,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@esri/hub-common": "^3.7.5",
+    "@esri/hub-common": "^3.9.2",
     "@esri/solution-common": "^0.9.2",
     "@esri/solution-feature-layer": "^0.9.2",
     "@esri/solution-file": "^0.9.2",

--- a/packages/deployer/src/deployerUtils.ts
+++ b/packages/deployer/src/deployerUtils.ts
@@ -32,11 +32,11 @@ export function _getSolutionTemplateItem(
       common.getItemBase(idOrObject, authentication),
       common.getItemDataAsJson(idOrObject, authentication)
     ]).then(([item, data]) => {
-      // format into a model
-      return {
+      // format into a model and migrate the schema
+      return common.migrateSchema({
         item,
         data
-      };
+      });
     });
   } else {
     // check if it is a "Model"

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -110,7 +110,7 @@ export default {
     extend: true // causes this module to extend the global specified by `moduleName`
   },
   context: "window",
-  external: packageNames.concat(arcgisRestJsPackageNames),
+  external: packageNames.concat(arcgisRestJsPackageNames, hubJsPackageNames),
   plugins: [
     typescript(),
     json(),

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -47,6 +47,7 @@ const copyright = `/* @preserve
  */
 const moduleName = "arcgisSolution";
 const arcgisRestModuleName = 'arcgisRest'
+const hubModuleName = 'arcgisHub'
 
 /**
  * Now we need to discover all the `@esri/solution-*` package names so we can create
@@ -66,6 +67,9 @@ const packageNames = fs
 const arcgisRestJsPackageNames = Object.keys(pkg.dependencies)
   .filter(key => /@esri\/arcgis-rest/.test(key));
 
+const hubJsPackageNames = Object.keys(pkg.dependencies)
+  .filter(key => /@esri\/hub-/.test(key));
+
 /**
  * Rollup will use this map to determine where to lookup modules on the global
  * window object when neither AMD or CommonJS is being used. This configuration
@@ -83,6 +87,11 @@ const globals = packageNames.reduce((globals, p) => {
 */
 arcgisRestJsPackageNames.reduce((globals, p) => {
   globals[p] = arcgisRestModuleName;
+  return globals;
+}, globals);
+
+hubJsPackageNames.reduce((globals, p) => {
+  globals[p] = hubModuleName;
   return globals;
 }, globals);
 


### PR DESCRIPTION
### Take two...
in which we have resolved the upstream issues in hub.js so that:
a) Blobs are only handled in browsers, and this eliminates the `stream` import
b) the node typescript `util` library is not used, thus eliminating the `util` import
c) we have resolved some of the import paths, resolving the circular dependency 

Locally, this also changes the UMD build to treat the `@esri/hub-*` packages as external imports, so UMD packages using solution-js will also need to bring in the `hub-common` umd package. I'm not sure how that works in terms of changed to other apps, but in order to support sites and pages, we will be bringing in more of the `@esri/hub-*` packages. 

This builds clean, and passes all tests w. 100% coverage for me on 12.16.1, and 10.16.1


### Original PR Description
--- 
This is just setting up the schema versioning system.

Adds `item.properties.schemaVersion` and runs migrations if needed.

Currently it just stamps schemaVersion as 3 unless the app encounters a solution w/ Hub specific typeKeywords - which it should not b/c the hub specific items lack the `Template` keyword.

It is one connected into the main workflows in `deployer` - but ideally we'd have a fn `getSolutionItem(...): Promise<ISolutionItem>`, put the migration in there and have everything use that fn.
