### PR TITLE
Add solution-form package with stubbed out convertItemToTemplate and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The API is divided into packages to make it easier to use just the parts that yo
 * `deployer`, which contains functions for deploying item templates into items in a destination organization
 * `feature-layer`, which contains functions for Feature Service items
 * `file`, which contains functions for items that contain files
+* `form`, which contains functions for form items
 * `group`, which contains functions for Groups
 * `simple-types`, which contains functions for the simpler item types Dashboard, Form, Web Map, Web Mapping Application, and Workforce Project
 * `storymap`, which contains functions for Storymap items

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,0 +1,53 @@
+[![npm status][npm-img]][npm-url]
+[![Build status][travis-img]][travis-url]
+[![gzip bundle size][gzip-img]][npm-url]
+[![Coverage status][coverage-img]][coverage-url]
+[![Apache 2.0 licensed][license-img]][license-url]
+
+[npm-img]: https://img.shields.io/npm/v/@esri/solution-form.svg?style=round-square&color=blue
+[npm-url]: https://www.npmjs.com/package/@esri/solution-form
+[travis-img]: https://img.shields.io/travis/Esri/solution.js/develop.svg
+[travis-url]: https://travis-ci.org/Esri/solution.js
+[gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-form/dist/umd/form.umd.min.js?compression=gzip
+[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
+[coverage-url]: https://coveralls.io/github/Esri/solution.js
+[license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
+[license-url]: #license
+
+# @esri/solution-form
+
+> Manages the creation and deployment of form item types for [`@esri/solution-*`](https://github.com/Esri/solution.js).
+
+### [API Reference](https://esri.github.io/solution.js/api/form/)
+
+### Issues
+
+Found a bug or want to request a new feature? Please take a look at [previously logged issues](https://github.com/Esri/solution.js/issues); if you don't see your concern, please let us know by [submitting an issue](https://github.com/Esri/solution.js/issues/new).
+
+### [Changelog](https://github.com/Esri/solution.js/blob/develop/CHANGELOG.md)
+
+##### Versioning
+
+For transparency into the release cycle and in striving to maintain backward compatibility, @esri/solution.js is maintained under Semantic Versioning guidelines and will adhere to these rules whenever possible. For more information on SemVer, please visit <http://semver.org/>.
+
+### Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](CONTRIBUTING.md).
+
+### License
+
+Copyright &copy; 2018-2020 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+> http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "@esri/solution-form",
+  "version": "0.13.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@esri/solution-common": {
+      "version": "0.14.0",
+      "requires": {
+        "@esri/arcgis-html-sanitizer": "^2.2.0",
+        "@types/lodash.isplainobject": "^4.0.6",
+        "adlib": "^3.0.4",
+        "lodash.isplainobject": "^4.0.6",
+        "tslib": "^1.10.0",
+        "xss": "^1.0.6"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
+      "integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
+      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    }
+  }
+}

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -4,17 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@esri/solution-common": {
-      "version": "0.14.0",
-      "requires": {
-        "@esri/arcgis-html-sanitizer": "^2.2.0",
-        "@types/lodash.isplainobject": "^4.0.6",
-        "adlib": "^3.0.4",
-        "lodash.isplainobject": "^4.0.6",
-        "tslib": "^1.10.0",
-        "xss": "^1.0.6"
-      }
-    },
     "@types/estree": {
       "version": "0.0.44",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/solution-form",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -21,7 +21,7 @@
     "@esri/solution-common": "^0.12.0"
   },
   "dependencies": {
-    "@esri/solution-common": "^0.13.0",
+    "@esri/solution-common": "^0.14.0",
     "tslib": "^1.10.0"
   },
   "scripts": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/solution-form",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Manages the creation and deployment of form item types for @esri/solution.js.",
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/file.umd.min.js",
@@ -15,10 +15,10 @@
   "devDependencies": {
     "rollup": "^1.22.0",
     "typescript": "^3.9.2",
-    "@esri/solution-common": "^0.12.0"
+    "@esri/solution-common": "^0.14.0"
   },
   "peerDependencies": {
-    "@esri/solution-common": "^0.12.0"
+    "@esri/solution-common": "^0.14.0"
   },
   "dependencies": {
     "@esri/solution-common": "^0.14.0",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@esri/solution-form",
+  "version": "0.13.0",
+  "description": "Manages the creation and deployment of form item types for @esri/solution.js.",
+  "main": "dist/node/index.js",
+  "unpkg": "dist/umd/file.umd.min.js",
+  "module": "dist/esm/index.js",
+  "js:next": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "author": "Esri",
+  "license": "Apache-2.0",
+  "files": [
+    "dist/**"
+  ],
+  "devDependencies": {
+    "rollup": "^1.22.0",
+    "typescript": "^3.9.2",
+    "@esri/solution-common": "^0.12.0"
+  },
+  "peerDependencies": {
+    "@esri/solution-common": "^0.12.0"
+  },
+  "dependencies": {
+    "@esri/solution-common": "^0.13.0",
+    "tslib": "^1.10.0"
+  },
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "npm run build:node && npm run build:umd && npm run build:esm",
+    "build:esm": "tsc -p ./tsconfig.json --module esnext --outDir ./dist/esm --declaration",
+    "build:umd": "rollup -c ../../umd-base-profile.js && rollup -c ../../umd-production-profile.js",
+    "build:node": "tsc -p ./tsconfig.json --module commonjs --outDir ./dist/node",
+    "dev:esm": "tsc -w --module esnext --outDir ./dist/esm --declaration",
+    "dev:umd": "rollup -w -c ../../umd-base-profile.js",
+    "dev:node": "tsc -w --module commonjs --outDir ./dist/node"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Esri/solution.js.git"
+  },
+  "contributors": [
+    {
+      "name": "Mike Tschudi",
+      "email": "mtschudi@esri.com"
+    },
+    {
+      "name": "Chris Fox",
+      "email": "cfox@esri.com"
+    },
+    {
+      "name": "John Hauck",
+      "email": "jhauck@esri.com"
+    },
+    {
+      "name": "Dave Bouwman",
+      "email": "dbouwman@esri.com"
+    },
+    {
+      "name": "John Gravois"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/Esri/solution.js/issues"
+  },
+  "homepage": "https://github.com/Esri/solution.js#readme",
+  "keywords": [
+    "typescript",
+    "promise",
+    "fetch",
+    "arcgis",
+    "esri",
+    "ES6"
+  ],
+  "gitHead": "3c6ec47455470fba467c431527e4e9a35a0ab277"
+}

--- a/packages/form/src/form.ts
+++ b/packages/form/src/form.ts
@@ -17,7 +17,7 @@
 /**
  * Manages the creation and deployment of form item types.
  *
- * @module file
+ * @module solution-form
  */
 
 import * as common from "@esri/solution-common";

--- a/packages/form/src/form.ts
+++ b/packages/form/src/form.ts
@@ -1,0 +1,49 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Manages the creation and deployment of form item types.
+ *
+ * @module file
+ */
+
+import * as common from "@esri/solution-common";
+
+export function convertItemToTemplate(
+  solutionItemId: string,
+  itemInfo: any,
+  authentication: common.UserSession,
+  isGroup?: boolean
+): Promise<common.IItemTemplate> {
+  return Promise.reject(
+    common.fail(
+      "convertItemToTemplate not yet implemented in solution-form package"
+    )
+  );
+}
+
+export function createItemFromTemplate(
+  template: common.IItemTemplate,
+  templateDictionary: any,
+  destinationAuthentication: common.UserSession,
+  itemProgressCallback: common.IItemProgressCallback
+): Promise<common.ICreateItemFromTemplateResponse> {
+  return Promise.reject(
+    common.fail(
+      "createItemFromTemplate not yet implemented in solution-form package"
+    )
+  );
+}

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,0 +1,23 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Manages the creation and deployment of item types that contain files.
+ *
+ * @module file
+ */
+
+export * from "./form";

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -17,7 +17,7 @@
 /**
  * Manages the creation and deployment of form item types.
  *
- * @module file
+ * @module solution-form
  */
 
 export * from "./form";

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Manages the creation and deployment of item types that contain files.
+ * Manages the creation and deployment of form item types.
  *
  * @module file
  */

--- a/packages/form/test/form.test.ts
+++ b/packages/form/test/form.test.ts
@@ -1,0 +1,92 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides tests for the creation and deployment of item types that contain files.
+ */
+
+import * as form from "../src/form";
+import * as utils from "../../common/test/mocks/utils";
+import * as mockItems from "../../common/test/mocks/agolItems";
+import * as templates from "../../common/test/mocks/templates";
+import * as common from "@esri/solution-common";
+import { spy } from "fetch-mock";
+
+let MOCK_USER_SESSION: common.UserSession;
+
+beforeEach(() => {
+  MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+});
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+describe("Module `form`: Manages the creation and deployment of form item types", () => {
+  describe("convertItemToTemplate", () => {
+    it("should reject with an error response", done => {
+      const failSpy = spyOn(common, "fail").and.callThrough();
+      form
+        .convertItemToTemplate(
+          "2c36d3679e7f4934ac599051df22daf6",
+          {},
+          MOCK_USER_SESSION,
+          false
+        )
+        .then(
+          _ => {
+            done.fail("convertItemToTemplate should have rejected");
+          },
+          e => {
+            const error =
+              "convertItemToTemplate not yet implemented in solution-form package";
+            const expected = { success: false, error };
+            expect(failSpy.calls.count()).toBe(1);
+            expect(failSpy.calls.first().args).toEqual([error]);
+            expect(e).toEqual(expected);
+            done();
+          }
+        );
+    });
+  });
+
+  describe("createItemFromTemplate", () => {
+    it("should reject with an error response", done => {
+      const failSpy = spyOn(common, "fail").and.callThrough();
+      const template = templates.getItemTemplate("Form");
+      const progressCallback = jasmine.createSpy();
+      form
+        .createItemFromTemplate(
+          template,
+          {},
+          MOCK_USER_SESSION,
+          progressCallback
+        )
+        .then(
+          _ => {
+            done.fail("createItemFromTemplate should have rejected");
+          },
+          e => {
+            const error =
+              "createItemFromTemplate not yet implemented in solution-form package";
+            const expected = { success: false, error };
+            expect(failSpy.calls.count()).toBe(1);
+            expect(failSpy.calls.first().args).toEqual([error]);
+            expect(e).toEqual(expected);
+            done();
+          }
+        );
+    });
+  });
+});

--- a/packages/form/tsconfig.json
+++ b/packages/form/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+      "src/**/*.ts"
+  ]
+}

--- a/support/publish.sh
+++ b/support/publish.sh
@@ -47,6 +47,8 @@ mkdir $TEMP_FOLDER/feature-layer
 cp -r packages/feature-layer/dist/umd/* $TEMP_FOLDER/feature-layer/
 mkdir $TEMP_FOLDER/file
 cp -r packages/file/dist/umd/* $TEMP_FOLDER/file/
+mkdir $TEMP_FOLDER/form
+cp -r packages/form/dist/umd/* $TEMP_FOLDER/form/
 mkdir $TEMP_FOLDER/group
 cp -r packages/group/dist/umd/* $TEMP_FOLDER/group/
 mkdir $TEMP_FOLDER/hub-types


### PR DESCRIPTION
…createItemFromTemplate methods

This is the first of a series of PRs I'll be submitting to introduce separate handling logic for Hub-flavor Survey templates. This PR adds a `solution-form` package which will provide a common entry point, delegate to appropriate handler (hub form vs solutions.js simple-types/form), and house the custom hub logic.