### PR TITLE
Support creating/deploying Survey123 published surveys

### DIFF
--- a/packages/common/src/featureServiceHelpers.ts
+++ b/packages/common/src/featureServiceHelpers.ts
@@ -29,10 +29,32 @@ export {
 
 //#region Imports -------------------------------------------------------------------------------------------------------//
 
-import { IDependency, IItemTemplate, INumberValuePair, IPostProcessArgs, IStringValuePair, IUpdate, UserSession } from "./interfaces";
-import { checkUrlPathTermination, deleteProp, fail, getProp } from "./generalHelpers";
-import { replaceInTemplate, templatizeTerm } from "./templatization";
-import { addToServiceDefinition, getLayerUpdates, getRequest, rest_request } from "./restHelpers";
+import {
+  IDependency,
+  IItemTemplate,
+  INumberValuePair,
+  IPostProcessArgs,
+  IStringValuePair,
+  IUpdate,
+  UserSession
+} from "./interfaces";
+import {
+  checkUrlPathTermination,
+  deleteProp,
+  fail,
+  getProp
+} from "./generalHelpers";
+import {
+  replaceInTemplate,
+  templatizeTerm,
+  templatizeIds
+} from "./templatization";
+import {
+  addToServiceDefinition,
+  getLayerUpdates,
+  getRequest,
+  rest_request
+} from "./restHelpers";
 
 //#endregion ------------------------------------------------------------------------------------------------------------//
 
@@ -54,8 +76,12 @@ export function templatize(
   // Common templatizations
   const id: string = itemTemplate.item.id;
 
-  itemTemplate.item.url = _templatize(id, "url");
-  itemTemplate.item.id = templatizeTerm(id, id, ".itemId");
+  itemTemplate.item = {
+    ...itemTemplate.item,
+    id: templatizeTerm(id, id, ".itemId"),
+    url: _templatize(id, "url"),
+    typeKeywords: templatizeIds(itemTemplate.item.typeKeywords)
+  };
 
   const jsonLayers: any[] = itemTemplate.properties.layers || [];
   const jsonTables: any[] = itemTemplate.properties.tables || [];
@@ -82,9 +108,7 @@ export function templatize(
     );
   }
   /* istanbul ignore else */
-  if (
-    getProp(itemTemplate, "properties.service.initialExtent")
-  ) {
+  if (getProp(itemTemplate, "properties.service.initialExtent")) {
     itemTemplate.properties.service.initialExtent = templatizeTerm(
       id,
       id,
@@ -403,10 +427,7 @@ export function deTemplatizeFieldInfos(
   fieldInfoKeys.forEach(id => {
     if (fieldInfos[id].hasOwnProperty("templates")) {
       fieldInfos[id].templates = JSON.parse(
-        replaceInTemplate(
-          JSON.stringify(fieldInfos[id].templates),
-          settings
-        )
+        replaceInTemplate(JSON.stringify(fieldInfos[id].templates), settings)
       );
     }
 
@@ -418,10 +439,7 @@ export function deTemplatizeFieldInfos(
 
     if (fieldInfos[id].hasOwnProperty("types")) {
       fieldInfos[id].types = JSON.parse(
-        replaceInTemplate(
-          JSON.stringify(fieldInfos[id].types),
-          settings
-        )
+        replaceInTemplate(JSON.stringify(fieldInfos[id].types), settings)
       );
     }
   });
@@ -442,18 +460,16 @@ export function deTemplatizeFieldInfos(
  * @param itemTemplate The current itemTemplate being processed.
  * @return array of layers and tables
  */
-export function getLayersAndTables(
-  itemTemplate: IItemTemplate
-): any[] {
+export function getLayersAndTables(itemTemplate: IItemTemplate): any[] {
   const properties: any = itemTemplate.properties;
   const layersAndTables: any[] = [];
-  (properties.layers || []).forEach(function (layer: any) {
+  (properties.layers || []).forEach(function(layer: any) {
     layersAndTables.push({
       item: layer,
       type: "layer"
     });
   });
-  (properties.tables || []).forEach(function (table: any) {
+  (properties.tables || []).forEach(function(table: any) {
     layersAndTables.push({
       item: table,
       type: "table"
@@ -721,9 +737,7 @@ export function postProcessFields(
   return new Promise((resolveFn, rejectFn) => {
     if (!itemTemplate.item.url) {
       rejectFn(
-        fail(
-          "Feature layer " + itemTemplate.itemId + " does not have a URL"
-        )
+        fail("Feature layer " + itemTemplate.itemId + " does not have a URL")
       );
     } else {
       const id = itemTemplate.itemId;
@@ -913,8 +927,7 @@ export function updatePopupInfo(
     /* istanbul ignore else */
     if (_items && Array.isArray(_items)) {
       _items.forEach((item: any) => {
-        item.popupInfo =
-          getProp(popupInfos, type + "." + item.id) || {};
+        item.popupInfo = getProp(popupInfos, type + "." + item.id) || {};
       });
     }
   });
@@ -1178,10 +1191,7 @@ export function _templatizeAdminLayerInfoFields(
   dependencies: IDependency[]
 ): void {
   // templatize the source layer fields
-  const table = getProp(
-    layer,
-    "adminLayerInfo.viewLayerDefinition.table"
-  );
+  const table = getProp(layer, "adminLayerInfo.viewLayerDefinition.table");
 
   if (table) {
     let id: string = _getDependantItemId(table.sourceServiceName, dependencies);
@@ -1426,10 +1436,7 @@ export function _templatizeFieldName(
       const relatedTable: any = relatedTables[relationshipId];
       // the layers relationships stores the property as relatedTableId
       // the layers adminLayerInfo relatedTables stores the property as sourceLayerId
-      const prop: string = getProp(
-        relatedTable,
-        "relatedTableId"
-      )
+      const prop: string = getProp(relatedTable, "relatedTableId")
         ? "relatedTableId"
         : "sourceLayerId";
       const _basePath: string =

--- a/packages/common/src/templatization.ts
+++ b/packages/common/src/templatization.ts
@@ -21,6 +21,7 @@
  */
 
 import { adlib } from "adlib";
+import { unique } from "@esri/hub-common";
 import { IItemTemplate } from "./interfaces";
 
 // ------------------------------------------------------------------------------------------------------------------ //
@@ -93,9 +94,7 @@ export function createShortId(): string {
   );
 }
 
-export function createInitializedGroupTemplate(
-  itemInfo: any
-): IItemTemplate {
+export function createInitializedGroupTemplate(itemInfo: any): IItemTemplate {
   const itemTemplate = createPlaceholderTemplate(itemInfo.id, itemInfo.type);
   itemTemplate.item = {
     ...itemTemplate.item,
@@ -108,9 +107,7 @@ export function createInitializedGroupTemplate(
   return itemTemplate;
 }
 
-export function createInitializedItemTemplate(
-  itemInfo: any
-): IItemTemplate {
+export function createInitializedItemTemplate(itemInfo: any): IItemTemplate {
   const itemTemplate = createPlaceholderTemplate(itemInfo.id, itemInfo.type);
   itemTemplate.item = {
     ...itemTemplate.item,
@@ -202,9 +199,7 @@ export function hasUnresolvedVariables(data: any): boolean {
   return getUnresolved(data).length > 0;
 }
 
-export function getIdsInTemplatesList(
-  templates: IItemTemplate[]
-): string[] {
+export function getIdsInTemplatesList(templates: IItemTemplate[]): string[] {
   return templates.map(template => template.itemId);
 }
 
@@ -215,10 +210,7 @@ export function getIdsInTemplatesList(
  * @param id Id of item in templates list to find; if not found, no replacement is done
  * @protected
  */
-export function removeTemplate(
-  templates: IItemTemplate[],
-  id: string
-): void {
+export function removeTemplate(templates: IItemTemplate[], id: string): void {
   const i = findTemplateIndexInList(templates, id);
   if (i >= 0) {
     templates.splice(i, 1);
@@ -319,11 +311,12 @@ export function templatizeIds(obj: any): any {
   const idTest: RegExp = /[0-9A-F]{32}/gim;
   if (obj && idTest.test(objString)) {
     // Templatize ids
-    const ids: string[] = objString.match(idTest) as string[];
-    ids.forEach(id => {
-      const regEx = new RegExp(id, "gm");
-      objString = objString.replace(regEx, "{{" + id + ".itemId}}");
-    });
+    const ids: string[] = objString.match(idTest).filter(unique);
+    const toTokenizedString = (memo: string, id: string) => {
+      const pat = new RegExp(id, "gm");
+      return memo.replace(pat, `{{${id + ".itemId"}}}`);
+    };
+    objString = ids.reduce(toTokenizedString, objString);
     obj = JSON.parse(objString);
   }
   return obj;

--- a/packages/common/src/templatization.ts
+++ b/packages/common/src/templatization.ts
@@ -312,11 +312,10 @@ export function templatizeIds(obj: any): any {
   if (obj && idTest.test(objString)) {
     // Templatize ids
     const ids: string[] = objString.match(idTest).filter(unique);
-    const toTokenizedString = (memo: string, id: string) => {
-      const pat = new RegExp(id, "gm");
-      return memo.replace(pat, `{{${id + ".itemId"}}}`);
-    };
-    objString = ids.reduce(toTokenizedString, objString);
+    ids.forEach(id => {
+      const regEx = new RegExp(id, "gm");
+      objString = objString.replace(regEx, "{{" + id + ".itemId}}");
+    });
     obj = JSON.parse(objString);
   }
   return obj;

--- a/packages/common/test/featureServiceHelpers.test.ts
+++ b/packages/common/test/featureServiceHelpers.test.ts
@@ -130,7 +130,8 @@ beforeEach(() => {
     type: "",
     item: {
       id: "",
-      type: ""
+      type: "",
+      typeKeywords: []
     },
     data: {},
     resources: [],
@@ -174,7 +175,8 @@ describe("Module `featureServiceHelpers`: utility functions for feature-service 
         item: {
           id: "{{ABC123.itemId}}",
           type: "",
-          url: "{{ABC123.url}}"
+          url: "{{ABC123.url}}",
+          typeKeywords: []
         },
         data: {},
         resources: [],
@@ -242,7 +244,8 @@ describe("Module `featureServiceHelpers`: utility functions for feature-service 
         item: {
           extent: "",
           id: "ab766cba0dd44ec080420acc10990282",
-          type: ""
+          type: "",
+          typeKeywords: ["ab766cba0dd44ec080420acc10990282", "typeKeyword2"]
         },
         data: {
           layers: [
@@ -324,7 +327,11 @@ describe("Module `featureServiceHelpers`: utility functions for feature-service 
           extent: "", // only set through createItemTemplate
           id: "{{ab766cba0dd44ec080420acc10990282.itemId}}",
           type: "",
-          url: "{{ab766cba0dd44ec080420acc10990282.url}}"
+          url: "{{ab766cba0dd44ec080420acc10990282.url}}",
+          typeKeywords: [
+            "{{ab766cba0dd44ec080420acc10990282.itemId}}",
+            "typeKeyword2"
+          ]
         },
         data: {
           layers: [
@@ -374,7 +381,8 @@ describe("Module `featureServiceHelpers`: utility functions for feature-service 
         item: {
           extent: "",
           id: "ab766cba0dd44ec080420acc10990282",
-          type: ""
+          type: "",
+          typeKeywords: ["ab766cba0dd44ec080420acc10990282", "two"]
         },
         data: {},
         resources: [],
@@ -397,7 +405,8 @@ describe("Module `featureServiceHelpers`: utility functions for feature-service 
           extent: "", // only set through createItemTemplate
           id: "{{ab766cba0dd44ec080420acc10990282.itemId}}",
           type: "",
-          url: "{{ab766cba0dd44ec080420acc10990282.url}}"
+          url: "{{ab766cba0dd44ec080420acc10990282.url}}",
+          typeKeywords: ["{{ab766cba0dd44ec080420acc10990282.itemId}}", "two"]
         },
         data: {},
         resources: [],

--- a/packages/common/test/templatization.test.ts
+++ b/packages/common/test/templatization.test.ts
@@ -473,6 +473,32 @@ describe("Module `templatization`: common functions involving the adlib library"
 
       expect(templatizedObj).toEqual(expectedTemplatizedObj);
     });
+
+    it("gracefully handles multiple occurrences of the same id", () => {
+      // i.e. prevents things like: {{{{bef773a670c0419f89194a4012320db3.itemId}}.itemId}}
+      const obj = [
+        {
+          relationshipType: "Survey2Service",
+          relatedItemIds: ["bef773a670c0419f89194a4012320db3"],
+          properties: {
+            anotherReference: "bef773a670c0419f89194a4012320db3"
+          }
+        }
+      ];
+      const expectedTemplatizedObj = [
+        {
+          relationshipType: "Survey2Service",
+          relatedItemIds: ["{{bef773a670c0419f89194a4012320db3.itemId}}"],
+          properties: {
+            anotherReference: "{{bef773a670c0419f89194a4012320db3.itemId}}"
+          }
+        }
+      ];
+
+      const templatizedObj: any = templatization.templatizeIds(obj);
+
+      expect(templatizedObj).toEqual(expectedTemplatizedObj);
+    });
   });
 });
 

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -1218,7 +1218,7 @@ describe("Module `deploySolutionItems`", () => {
 
   describe("postProcessDependencies", () => {
     if (typeof window !== "undefined") {
-      it("should update unresolved variables in an items data", done => {
+      it("should update unresolved variables in an item and it's data", done => {
         const _templates: any[] = [
           {
             type: "Group",
@@ -1236,6 +1236,18 @@ describe("Module `deploySolutionItems`", () => {
           unresolved: {
             itemId: "resolved"
           }
+        };
+
+        const workforceItem = {
+          id: "NEW123ABC",
+          owner: "jdoe",
+          tags: ["tag1"],
+          created: 1590063887071,
+          modified: 1590063887071,
+          numViews: 1,
+          size: 50,
+          protected: false,
+          other: "{{unresolved.itemId}}"
         };
 
         const workforceData: any = {
@@ -1263,6 +1275,10 @@ describe("Module `deploySolutionItems`", () => {
 
         fetchMock
           .post(
+            utils.PORTAL_SUBSET.restUrl + "/content/items/NEW123ABC",
+            workforceItem
+          )
+          .post(
             utils.PORTAL_SUBSET.restUrl + "/content/items/NEW123ABC/data",
             workforceData
           )
@@ -1289,7 +1305,7 @@ describe("Module `deploySolutionItems`", () => {
           }, done.fail);
       });
 
-      it("should update unresolved variables in Notebook item data", done => {
+      it("should update unresolved variables in Notebook item and it's data", done => {
         const _templates: any[] = [
           {
             type: "Notebook",
@@ -1303,11 +1319,25 @@ describe("Module `deploySolutionItems`", () => {
           }
         };
 
+        const notebookItem = {
+          id: "NEW123ABC",
+          owner: "jdoe",
+          tags: ["tag1"],
+          created: 1590063887071,
+          modified: 1590063887071,
+          numViews: 1,
+          size: 50,
+          protected: false,
+          other: "{{unresolved.itemId}}"
+        };
+
         const notebookData: any = {
           unresolvedVariable: "{{unresolved.itemId}}"
         };
 
-        const expected: any = { unresolvedVariable: "resolved" };
+        const expectedData: any = { unresolvedVariable: "resolved" };
+
+        const expectedItem = { ...notebookItem, other: "resolved" };
 
         const clonedSolutionsResponse: common.ICreateItemFromTemplateResponse[] = [
           {
@@ -1318,6 +1348,10 @@ describe("Module `deploySolutionItems`", () => {
         ];
 
         fetchMock
+          .post(
+            utils.PORTAL_SUBSET.restUrl + "/content/items/NEW123ABC",
+            notebookItem
+          )
           .post(
             utils.PORTAL_SUBSET.restUrl + "/content/items/NEW123ABC/data",
             notebookData
@@ -1339,8 +1373,8 @@ describe("Module `deploySolutionItems`", () => {
           )
           .then(() => {
             expect(notebook.postProcessItemDependencies).toHaveBeenCalledWith(
-              clonedSolutionsResponse[0].id,
-              expected,
+              expectedItem,
+              expectedData,
               MOCK_USER_SESSION
             );
             done();

--- a/packages/feature-layer/src/feature-layer.ts
+++ b/packages/feature-layer/src/feature-layer.ts
@@ -248,9 +248,10 @@ export function createItemFromTemplate(
                               resolve({
                                 id: createResponse.serviceItemId,
                                 type: newItemTemplate.type,
-                                postProcess: common.hasUnresolvedVariables(
-                                  newItemTemplate.data
-                                )
+                                postProcess: common.hasUnresolvedVariables({
+                                  data: newItemTemplate.data,
+                                  item: newItemTemplate.item
+                                })
                               });
                             }
                           },

--- a/packages/feature-layer/test/feature-layer.test.ts
+++ b/packages/feature-layer/test/feature-layer.test.ts
@@ -529,6 +529,234 @@ describe("Module `feature-layer`: manages the creation and deployment of feature
         });
     });
 
+    it("should set postProcess to true when the item has unprocessed interpolation tokens", done => {
+      const expectedId: string = "svc1234567890";
+      const id: string = "{{" + expectedId + ".itemId}}";
+
+      const expectedUrl: string =
+        "https://services123.arcgis.com/org1234567890/arcgis/rest/services/ROWPermits_publiccomment/FeatureServer";
+      const url: string = "{{" + expectedId + ".url}}";
+
+      const adminUrl: string =
+        "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer";
+
+      const layerKeyField: string =
+        "{{" + expectedId + ".layer0.fields.globalid.name}}";
+      const tableKeyField: string =
+        "{{" + expectedId + ".layer1.fields.globalid.name}}";
+      const layerDefQuery: string =
+        "status = '{{" + expectedId + ".layer0.fields.boardreview.name}}'";
+      const tableDefQuery: string =
+        "status = '{{" + expectedId + ".layer1.fields.boardreview.name}}'";
+
+      itemTemplate.properties.layers[0].relationships[0].keyField = layerKeyField;
+      itemTemplate.properties.layers[0].definitionQuery = layerDefQuery;
+      itemTemplate.properties.layers[0].viewDefinitionQuery = layerDefQuery;
+
+      itemTemplate.properties.tables[0].relationships[0].keyField = tableKeyField;
+      itemTemplate.properties.tables[0].definitionQuery = tableDefQuery;
+      itemTemplate.properties.tables[0].viewDefinitionQuery = tableDefQuery;
+
+      itemTemplate.item.other = "{{unprocessed.itemId}}";
+
+      // verify the state up front
+      expect(itemTemplate.item.id).toEqual(id);
+      expect(itemTemplate.item.url).toEqual(expectedUrl);
+      expect(itemTemplate.dependencies.length).toEqual(0);
+      expect(itemTemplate.properties.service.serviceItemId).toEqual(id);
+
+      expect(itemTemplate.properties.layers[0].serviceItemId).toEqual(id);
+      expect(
+        itemTemplate.properties.layers[0].relationships[0].keyField
+      ).toEqual(layerKeyField);
+      expect(itemTemplate.properties.layers[0].viewDefinitionQuery).toEqual(
+        layerDefQuery
+      );
+      expect(itemTemplate.properties.layers[0].definitionQuery).toEqual(
+        layerDefQuery
+      );
+
+      expect(itemTemplate.properties.tables[0].serviceItemId).toEqual(id);
+      expect(
+        itemTemplate.properties.tables[0].relationships[0].keyField
+      ).toEqual(tableKeyField);
+      expect(itemTemplate.properties.tables[0].viewDefinitionQuery).toEqual(
+        tableDefQuery
+      );
+      expect(itemTemplate.properties.tables[0].definitionQuery).toEqual(
+        tableDefQuery
+      );
+
+      const createResponse: any = mockItems.getAGOLService([], [], true);
+      createResponse.success = true;
+
+      fetchMock
+        .post(url + "?f=json", itemTemplate.properties.service)
+        .post(adminUrl + "/0?f=json", itemTemplate.properties.layers[0])
+        .post(adminUrl + "/1?f=json", itemTemplate.properties.tables[0])
+        .post(url + "/sources?f=json", mockItems.getAGOLServiceSources())
+        .post(
+          utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createService",
+          createResponse
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/addToDefinition",
+          '{"success":true}'
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/refresh",
+          '{"success":true}'
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/0/updateDefinition",
+          '{"success":true}'
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/1/updateDefinition",
+          '{"success":true}'
+        )
+        .post(
+          utils.PORTAL_SUBSET.restUrl +
+            "/content/users/casey/items/svc1234567890/update",
+          '{"success":true}'
+        );
+
+      // tslint:disable-next-line: no-floating-promises
+      featureLayer
+        .createItemFromTemplate(
+          itemTemplate,
+          {
+            svc1234567890: {},
+            organization: _organization,
+            solutionItemExtent: _solutionItemExtent
+          },
+          MOCK_USER_SESSION,
+          utils.ITEM_PROGRESS_CALLBACK
+        )
+        .then(r => {
+          expect(r).toEqual({
+            id: "svc1234567890",
+            type: itemTemplate.type,
+            postProcess: true
+          });
+          done();
+        });
+    });
+
+    it("should set postProcess to true when the item data has unprocessed interpolation tokens", done => {
+      const expectedId: string = "svc1234567890";
+      const id: string = "{{" + expectedId + ".itemId}}";
+
+      const expectedUrl: string =
+        "https://services123.arcgis.com/org1234567890/arcgis/rest/services/ROWPermits_publiccomment/FeatureServer";
+      const url: string = "{{" + expectedId + ".url}}";
+
+      const adminUrl: string =
+        "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer";
+
+      const layerKeyField: string =
+        "{{" + expectedId + ".layer0.fields.globalid.name}}";
+      const tableKeyField: string =
+        "{{" + expectedId + ".layer1.fields.globalid.name}}";
+      const layerDefQuery: string =
+        "status = '{{" + expectedId + ".layer0.fields.boardreview.name}}'";
+      const tableDefQuery: string =
+        "status = '{{" + expectedId + ".layer1.fields.boardreview.name}}'";
+
+      itemTemplate.properties.layers[0].relationships[0].keyField = layerKeyField;
+      itemTemplate.properties.layers[0].definitionQuery = layerDefQuery;
+      itemTemplate.properties.layers[0].viewDefinitionQuery = layerDefQuery;
+
+      itemTemplate.properties.tables[0].relationships[0].keyField = tableKeyField;
+      itemTemplate.properties.tables[0].definitionQuery = tableDefQuery;
+      itemTemplate.properties.tables[0].viewDefinitionQuery = tableDefQuery;
+
+      itemTemplate.data.other = "{{unprocessed.itemId}}";
+
+      // verify the state up front
+      expect(itemTemplate.item.id).toEqual(id);
+      expect(itemTemplate.item.url).toEqual(expectedUrl);
+      expect(itemTemplate.dependencies.length).toEqual(0);
+      expect(itemTemplate.properties.service.serviceItemId).toEqual(id);
+
+      expect(itemTemplate.properties.layers[0].serviceItemId).toEqual(id);
+      expect(
+        itemTemplate.properties.layers[0].relationships[0].keyField
+      ).toEqual(layerKeyField);
+      expect(itemTemplate.properties.layers[0].viewDefinitionQuery).toEqual(
+        layerDefQuery
+      );
+      expect(itemTemplate.properties.layers[0].definitionQuery).toEqual(
+        layerDefQuery
+      );
+
+      expect(itemTemplate.properties.tables[0].serviceItemId).toEqual(id);
+      expect(
+        itemTemplate.properties.tables[0].relationships[0].keyField
+      ).toEqual(tableKeyField);
+      expect(itemTemplate.properties.tables[0].viewDefinitionQuery).toEqual(
+        tableDefQuery
+      );
+      expect(itemTemplate.properties.tables[0].definitionQuery).toEqual(
+        tableDefQuery
+      );
+
+      const createResponse: any = mockItems.getAGOLService([], [], true);
+      createResponse.success = true;
+
+      fetchMock
+        .post(url + "?f=json", itemTemplate.properties.service)
+        .post(adminUrl + "/0?f=json", itemTemplate.properties.layers[0])
+        .post(adminUrl + "/1?f=json", itemTemplate.properties.tables[0])
+        .post(url + "/sources?f=json", mockItems.getAGOLServiceSources())
+        .post(
+          utils.PORTAL_SUBSET.restUrl + "/content/users/casey/createService",
+          createResponse
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/addToDefinition",
+          '{"success":true}'
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/refresh",
+          '{"success":true}'
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/0/updateDefinition",
+          '{"success":true}'
+        )
+        .post(
+          "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/1/updateDefinition",
+          '{"success":true}'
+        )
+        .post(
+          utils.PORTAL_SUBSET.restUrl +
+            "/content/users/casey/items/svc1234567890/update",
+          '{"success":true}'
+        );
+
+      // tslint:disable-next-line: no-floating-promises
+      featureLayer
+        .createItemFromTemplate(
+          itemTemplate,
+          {
+            svc1234567890: {},
+            organization: _organization,
+            solutionItemExtent: _solutionItemExtent
+          },
+          MOCK_USER_SESSION,
+          utils.ITEM_PROGRESS_CALLBACK
+        )
+        .then(r => {
+          expect(r).toEqual({
+            id: "svc1234567890",
+            type: itemTemplate.type,
+            postProcess: true
+          });
+          done();
+        });
+    });
+
     it("should create a solution from a template in portal", done => {
       const expectedId: string = "svc1234567890";
       const id: string = "{{" + expectedId + ".itemId}}";

--- a/packages/simple-types/src/notebook.ts
+++ b/packages/simple-types/src/notebook.ts
@@ -104,21 +104,21 @@ export function fineTuneCreatedItem(
  * @return A promise that will resolve once any updates have been made
  */
 export function postProcessItemDependencies(
-  itemId: string,
+  item: common.IItemUpdate,
   data: any,
   authentication: common.UserSession
 ): Promise<any> {
-  return _updateItemData(itemId, data, authentication);
+  return _updateItemData(item, data, authentication);
 }
 
 export function _updateItemData(
-  itemId: string,
+  item: common.IItemUpdate,
   data: any,
   authentication: common.UserSession
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     const updateOptions: common.IItemUpdate = {
-      id: itemId,
+      ...item,
       data: common.jsonToBlob(data)
     };
     common.updateItem(updateOptions, authentication).then(

--- a/packages/simple-types/src/simple-types.ts
+++ b/packages/simple-types/src/simple-types.ts
@@ -271,9 +271,10 @@ export function createItemFromTemplate(
                   createResponse.id
                 );
               }
-              const postProcess: boolean = common.hasUnresolvedVariables(
-                newItemTemplate.data
-              );
+              const postProcess: boolean = common.hasUnresolvedVariables({
+                data: newItemTemplate.data,
+                item: newItemTemplate.item
+              });
 
               // Update the template again now that we have the new item id
               const originalURL = newItemTemplate.item.url;
@@ -472,7 +473,7 @@ export function postProcessFieldReferences(
  * @return A promise that will resolve once any updates have been made
  */
 export function postProcessItemDependencies(
-  itemId: string,
+  item: common.IItemUpdate,
   type: string,
   data: any,
   authentication: common.UserSession
@@ -480,7 +481,7 @@ export function postProcessItemDependencies(
   let p: Promise<any> = Promise.resolve();
   switch (type) {
     case "Notebook":
-      p = notebook.postProcessItemDependencies(itemId, data, authentication);
+      p = notebook.postProcessItemDependencies(item, data, authentication);
       break;
   }
   return p;

--- a/packages/simple-types/test/notebook.test.ts
+++ b/packages/simple-types/test/notebook.test.ts
@@ -34,9 +34,10 @@ beforeEach(() => {
 describe("Module `notebook`: manages the creation and deployment of notebook project item types", () => {
   describe("_updateItemData", () => {
     it("handles update error", done => {
+      const item = { id: "itm1234567890" };
       const data = {};
 
-      notebook._updateItemData("itm1234567890", data, MOCK_USER_SESSION).then(
+      notebook._updateItemData(item, data, MOCK_USER_SESSION).then(
         () => done.fail(),
         () => done()
       );

--- a/packages/simple-types/test/simple-types.test.ts
+++ b/packages/simple-types/test/simple-types.test.ts
@@ -401,6 +401,7 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
       it("should handle item resource", done => {
         const solutionItemId = "sln1234567890";
         const itemTemplate: common.IItemTemplate = templates.getItemTemplateSkeleton();
+
         itemTemplate.item = mockItems.getAGOLItem("Web Map", null);
         itemTemplate.item.item = itemTemplate.itemId = itemTemplate.item.id;
         itemTemplate.item.thumbnail = "thumbnail/banner.png";
@@ -1454,9 +1455,14 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
       itemTemplate.data = mockItems.getAGOLItemData("Workforce Project");
 
       const newItemID: string = "abc1cab401af4828a25cc6eaeb59fb69";
-      const expected: any = {};
+      const wrk1234567890 = { itemId: "wrk1234567890" };
+      const solutionItemExtent = [
+        [0, 0],
+        [1, 1]
+      ];
+      const expected: any = { wrk1234567890, solutionItemExtent };
       expected[itemTemplate.itemId] = { itemId: newItemID };
-      const templateDictionary: any = {};
+      const templateDictionary: any = { wrk1234567890, solutionItemExtent };
 
       const userUrl: string =
         utils.PORTAL_SUBSET.restUrl +
@@ -1809,17 +1815,22 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
         { total: 0, relatedItems: [] }
       );
 
+      const templateDictionary = {
+        portalBaseUrl: utils.PORTAL_SUBSET.portalUrl,
+        folderId: "folderb401af4828a25cc6eaeb59fb69",
+        myMapId: {
+          itemId: "map0cab401af4828a25cc6eaeb59fb69"
+        },
+        abc0cab401af4828a25cc6eaeb59fb69: {
+          itemId: "abc0cab401af4828a25cc6eaeb59fb69"
+        }
+      };
+
       // tslint:disable-next-line: no-floating-promises
       simpleTypes
         .createItemFromTemplate(
           itemTemplate,
-          {
-            portalBaseUrl: utils.PORTAL_SUBSET.portalUrl,
-            folderId: "folderb401af4828a25cc6eaeb59fb69",
-            myMapId: {
-              itemId: "map0cab401af4828a25cc6eaeb59fb69"
-            }
-          },
+          templateDictionary,
           MOCK_USER_SESSION,
           utils.ITEM_PROGRESS_CALLBACK
         )
@@ -2093,6 +2104,9 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
             folderId: "folderb401af4828a25cc6eaeb59fb69",
             myMapId: {
               itemId: "map0cab401af4828a25cc6eaeb59fb69"
+            },
+            abc0cab401af4828a25cc6eaeb59fb69: {
+              itemId: "bbc0cab401af4828a25cc6eaeb59fb69"
             }
           },
           MOCK_USER_SESSION,
@@ -2167,7 +2181,10 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
         .createItemFromTemplate(
           itemTemplate,
           {
-            portalBaseUrl: utils.PORTAL_SUBSET.portalUrl
+            portalBaseUrl: utils.PORTAL_SUBSET.portalUrl,
+            abc0cab401af4828a25cc6eaeb59fb69: {
+              itemId: "bbc0cab401af4828a25cc6eaeb59fb69"
+            }
           },
           MOCK_USER_SESSION,
           utils.ITEM_PROGRESS_CALLBACK


### PR DESCRIPTION
Survey123 `Feature Service` items have a `typeKeyword` that references the related `Form` item ID. However, the `Feature Service` items are dependencies of the `Form` item, so we need to post process the `Feature Service` items after the `Form` item is created. Additionally, only item data is currently post-processed, this PR introduces the ability to post-process item properties as well.