### PR TITLE
Adjusted repo for ts 3.9.2

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,7 +42,7 @@ module.exports = function(config) {
       compilerOptions: {
         module: "commonjs"
       },
-      tsconfig: "./tsconfig.json",
+      tsconfig: "./tsconfig.test.json",
       bundlerOptions: {
         transforms: [require("karma-typescript-es6-transform")()],
         exclude: ["@esri/arcgis-rest-common-types"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,14 +219,14 @@
       }
     },
     "@lerna/add": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.20.0.tgz",
-      "integrity": "sha512-AnH1oRIEEg/VDa3SjYq4x1/UglEAvrZuV0WssHUMN81RTZgQk3we+Mv3qZNddrZ/fBcZu2IAdN/EQ3+ie2JxKQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.21.0.tgz",
+      "integrity": "sha512-vhUXXF6SpufBE1EkNEXwz1VLW03f177G9uMOFMQkp6OJ30/PWg4Ekifuz9/3YfgB2/GH8Tu4Lk3O51P2Hskg/A==",
       "dev": true,
       "requires": {
         "@evocateur/pacote": "^9.6.3",
-        "@lerna/bootstrap": "3.20.0",
-        "@lerna/command": "3.18.5",
+        "@lerna/bootstrap": "3.21.0",
+        "@lerna/command": "3.21.0",
         "@lerna/filter-options": "3.20.0",
         "@lerna/npm-conf": "3.16.0",
         "@lerna/validation-error": "3.13.0",
@@ -251,12 +251,12 @@
       }
     },
     "@lerna/bootstrap": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.20.0.tgz",
-      "integrity": "sha512-Wylullx3uthKE7r4izo09qeRGL20Y5yONlQEjPCfnbxCC2Elu+QcPu4RC6kqKQ7b+g7pdC3OOgcHZjngrwr5XQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.21.0.tgz",
+      "integrity": "sha512-mtNHlXpmvJn6JTu0KcuTTPl2jLsDNud0QacV/h++qsaKbhAaJr/FElNZ5s7MwZFUM3XaDmvWzHKaszeBMHIbBw==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/filter-options": "3.20.0",
         "@lerna/has-npm-version": "3.16.5",
         "@lerna/npm-install": "3.16.5",
@@ -296,13 +296,13 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.20.0.tgz",
-      "integrity": "sha512-+hzMFSldbRPulZ0vbKk6RD9f36gaH3Osjx34wrrZ62VB4pKmjyuS/rxVYkCA3viPLHoiIw2F8zHM5BdYoDSbjw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.21.0.tgz",
+      "integrity": "sha512-hzqoyf8MSHVjZp0gfJ7G8jaz+++mgXYiNs9iViQGA8JlN/dnWLI5sWDptEH3/B30Izo+fdVz0S0s7ydVE3pWIw==",
       "dev": true,
       "requires": {
         "@lerna/collect-updates": "3.20.0",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/listable": "3.18.5",
         "@lerna/output": "3.13.0"
       }
@@ -369,12 +369,12 @@
       }
     },
     "@lerna/clean": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.20.0.tgz",
-      "integrity": "sha512-9ZdYrrjQvR5wNXmHfDsfjWjp0foOkCwKe3hrckTzkAeQA1ibyz5llGwz5e1AeFrV12e2/OLajVqYfe+qdkZUgg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.21.0.tgz",
+      "integrity": "sha512-b/L9l+MDgE/7oGbrav6rG8RTQvRiZLO1zTcG17zgJAAuhlsPxJExMlh2DFwJEVi2les70vMhHfST3Ue1IMMjpg==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/filter-options": "3.20.0",
         "@lerna/prompt": "3.18.5",
         "@lerna/pulse-till-done": "3.13.0",
@@ -587,14 +587,14 @@
       }
     },
     "@lerna/command": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.18.5.tgz",
-      "integrity": "sha512-36EnqR59yaTU4HrR1C9XDFti2jRx0BgpIUBeWn129LZZB8kAB3ov1/dJNa1KcNRKp91DncoKHLY99FZ6zTNpMQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.21.0.tgz",
+      "integrity": "sha512-T2bu6R8R3KkH5YoCKdutKv123iUgUbW8efVjdGCDnCMthAQzoentOJfDeodBwn0P2OqCl3ohsiNVtSn9h78fyQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.16.5",
         "@lerna/package-graph": "3.18.5",
-        "@lerna/project": "3.18.0",
+        "@lerna/project": "3.21.0",
         "@lerna/validation-error": "3.13.0",
         "@lerna/write-log-file": "3.13.0",
         "clone-deep": "^4.0.1",
@@ -721,14 +721,14 @@
       }
     },
     "@lerna/create": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.18.5.tgz",
-      "integrity": "sha512-cHpjocbpKmLopCuZFI7cKEM3E/QY8y+yC7VtZ4FQRSaLU8D8i2xXtXmYaP1GOlVNavji0iwoXjuNpnRMInIr2g==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.21.0.tgz",
+      "integrity": "sha512-cRIopzKzE2vXJPmsiwCDMWo4Ct+KTmX3nvvkQLDoQNrrRK7w+3KQT3iiorbj1koD95RsVQA7mS2haWok9SIv0g==",
       "dev": true,
       "requires": {
         "@evocateur/pacote": "^9.6.3",
         "@lerna/child-process": "3.16.5",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/npm-conf": "3.16.0",
         "@lerna/validation-error": "3.13.0",
         "camelcase": "^5.0.0",
@@ -863,25 +863,25 @@
       }
     },
     "@lerna/diff": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.18.5.tgz",
-      "integrity": "sha512-u90lGs+B8DRA9Z/2xX4YaS3h9X6GbypmGV6ITzx9+1Ga12UWGTVlKaCXBgONMBjzJDzAQOK8qPTwLA57SeBLgA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.21.0.tgz",
+      "integrity": "sha512-5viTR33QV3S7O+bjruo1SaR40m7F2aUHJaDAC7fL9Ca6xji+aw1KFkpCtVlISS0G8vikUREGMJh+c/VMSc8Usw==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.16.5",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/validation-error": "3.13.0",
         "npmlog": "^4.1.2"
       }
     },
     "@lerna/exec": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.20.0.tgz",
-      "integrity": "sha512-pS1mmC7kzV668rHLWuv31ClngqeXjeHC8kJuM+W2D6IpUVMGQHLcCTYLudFgQsuKGVpl0DGNYG+sjLhAPiiu6A==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.21.0.tgz",
+      "integrity": "sha512-iLvDBrIE6rpdd4GIKTY9mkXyhwsJ2RvQdB9ZU+/NhR3okXfqKc6py/24tV111jqpXTtZUW6HNydT4dMao2hi1Q==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.16.5",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/filter-options": "3.20.0",
         "@lerna/profiler": "3.20.0",
         "@lerna/run-topologically": "3.18.5",
@@ -987,12 +987,6 @@
         "whatwg-url": "^7.0.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
         "whatwg-url": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
@@ -1031,13 +1025,13 @@
       }
     },
     "@lerna/import": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.18.5.tgz",
-      "integrity": "sha512-PH0WVLEgp+ORyNKbGGwUcrueW89K3Iuk/DDCz8mFyG2IG09l/jOF0vzckEyGyz6PO5CMcz4TI1al/qnp3FrahQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.21.0.tgz",
+      "integrity": "sha512-aISkL4XD0Dqf5asDaOZWu65jgj8fWUhuQseZWuQe3UfHxav69fTS2YLIngUfencaOSZVOcVCom28YCzp61YDxw==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.16.5",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/prompt": "3.18.5",
         "@lerna/pulse-till-done": "3.13.0",
         "@lerna/validation-error": "3.13.0",
@@ -1069,24 +1063,24 @@
       }
     },
     "@lerna/info": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/info/-/info-3.20.0.tgz",
-      "integrity": "sha512-Rsz+KQF9mczbGUbPTrtOed1N0C+cA08Qz0eX/oI+NNjvsryZIju/o7uedG4I3P55MBiAioNrJI88fHH3eTgYug==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/info/-/info-3.21.0.tgz",
+      "integrity": "sha512-0XDqGYVBgWxUquFaIptW2bYSIu6jOs1BtkvRTWDDhw4zyEdp6q4eaMvqdSap1CG+7wM5jeLCi6z94wS0AuiuwA==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/output": "3.13.0",
         "envinfo": "^7.3.1"
       }
     },
     "@lerna/init": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.18.5.tgz",
-      "integrity": "sha512-oCwipWrha98EcJAHm8AGd2YFFLNI7AW9AWi0/LbClj1+XY9ah+uifXIgYGfTk63LbgophDd8936ZEpHMxBsbAg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.21.0.tgz",
+      "integrity": "sha512-6CM0z+EFUkFfurwdJCR+LQQF6MqHbYDCBPyhu/d086LRf58GtYZYj49J8mKG9ktayp/TOIxL/pKKjgLD8QBPOg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.16.5",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "fs-extra": "^8.1.0",
         "p-map": "^2.1.0",
         "write-json-file": "^3.2.0"
@@ -1121,12 +1115,12 @@
       }
     },
     "@lerna/link": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.18.5.tgz",
-      "integrity": "sha512-xTN3vktJpkT7Nqc3QkZRtHO4bT5NvuLMtKNIBDkks0HpGxC9PRyyqwOoCoh1yOGbrWIuDezhfMg3Qow+6I69IQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.21.0.tgz",
+      "integrity": "sha512-tGu9GxrX7Ivs+Wl3w1+jrLi1nQ36kNI32dcOssij6bg0oZ2M2MDEFI9UF2gmoypTaN9uO5TSsjCFS7aR79HbdQ==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/package-graph": "3.18.5",
         "@lerna/symlink-dependencies": "3.17.0",
         "p-map": "^2.1.0",
@@ -1148,12 +1142,12 @@
       }
     },
     "@lerna/list": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.20.0.tgz",
-      "integrity": "sha512-fXTicPrfioVnRzknyPawmYIVkzDRBaQqk9spejS1S3O1DOidkihK0xxNkr8HCVC0L22w6f92g83qWDp2BYRUbg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.21.0.tgz",
+      "integrity": "sha512-KehRjE83B1VaAbRRkRy6jLX1Cin8ltsrQ7FHf2bhwhRHK0S54YuA6LOoBnY/NtA8bHDX/Z+G5sMY78X30NS9tg==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/filter-options": "3.20.0",
         "@lerna/listable": "3.18.5",
         "@lerna/output": "3.13.0"
@@ -1468,9 +1462,9 @@
       }
     },
     "@lerna/project": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.18.0.tgz",
-      "integrity": "sha512-+LDwvdAp0BurOAWmeHE3uuticsq9hNxBI0+FMHiIai8jrygpJGahaQrBYWpwbshbQyVLeQgx3+YJdW2TbEdFWA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.21.0.tgz",
+      "integrity": "sha512-xT1mrpET2BF11CY32uypV2GPtPVm6Hgtha7D81GQP9iAitk9EccrdNjYGt5UBYASl4CIDXBRxwmTTVGfrCx82A==",
       "dev": true,
       "requires": {
         "@lerna/package": "3.16.0",
@@ -1593,9 +1587,9 @@
       }
     },
     "@lerna/publish": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.20.2.tgz",
-      "integrity": "sha512-N7Y6PdhJ+tYQPdI1tZum8W25cDlTp4D6brvRacKZusweWexxaopbV8RprBaKexkEX/KIbncuADq7qjDBdQHzaA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.21.0.tgz",
+      "integrity": "sha512-JZ+ehZB9UCQ9nqH8Ld/Yqc/If++aK/7XIubkrB9sQ5hf2GeIbmI/BrJpMgLW/e9T5bKrUBZPUvoUN3daVipA5A==",
       "dev": true,
       "requires": {
         "@evocateur/libnpmaccess": "^3.1.2",
@@ -1604,7 +1598,7 @@
         "@lerna/check-working-tree": "3.16.5",
         "@lerna/child-process": "3.16.5",
         "@lerna/collect-updates": "3.20.0",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/describe-ref": "3.16.5",
         "@lerna/log-packed": "3.16.0",
         "@lerna/npm-conf": "3.16.0",
@@ -1619,7 +1613,7 @@
         "@lerna/run-lifecycle": "3.16.2",
         "@lerna/run-topologically": "3.18.5",
         "@lerna/validation-error": "3.13.0",
-        "@lerna/version": "3.20.2",
+        "@lerna/version": "3.21.0",
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^8.1.0",
         "npm-package-arg": "^6.1.0",
@@ -1737,12 +1731,12 @@
       }
     },
     "@lerna/run": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.20.0.tgz",
-      "integrity": "sha512-9U3AqeaCeB7KsGS9oyKNp62s9vYoULg/B4cqXTKZkc+OKL6QOEjYHYVSBcMK9lUXrMjCjDIuDSX3PnTCPxQ2Dw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.21.0.tgz",
+      "integrity": "sha512-fJF68rT3veh+hkToFsBmUJ9MHc9yGXA7LSDvhziAojzOb0AI/jBDp6cEcDQyJ7dbnplba2Lj02IH61QUf9oW0Q==",
       "dev": true,
       "requires": {
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/filter-options": "3.20.0",
         "@lerna/npm-run-script": "3.16.5",
         "@lerna/output": "3.13.0",
@@ -1883,15 +1877,15 @@
       }
     },
     "@lerna/version": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.20.2.tgz",
-      "integrity": "sha512-ckBJMaBWc+xJen0cMyCE7W67QXLLrc0ELvigPIn8p609qkfNM0L0CF803MKxjVOldJAjw84b8ucNWZLvJagP/Q==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.21.0.tgz",
+      "integrity": "sha512-nIT3u43fCNj6uSMN1dRxFnF4GhmIiOEqSTkGSjrMU+8kHKwzOqS/6X6TOzklBmCyEZOpF/fLlGqH3BZHnwLDzQ==",
       "dev": true,
       "requires": {
         "@lerna/check-working-tree": "3.16.5",
         "@lerna/child-process": "3.16.5",
         "@lerna/collect-updates": "3.20.0",
-        "@lerna/command": "3.18.5",
+        "@lerna/command": "3.21.0",
         "@lerna/conventional-commits": "3.18.5",
         "@lerna/github-client": "3.16.5",
         "@lerna/gitlab-client": "3.15.0",
@@ -2158,12 +2152,6 @@
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
           "dev": true
         },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
         "universal-user-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
@@ -2211,9 +2199,9 @@
       }
     },
     "@octokit/types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.0.tgz",
-      "integrity": "sha512-hA06ZYqkAVxvwFVu7yqRNVBGfG9MZvLMbqfgfm6F79g5xWspxsbL/2/rHcFP/z1YBN3zbcNQYuUHiBml4b24MA==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+      "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -2234,17 +2222,26 @@
         "resolve": "^1.11.0"
       }
     },
-    "@rollup/plugin-node-resolve": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
-      "integrity": "sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==",
+    "@rollup/plugin-json": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.0.3.tgz",
+      "integrity": "sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.0",
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
+      "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
         "@types/resolve": "0.0.8",
         "builtin-modules": "^3.1.0",
         "is-module": "^1.0.0",
-        "resolve": "^1.11.1"
+        "resolve": "^1.14.2"
       }
     },
     "@rollup/pluginutils": {
@@ -3360,7 +3357,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -5065,9 +5063,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001055",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001055.tgz",
-      "integrity": "sha512-MbwsBmKrBSKIWldfdIagO5OJWZclpJtS4h0Jrk/4HFrXJxTdVdH23Fd+xCiHriVGvYcWyW8mR/CPsYajlH8Iuw==",
+      "version": "1.0.30001058",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001058.tgz",
+      "integrity": "sha512-UiRZmBYd1HdVVdFKy7PuLVx9e2NS7SMyx7QpWvFjiklYrLJKpLd19cRnRNqlw4zYa7vVejS3c8JUVobX241zHQ==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -5286,6 +5284,12 @@
           "requires": {
             "safe-buffer": "^5.0.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -5492,6 +5496,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -7100,7 +7105,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -7413,9 +7419,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.434",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.434.tgz",
-      "integrity": "sha512-WjzGrE6appXvMyc2kH9Ide7OxsgTuRzag9sjQ5AcbOnbS9ut7P1HzOeEbJFLhr81IR7n2Hlr6qTTSGTXLIX5Pg==",
+      "version": "1.3.437",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.437.tgz",
+      "integrity": "sha512-PBQn2q68ErqMyBUABh9Gh8R6DunGky8aB5y3N5lPM7OVpldwyUbAK5AX9WcwE/5F6ceqvQ+iQLYkJYRysAs6Bg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7463,6 +7469,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -7532,12 +7539,12 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
-      "integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.2.tgz",
+      "integrity": "sha512-AWjc1Xg06a6UPFOBAzJf48W1UR/qKYmv/ubgSCumo9GXgvL/xGIvo05dXoBL+2NTLMipDI7in8xK61C17L25xg==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
+        "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
         "debug": "~4.1.0",
         "engine.io-parser": "~2.2.0",
@@ -7548,6 +7555,14 @@
         "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "dev": true
+        }
       }
     },
     "engine.io-parser": {
@@ -7757,7 +7772,8 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -8526,12 +8542,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.5",
         "mime-types": "^2.1.12"
       }
     },
@@ -9118,6 +9135,12 @@
             "safe-buffer": "^5.0.1"
           }
         },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
         "yargs": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
@@ -9262,6 +9285,12 @@
           "requires": {
             "safe-buffer": "^5.0.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -10487,6 +10516,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -11455,7 +11485,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -11559,17 +11590,44 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isomorphic-form-data": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
       "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
+      "dev": true,
       "requires": {
         "form-data": "^2.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "isstream": {
@@ -12280,27 +12338,27 @@
       "dev": true
     },
     "lerna": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.20.2.tgz",
-      "integrity": "sha512-bjdL7hPLpU3Y8CBnw/1ys3ynQMUjiK6l9iDWnEGwFtDy48Xh5JboR9ZJwmKGCz9A/sarVVIGwf1tlRNKUG9etA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.21.0.tgz",
+      "integrity": "sha512-ux8yOwQEgIXOZVUfq+T8nVzPymL19vlIoPbysOP3YA4hcjKlqQIlsjI/1ugBe6b4MF7W4iV5vS3gH9cGqBBc1A==",
       "dev": true,
       "requires": {
-        "@lerna/add": "3.20.0",
-        "@lerna/bootstrap": "3.20.0",
-        "@lerna/changed": "3.20.0",
-        "@lerna/clean": "3.20.0",
+        "@lerna/add": "3.21.0",
+        "@lerna/bootstrap": "3.21.0",
+        "@lerna/changed": "3.21.0",
+        "@lerna/clean": "3.21.0",
         "@lerna/cli": "3.18.5",
-        "@lerna/create": "3.18.5",
-        "@lerna/diff": "3.18.5",
-        "@lerna/exec": "3.20.0",
-        "@lerna/import": "3.18.5",
-        "@lerna/info": "3.20.0",
-        "@lerna/init": "3.18.5",
-        "@lerna/link": "3.18.5",
-        "@lerna/list": "3.20.0",
-        "@lerna/publish": "3.20.2",
-        "@lerna/run": "3.20.0",
-        "@lerna/version": "3.20.2",
+        "@lerna/create": "3.21.0",
+        "@lerna/diff": "3.21.0",
+        "@lerna/exec": "3.21.0",
+        "@lerna/import": "3.21.0",
+        "@lerna/info": "3.21.0",
+        "@lerna/init": "3.21.0",
+        "@lerna/link": "3.21.0",
+        "@lerna/list": "3.21.0",
+        "@lerna/publish": "3.21.0",
+        "@lerna/run": "3.21.0",
+        "@lerna/version": "3.21.0",
         "import-local": "^2.0.0",
         "npmlog": "^4.1.2"
       }
@@ -13248,12 +13306,14 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -13569,13 +13629,10 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-fetch-npm": {
       "version": "2.0.4",
@@ -13731,6 +13788,12 @@
           "requires": {
             "safe-buffer": "^5.0.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -14059,6 +14122,12 @@
           "requires": {
             "safe-buffer": "^5.0.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -19739,21 +19808,16 @@
         "uuid": "^3.0.0"
       },
       "dependencies": {
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
         "qs": {
           "version": "6.3.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
           "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }
@@ -20393,7 +20457,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sass-graph": {
       "version": "2.2.5",
@@ -21737,9 +21802,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -22296,10 +22361,10 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }
@@ -22346,6 +22411,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }
@@ -22679,9 +22750,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tslint": {
@@ -22903,9 +22974,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "ua-parser-js": {
@@ -22921,9 +22992,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.2.tgz",
-      "integrity": "sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -23219,9 +23290,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "dev": true
     },
     "v8flags": {
@@ -23301,7 +23372,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.9.2",
   "description": "A library running in Node.js and modern browsers for transferring ArcGIS Online items from one organization to another.",
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.0",
-    "@rollup/plugin-node-resolve": "^6.0.0",
+    "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-json": "^4.0.3",
+    "@rollup/plugin-node-resolve": "^7.1.3",
     "@semantic-release/commit-analyzer": "^6.3.1",
     "@types/fetch-mock": "^7.3.2",
     "@types/jasmine": "^3.5.10",
     "@types/node": "^10.17.0",
+    "@types/sinon": "^9.0.0",
     "acetate": "^2.0.8",
     "acetate-cli": "^1.0.1",
     "changelog-parser": "^2.7.0",
@@ -22,6 +24,7 @@
     "cross-spawn": "^5.1.0",
     "cz-lerna-changelog": "^2.0.2",
     "date-fns": "^1.29.0",
+    "es6-promise": "^4.2.8",
     "event-stream": "3.3.4",
     "fetch-mock": "^7.7.3",
     "gh-pages": "^1.1.0",
@@ -29,6 +32,8 @@
     "handlebars": "^4.5.1",
     "husky": "^0.14.3",
     "inspect-process": "^0.5.0",
+    "isomorphic-fetch": "^2.2.1",
+    "isomorphic-form-data": "^2.0.0",
     "jasmine": "^3.5.0",
     "jasmine-core": "^3.5.0",
     "karma": "^4.4.1",
@@ -60,6 +65,7 @@
     "rollup-plugin-uglify": "^3.0.0",
     "semantic-release": "^15.13.28",
     "shelljs": "^0.7.8",
+    "sinon": "^9.0.2",
     "slug": "^0.9.1",
     "sri-toolbox": "0.2.0",
     "ts-node": "^8.3.0",
@@ -69,15 +75,9 @@
     "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.15.0",
     "typescript": "^3.8.3",
-    "uuid": "^3.3.3",
-    "@types/sinon": "^9.0.0",
-    "sinon": "^9.0.2"
+    "uuid": "^8.0.0"
   },
-  "dependencies": {
-    "es6-promise": "^4.2.1",
-    "isomorphic-fetch": "^2.2.1",
-    "isomorphic-form-data": "^2.0.0"
-  },
+  "dependencies": {},
   "lint-staged": {
     "*.ts": [
       "prettier --write --parser typescript --tab-width 2 --use-tabs false",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -99,9 +99,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -159,14 +159,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		},
 		"xss": {

--- a/packages/common/src/dependencies.ts
+++ b/packages/common/src/dependencies.ts
@@ -20,8 +20,8 @@
  * @module dependencies
  */
 
-import * as interfaces from "./interfaces";
-import * as templatization from "./templatization";
+import { IItemTemplate } from "./interfaces";
+import { findTemplateIndexInList } from "./templatization";
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
@@ -35,7 +35,7 @@ import * as templatization from "./templatization";
  * @protected
  */
 export function topologicallySortItems(
-  templates: interfaces.IItemTemplate[]
+  templates: IItemTemplate[]
 ): string[] {
   // Cormen, Thomas H.; Leiserson, Charles E.; Rivest, Ronald L.; Stein, Clifford (2009)
   // Sections 22.3 (Depth-first search) & 22.4 (Topological sort), pp. 603-615
@@ -90,7 +90,7 @@ export function topologicallySortItems(
     // Visit dependents if not already visited; template has to be in templates list because calls to visit()
     // are based on verticiesToVisit[], which is initialized using the templates list
     const template =
-      templates[templatization.findTemplateIndexInList(templates, vertexId)];
+      templates[findTemplateIndexInList(templates, vertexId)];
     const dependencies: string[] = template.dependencies || [];
     dependencies.forEach(function(dependencyId) {
       if (verticesToVisit[dependencyId] === SortVisitColor.White) {

--- a/packages/common/src/featureServiceHelpers.ts
+++ b/packages/common/src/featureServiceHelpers.ts
@@ -313,7 +313,7 @@ export function updateSettingsFieldInfos(
         settingsKeys.forEach((_k: any) => {
           /* istanbul ignore else */
           if (d === _k) {
-            settings[k]["sourceServiceFields"] = generalHelpers.getProp(
+            settings[k]["sourceServiceFields"] = getProp(
               settings[_k],
               "fieldInfos"
             );
@@ -570,7 +570,7 @@ export function updateFeatureServiceDefinition(
     // if the service has veiws keep track of the fields so we can use them to
     // compare with the view fields
     /* istanbul ignore else */
-    if (generalHelpers.getProp(itemTemplate, "properties.service.hasViews")) {
+    if (getProp(itemTemplate, "properties.service.hasViews")) {
       _updateTemplateDictionaryFields(itemTemplate, templateDictionary);
     }
 
@@ -633,7 +633,7 @@ export function updateFeatureServiceDefinition(
  * @protected
  */
 export function _updateTemplateDictionaryFields(
-  itemTemplate: interfaces.IItemTemplate,
+  itemTemplate: IItemTemplate,
   templateDictionary: any
 ): void {
   const layers: any[] = itemTemplate.properties.layers;
@@ -756,7 +756,7 @@ export function postProcessFields(
             item.sourceSchemaChangesAllowed;
           // when the item is a view bring over the source service fields so we can compare the domains
           if (item.isView && templateInfo) {
-            layerInfos[item.id]["sourceServiceFields"] = generalHelpers.getProp(
+            layerInfos[item.id]["sourceServiceFields"] = getProp(
               templateInfo,
               `sourceServiceFields.${item.id}`
             );

--- a/packages/common/src/generalHelpers.ts
+++ b/packages/common/src/generalHelpers.ts
@@ -20,9 +20,9 @@
  * @module generalHelpers
  */
 
-import * as interfaces from "./interfaces";
-import * as libs from "./libs";
-import * as polyfills from "./polyfills";
+import { IDatasourceInfo, IItemTemplate } from "./interfaces";
+import { Sanitizer, sanitizeJSON } from "./libs";
+import { new_File } from "./polyfills";
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
@@ -71,7 +71,7 @@ export function blobToFile(
   filename: string,
   mimeType?: string
 ): File {
-  return polyfills.new_File([blob], filename ? filename : "", {
+  return new_File([blob], filename ? filename : "", {
     type: mimeType || blob.type
   });
 }
@@ -269,9 +269,9 @@ export function compareJSONProperties(json1: any, json2: any): string[] {
  */
 export function sanitizeJSONAndReportChanges(
   json: any,
-  sanitizer?: libs.Sanitizer
+  sanitizer?: Sanitizer
 ): any {
-  const sanitizedJSON = libs.sanitizeJSON(json, sanitizer);
+  const sanitizedJSON = sanitizeJSON(json, sanitizer);
 
   const mismatches = compareJSONProperties(json, sanitizedJSON);
   if (mismatches.length > 0) {
@@ -554,7 +554,7 @@ export function getUniqueTitle(
  * @return Boolean indicating result
  */
 export function hasDatasource(
-  datasourceInfos: interfaces.IDatasourceInfo[],
+  datasourceInfos: IDatasourceInfo[],
   itemId: string,
   layerId: number
 ): boolean {
@@ -612,7 +612,7 @@ export function cleanLayerId(id: any) {
  * @return Template associated with the user provided id argument
  */
 export function getTemplateById(
-  templates: interfaces.IItemTemplate[],
+  templates: IItemTemplate[],
   id: string
 ): any {
   let template;

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -18,8 +18,8 @@
  * Provides common interfaces.
  */
 
-import * as portal from "@esri/arcgis-rest-portal";
-import * as serviceAdmin from "@esri/arcgis-rest-service-admin";
+import { IGroup, IGetRelatedItemsResponse as IPortalGetRelatedItemsResponse, IItem } from "@esri/arcgis-rest-portal";
+import { ISpatialReference } from "@esri/arcgis-rest-service-admin";
 import { UserSession } from "@esri/arcgis-rest-auth";
 
 //#region Re-exports -------------------------------------------------------------------------------------------------//
@@ -109,7 +109,7 @@ export type INoArgFunction = () => any;
 
 export interface IAddGroupResponse {
   success: boolean;
-  group: portal.IGroup;
+  group: IGroup;
 }
 
 export interface IAdditionalSearchOptions {
@@ -291,12 +291,12 @@ export interface IFolderStatusResponse {
 }
 
 export interface IGetRelatedItemsResponse
-  extends portal.IGetRelatedItemsResponse {
+  extends IPortalGetRelatedItemsResponse {
   total: number;
   start: number;
   num: number;
   nextStart: number;
-  relatedItems: portal.IItem[];
+  relatedItems: IItem[];
 }
 
 export interface IGetResourcesResponse {
@@ -329,7 +329,7 @@ export interface IItemGeneralized {
   id: string;
   properties?: any;
   snippet?: string;
-  spatialReference?: serviceAdmin.ISpatialReference;
+  spatialReference?: ISpatialReference;
   tags?: string[];
   title?: string;
   type: string;

--- a/packages/common/src/templatization.ts
+++ b/packages/common/src/templatization.ts
@@ -20,8 +20,8 @@
  * @module templatization
  */
 
-import * as adlib from "adlib";
-import * as interfaces from "./interfaces";
+import { adlib } from "adlib";
+import { IItemTemplate } from "./interfaces";
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
@@ -95,7 +95,7 @@ export function createShortId(): string {
 
 export function createInitializedGroupTemplate(
   itemInfo: any
-): interfaces.IItemTemplate {
+): IItemTemplate {
   const itemTemplate = createPlaceholderTemplate(itemInfo.id, itemInfo.type);
   itemTemplate.item = {
     ...itemTemplate.item,
@@ -110,7 +110,7 @@ export function createInitializedGroupTemplate(
 
 export function createInitializedItemTemplate(
   itemInfo: any
-): interfaces.IItemTemplate {
+): IItemTemplate {
   const itemTemplate = createPlaceholderTemplate(itemInfo.id, itemInfo.type);
   itemTemplate.item = {
     ...itemTemplate.item,
@@ -144,7 +144,7 @@ export function createInitializedItemTemplate(
 export function createPlaceholderTemplate(
   id: string,
   type = ""
-): interfaces.IItemTemplate {
+): IItemTemplate {
   return {
     itemId: id,
     type,
@@ -171,7 +171,7 @@ export function createPlaceholderTemplate(
  * @protected
  */
 export function findTemplateIndexInList(
-  templates: interfaces.IItemTemplate[],
+  templates: IItemTemplate[],
   id: string
 ): number {
   const baseId = id;
@@ -188,9 +188,9 @@ export function findTemplateIndexInList(
  * @return Matching template or null
  */
 export function findTemplateInList(
-  templates: interfaces.IItemTemplate[],
+  templates: IItemTemplate[],
   id: string
-): interfaces.IItemTemplate | null {
+): IItemTemplate | null {
   const iTemplate = findTemplateIndexInList(templates, id);
   return iTemplate >= 0 ? templates[iTemplate] : null;
 }
@@ -203,7 +203,7 @@ export function hasUnresolvedVariables(data: any): boolean {
 }
 
 export function getIdsInTemplatesList(
-  templates: interfaces.IItemTemplate[]
+  templates: IItemTemplate[]
 ): string[] {
   return templates.map(template => template.itemId);
 }
@@ -216,7 +216,7 @@ export function getIdsInTemplatesList(
  * @protected
  */
 export function removeTemplate(
-  templates: interfaces.IItemTemplate[],
+  templates: IItemTemplate[],
   id: string
 ): void {
   const i = findTemplateIndexInList(templates, id);
@@ -226,7 +226,7 @@ export function removeTemplate(
 }
 
 export function replaceInTemplate(template: any, replacements: any): any {
-  return adlib.adlib(template, replacements, TRANSFORMS);
+  return adlib(template, replacements, TRANSFORMS);
 }
 
 /**
@@ -239,9 +239,9 @@ export function replaceInTemplate(template: any, replacements: any): any {
  * @protected
  */
 export function replaceTemplate(
-  templates: interfaces.IItemTemplate[],
+  templates: IItemTemplate[],
   id: string,
-  template: interfaces.IItemTemplate
+  template: IItemTemplate
 ): boolean {
   const i = findTemplateIndexInList(templates, id);
   if (i >= 0) {

--- a/packages/creator/package-lock.json
+++ b/packages/creator/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -57,9 +57,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -102,14 +102,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/feature-layer/package-lock.json
+++ b/packages/feature-layer/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/file/package-lock.json
+++ b/packages/file/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/group/package-lock.json
+++ b/packages/group/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/simple-types/package-lock.json
+++ b/packages/simple-types/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/simple-types/src/simple-types.ts
+++ b/packages/simple-types/src/simple-types.ts
@@ -93,7 +93,7 @@ export function convertItemToTemplate(
       responses => {
         const [itemDataResponse, relatedItemsResponse] = responses;
         itemTemplate.data = itemDataResponse;
-        const relationships = relatedItemsResponse as common.IRelatedItems[];
+        const relationships = relatedItemsResponse;
 
         // Save the mappings to related items & add those items to the dependencies, but not WMA Code Attachments
         itemTemplate.dependencies = [] as string[];

--- a/packages/storymap/package-lock.json
+++ b/packages/storymap/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/packages/viewer/package-lock.json
+++ b/packages/viewer/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
 			"dev": true
 		},
 		"acorn": {
@@ -34,14 +34,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		}
 	}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,71 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "es2015",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es6', or 'ESNext'. */
+    "lib": ["dom", "es2015"],                             /* Specify library files to be included in the compilation:  */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "forceConsistentCasingInFileNames": true,   /* To reduce issues when working with different OSes */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                            /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": false,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "typeRoots": [
+      "./node_modules/@types"
+    ],                                        /* List of folders to include type definitions from. */
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "jasmine"
+    ],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    //"esModuleInterop": true,
+    "suppressImplicitAnyIndexErrors": true
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "exclude": [
+    "node_modules",
+    "packages/**/examples"
+  ],
+  "include": [
+    "./node_modules/@types",
+    "packages",
+    "support"
+  ]
+}


### PR DESCRIPTION
#329 

* Fall back from es6 to es2015 just for tests to continue to use spyOn
* Switched to single imports for common to prepare for es6 with spyOn and sinon.stub; recommendation to make it easier to insert stubs
* Adjusted package and rebuilt package-locks
