### PR TITLE
Custom Hub Survey processing logic

### DIFF
--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -638,46 +638,160 @@ export interface IUpdate {
   args: IPostProcessArgs;
 }
 
+/**
+ * Survey 123 create API parameters
+ */
 export interface ISurvey123CreateParams {
+  /**
+   * Title for the survey Form item & folder
+   */
   title: string;
+
+  /**
+   * Array of tags for the survey Form item
+   */
   tags: string[];
+
+  /**
+   * Array of typeKeywords for the survey Form item
+   */
   typeKeywords: string[];
+
+  /**
+   * Description for the survey Form item
+   */
   description: string;
+
+  /**
+   * The survey form configuration schema. This defines configurable
+   * content like the theme, questions, & header/footer text, etc.
+   */
   form: any;
+
+  /**
+   * The username from the current session
+   */
   username: string;
+
+  /**
+   * The token from the current session
+   */
   token: string;
+
+  /**
+   * The portalUrl for Survey123 to direct API requests to
+   */
   portalUrl: string;
+
+  /**
+   * Binary image data represented as a File
+   */
   thumbnailFile: File;
 }
 
+/**
+ * Successful Survey123 create API response
+ */
 export interface ISurvey123CreateSuccess {
+  /**
+   * Statically defined, always true for success
+   */
   success: true;
+
+  /**
+   * Resulting Form item ID
+   */
   id: string;
+
+  /**
+   * Subset of resulting Form item details
+   */
   formItemInfo: {
+    /**
+     * Resulting Form item typeKeywords
+     */
     typeKeywords: string[];
+
+    /**
+     * Resulting Form item ownerFolder
+     */
     ownerFolder: string;
+
+    /**
+     * Resulting Form item access
+     */
     access: string;
+
+    /**
+     * Resulting Form item owner
+     */
     owner: string;
   };
+  /**
+   * Subset of resulting Feature Service(s) details
+   */
   featureService: {
+    /**
+     * Subset of source Feature Service details
+     */
     source: {
+      /**
+       * Resulting Feature Service item ID
+       */
       itemId: string;
+
+      /**
+       * Generically definines remaining/unused properties
+       */
       [key: string]: any;
     };
+
+    /**
+     * Generically definines remaining/unused properties
+     */
     [key: string]: any;
   };
+
+  /**
+   * Generically definines remaining/unused properties
+   */
   [key: string]: any;
 }
 
+/**
+ * Unsuccessful Survey123 create API response
+ */
 export interface ISurvey123CreateError {
+  /**
+   * Statically defined, always false when unsuccessful
+   */
   success: false;
+
+  /**
+   * Error details
+   */
   error: {
+    /**
+     * HTTP error code
+     */
     code: number;
+
+    /**
+     * Optional, additional details about the error
+     */
     details: string[];
+
+    /**
+     * Message describing the error
+     */
     message: string;
   };
 }
 
+/**
+ * Result details for a successful Survey123 create
+ * API request
+ */
 export interface ISurvey123CreateResult {
   formId: string;
   featureServiceId: string;

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -638,4 +638,50 @@ export interface IUpdate {
   args: IPostProcessArgs;
 }
 
+export interface ISurvey123CreateParams {
+  title: string;
+  tags: string[];
+  typeKeywords: string[];
+  description: string;
+  form: any;
+  username: string;
+  token: string;
+  portalUrl: string;
+  thumbnailFile: File;
+}
+
+export interface ISurvey123CreateSuccess {
+  success: true;
+  id: string;
+  formItemInfo: {
+    typeKeywords: string[];
+    ownerFolder: string;
+    access: string;
+    owner: string;
+  };
+  featureService: {
+    source: {
+      itemId: string;
+      [key: string]: any;
+    };
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+export interface ISurvey123CreateError {
+  success: false;
+  error: {
+    code: number;
+    details: string[];
+    message: string;
+  };
+}
+
+export interface ISurvey123CreateResult {
+  formId: string;
+  featureServiceId: string;
+  folderId: string;
+}
+
 //#endregion ---------------------------------------------------------------------------------------------------------//

--- a/packages/common/src/migrations/upgrade-two-dot-five.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-five.ts
@@ -17,6 +17,11 @@
 import { ISolutionItem } from "../interfaces";
 import { getProp, cloneObject, deleteProp } from "@esri/hub-common";
 
+/**
+ * Applies Survey123 Form Config Schema migrations.
+ * @param {ISolutionItem} model A Solution model
+ * @returns {ISolutionItem}
+ */
 export function _upgradeTwoDotFive(model: ISolutionItem): ISolutionItem {
   if (getProp(model, "item.properties.schemaVersion") >= 2.5) {
     return model;

--- a/packages/common/src/migrations/upgrade-two-dot-five.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-five.ts
@@ -1,0 +1,60 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISolutionItem } from "../interfaces";
+import { getProp, cloneObject, deleteProp } from "@esri/hub-common";
+
+export function _upgradeTwoDotFive(model: ISolutionItem): ISolutionItem {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.5) {
+    return model;
+  } else {
+    const clone = cloneObject(model);
+
+    clone.data.templates.forEach(template => {
+      if (template.type === "Form") {
+        if (getProp(template, "properties.form.portalUrl")) {
+          template.properties.form.portalUrl = "{{portalBaseUrl}}";
+        }
+
+        const ver = parseFloat(
+          getProp(template, "properties.form.version") || "2.5"
+        );
+        const hasFormSchema = getProp(template, "properties.form");
+        if (!hasFormSchema || ver >= 3.8) {
+          return template;
+        }
+
+        template.properties.form.layerName = "survey";
+        // nest the theme into themes
+        if (getProp(template, "properties.form.theme")) {
+          template.properties.form.themes = [template.properties.form.theme];
+          delete template.properties.form.theme;
+        }
+        // replace whatever layout on all questions with vertical
+        template.properties.form.questions.forEach((q: any) => {
+          if (q.appearance && q.appearance.layout) {
+            q.appearance.layout = "vertical";
+          }
+        });
+        template.properties.form.version = 3.8;
+      }
+    });
+
+    // update the schema version
+    clone.item.properties.schemaVersion = 2.5;
+    return clone;
+  }
+}

--- a/packages/common/src/migrator.ts
+++ b/packages/common/src/migrator.ts
@@ -20,6 +20,7 @@ import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
 import { _upgradeTwoDotTwo } from "./migrations/upgrade-two-dot-two";
 import { _upgradeTwoDotThree } from "./migrations/upgrade-two-dot-three";
 import { _upgradeTwoDotFour } from "./migrations/upgrade-two-dot-four";
+import { _upgradeTwoDotFive } from "./migrations/upgrade-two-dot-five";
 import { getProp } from "@esri/hub-common";
 
 // Starting at 3.0 because Hub has been versioning Solution items up to 2.x
@@ -58,6 +59,7 @@ export function migrateSchema(model: ISolutionItem): ISolutionItem {
         model = _upgradeTwoDotThree(model);
         model = _upgradeThreeDotZero(model);
         model = _upgradeTwoDotFour(model);
+        model = _upgradeTwoDotFive(model);
       }
       // When we need to apply schema upgrades 3.0+ we add those here...
     }

--- a/packages/common/test/migrations/upgrade-two-dot-five.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-five.test.ts
@@ -1,0 +1,190 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { _upgradeTwoDotFive } from "../../src/migrations/upgrade-two-dot-five";
+import * as utils from "../../../common/test/mocks/utils";
+import { ISolutionItem } from "../../src/interfaces";
+
+describe("Upgrade 2.5 ::", () => {
+  const theme = {
+    id: "hrEKQnEsn",
+    name: "theme-custom"
+  };
+  const question = {
+    appearance: {
+      layout: "horizontal"
+    }
+  };
+  const defaultModel = {
+    item: {
+      type: "Solution",
+      typeKeywords: ["Solution", "Template"],
+      properties: {
+        schemaVersion: 2.4
+      }
+    },
+    data: {
+      templates: [
+        {
+          type: "Form",
+          properties: {
+            form: {
+              version: "3.7",
+              portalUrl: utils.PORTAL_SUBSET.portalUrl,
+              layerName: "someName",
+              theme,
+              questions: [question]
+            }
+          }
+        }
+      ] as IItemTemplate[]
+    }
+  } as ISolutionItem;
+
+  it("returns same model if on or above 2.5", () => {
+    const model = cloneObject(defaultModel);
+    model.item.properties.schemaVersion = 2.5;
+    const results = _upgradeTwoDotFive(model);
+    expect(results).toBe(model, "should return the exact same object");
+  });
+
+  it("only upgrades the schema version for non-Form templates", () => {
+    const model = cloneObject(defaultModel);
+    model.data.templates[0].type = "Feature Service";
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it always tokenizes portalUrl when the key/value exists for Form templates", () => {
+    const model = cloneObject(defaultModel);
+    model.data.templates[0].properties.form.version = 3.8;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.item.properties.schemaVersion = 2.5;
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expect(results).toEqual(expected);
+  });
+
+  it("it doesn't tokenize portalUrl when the key/value is missing for Form templates", () => {
+    const model = cloneObject(defaultModel);
+    model.data.templates[0].properties.form.version = 3.8;
+    delete model.data.templates[0].properties.form.portalUrl;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it doesn't migrate the Form template's form config schema when the version is >= 3.8", () => {
+    const model = cloneObject(defaultModel);
+    model.data.templates[0].properties.form.version = 3.8;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it doesn't migrate the Form template's form config schema when that schema is missing", () => {
+    const model = cloneObject(defaultModel);
+    delete model.data.templates[0].properties.form;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it defaults the Form template's form config schema to 2.5 if not set then upgrades the form config schema", () => {
+    const model = cloneObject(defaultModel);
+    delete model.data.templates[0].properties.form.version;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expected.data.templates[0].properties.form.layerName = "survey";
+    expected.data.templates[0].properties.form.themes = [theme];
+    delete expected.data.templates[0].properties.form.theme;
+    expected.data.templates[0].properties.form.questions[0].appearance.layout =
+      "vertical";
+    expected.data.templates[0].properties.form.version = 3.8;
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it upgrades the Form template's form config schema when it's < 3.8", () => {
+    const model = cloneObject(defaultModel);
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expected.data.templates[0].properties.form.layerName = "survey";
+    expected.data.templates[0].properties.form.themes = [theme];
+    delete expected.data.templates[0].properties.form.theme;
+    expected.data.templates[0].properties.form.questions[0].appearance.layout =
+      "vertical";
+    expected.data.templates[0].properties.form.version = 3.8;
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it doesn't wrap the theme in an array when it's missing", () => {
+    const model = cloneObject(defaultModel);
+    delete model.data.templates[0].properties.form.theme;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expected.data.templates[0].properties.form.layerName = "survey";
+    delete expected.data.templates[0].properties.form.theme;
+    expected.data.templates[0].properties.form.questions[0].appearance.layout =
+      "vertical";
+    expected.data.templates[0].properties.form.version = 3.8;
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it doesn't migrate appearance.layout when appearance is missing", () => {
+    const model = cloneObject(defaultModel);
+    delete model.data.templates[0].properties.form.questions[0].appearance;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    delete expected.data.templates[0].properties.form.questions[0].appearance;
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expected.data.templates[0].properties.form.layerName = "survey";
+    expected.data.templates[0].properties.form.themes = [theme];
+    delete expected.data.templates[0].properties.form.theme;
+    expected.data.templates[0].properties.form.version = 3.8;
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+
+  it("it doesn't migrate appearance.layout when layout is missing", () => {
+    const model = cloneObject(defaultModel);
+    delete model.data.templates[0].properties.form.questions[0].appearance
+      .layout;
+    const results = _upgradeTwoDotFive(model);
+    const expected = cloneObject(model);
+    delete expected.data.templates[0].properties.form.questions[0].appearance
+      .layout;
+    expected.data.templates[0].properties.form.portalUrl = "{{portalBaseUrl}}";
+    expected.data.templates[0].properties.form.layerName = "survey";
+    expected.data.templates[0].properties.form.themes = [theme];
+    delete expected.data.templates[0].properties.form.theme;
+    expected.data.templates[0].properties.form.version = 3.8;
+    expected.item.properties.schemaVersion = 2.5;
+    expect(results).toEqual(expected);
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-four.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-four.test.ts
@@ -18,7 +18,7 @@ import { _upgradeTwoDotFour } from "../../src/migrations/upgrade-two-dot-four";
 import { cloneObject, IItemTemplate } from "@esri/hub-common";
 import { ISolutionItem } from "../../src/interfaces";
 
-describe("Upgrade 2.3 ::", () => {
+describe("Upgrade 2.4 ::", () => {
   const defaultModel = {
     item: {
       type: "Solution",

--- a/packages/common/test/migrations/upgrade-two-dot-four.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-four.test.ts
@@ -18,7 +18,7 @@ import { _upgradeTwoDotFour } from "../../src/migrations/upgrade-two-dot-four";
 import { cloneObject, IItemTemplate } from "@esri/hub-common";
 import { ISolutionItem } from "../../src/interfaces";
 
-describe("Upgrade 2.2 ::", () => {
+describe("Upgrade 2.3 ::", () => {
   const defaultModel = {
     item: {
       type: "Solution",

--- a/packages/common/test/migrator.test.ts
+++ b/packages/common/test/migrator.test.ts
@@ -17,9 +17,11 @@
 import { migrateSchema, CURRENT_SCHEMA_VERSION } from "../src/migrator";
 import { cloneObject, IItemTemplate } from "@esri/hub-common";
 import { ISolutionItem } from "../src/interfaces";
-import * as firstUpgrade from "../src/migrations/upgrade-two-dot-two";
-import * as secondUpgrade from "../src/migrations/upgrade-two-dot-three";
-import * as thirdUpgrade from "../src/migrations/upgrade-three-dot-zero";
+import * as twoDotTwo from "../src/migrations/upgrade-two-dot-two";
+import * as twoDotThree from "../src/migrations/upgrade-two-dot-three";
+import * as twoDotFour from "../src/migrations/upgrade-two-dot-four";
+import * as twoDotFive from "../src/migrations/upgrade-two-dot-five";
+import * as threeDotZero from "../src/migrations/upgrade-three-dot-zero";
 
 describe("Schema Migrator", () => {
   const defaultModel = {
@@ -56,15 +58,21 @@ describe("Schema Migrator", () => {
     // kill the schema version
     m.item.properties.schemaVersion = 2.1;
     m.item.typeKeywords = ["hubSolutionTemplate", "solutionTemplate"];
-    const sp1 = spyOn(firstUpgrade, "_upgradeTwoDotTwo").and.callFake(model => {
+    const sp1 = spyOn(twoDotTwo, "_upgradeTwoDotTwo").and.callFake(model => {
       return cloneObject(model);
     });
-    const sp2 = spyOn(secondUpgrade, "_upgradeTwoDotThree").and.callFake(
+    const sp2 = spyOn(twoDotThree, "_upgradeTwoDotThree").and.callFake(
       model => {
         return cloneObject(model);
       }
     );
-    const sp3 = spyOn(thirdUpgrade, "_upgradeThreeDotZero").and.callFake(
+    const sp3 = spyOn(twoDotFour, "_upgradeTwoDotFour").and.callFake(model => {
+      return cloneObject(model);
+    });
+    const sp4 = spyOn(twoDotFive, "_upgradeTwoDotFive").and.callFake(model => {
+      return cloneObject(model);
+    });
+    const sp5 = spyOn(threeDotZero, "_upgradeThreeDotZero").and.callFake(
       model => {
         return cloneObject(model);
       }
@@ -72,7 +80,9 @@ describe("Schema Migrator", () => {
     const chk = migrateSchema(m);
     expect(sp1.calls.count()).toBe(1, "should call first upgrade");
     expect(sp2.calls.count()).toBe(1, "should call second upgrade");
-    expect(sp3.calls.count()).toBe(1, "should call second upgrade");
+    expect(sp3.calls.count()).toBe(1, "should call third upgrade");
+    expect(sp4.calls.count()).toBe(1, "should call fourth upgrade");
+    expect(sp5.calls.count()).toBe(1, "should call fifth upgrade");
     expect(chk).not.toBe(m, "should not return the exact same object");
     // since the upgrades are all spies, we don't make assertions on the schemaVersion
   });

--- a/packages/form/src/form.ts
+++ b/packages/form/src/form.ts
@@ -23,6 +23,7 @@
 import * as common from "@esri/solution-common";
 import { simpleTypes } from "@esri/solution-simple-types";
 import { isHubFormTemplate } from "./helpers/is-hub-form-template";
+import { createItemFromHubTemplate } from "./helpers/create-item-from-hub-template";
 
 export function convertItemToTemplate(
   solutionItemId: string,
@@ -45,10 +46,11 @@ export function createItemFromTemplate(
 ): Promise<common.ICreateItemFromTemplateResponse> {
   // Hub Form template custom processing
   if (isHubFormTemplate(template)) {
-    return Promise.reject(
-      common.fail(
-        "createItemFromTemplate not yet implemented for Hub templates in solution-form package"
-      )
+    return createItemFromHubTemplate(
+      template,
+      templateDictionary,
+      destinationAuthentication,
+      itemProgressCallback
     );
   }
 

--- a/packages/form/src/form.ts
+++ b/packages/form/src/form.ts
@@ -25,6 +25,13 @@ import { simpleTypes } from "@esri/solution-simple-types";
 import { isHubFormTemplate } from "./helpers/is-hub-form-template";
 import { createItemFromHubTemplate } from "./helpers/create-item-from-hub-template";
 
+/**
+ * Creates a template from a Form item
+ * @param {string} solutionItemId The solution item ID
+ * @param {any} itemInfo: The base item info
+ * @param {UserSession} authentication The source user session information
+ * @returns {Promise<IItemTemplate>}
+ */
 export function convertItemToTemplate(
   solutionItemId: string,
   itemInfo: any,
@@ -38,6 +45,14 @@ export function convertItemToTemplate(
   );
 }
 
+/**
+ * Creates a Form item from a template
+ * @param {IItemTemplate} template The template
+ * @param {any} templateDictionary The template dictionary
+ * @param {UserSession} destinationAuthentication The destination user session info
+ * @param itemProgressCallback An item progress callback
+ * @returns {Promise<ICreateItemFromTemplateResponse>}
+ */
 export function createItemFromTemplate(
   template: common.IItemTemplate,
   templateDictionary: any,

--- a/packages/form/src/helpers/build-create-params.ts
+++ b/packages/form/src/helpers/build-create-params.ts
@@ -1,0 +1,55 @@
+import {
+  IItemTemplate,
+  UserSession,
+  getUniqueTitle,
+  getItemThumbnail,
+  blobToFile,
+  ISurvey123CreateParams
+} from "@esri/solution-common";
+import { encodeSurveyForm } from "./encode-survey-form";
+
+export function buildCreateParams(
+  template: IItemTemplate,
+  templateDictionary: any,
+  destinationAuthentication: UserSession
+): Promise<ISurvey123CreateParams> {
+  const {
+    item: { title: originalTitle, description, tags, typeKeywords },
+    properties: { form: unencodedForm }
+  } = template;
+  const {
+    user: { username },
+    portalBaseUrl: portalUrl
+  } = templateDictionary;
+  const { token } = destinationAuthentication.toCredential();
+  return getItemThumbnail(
+    template.itemId,
+    template.item.thumbnail,
+    false,
+    destinationAuthentication
+  ).then(blob => {
+    // The S123 API appends "Survey-" to the survey title when computing
+    // the folder name. We need to use the same prefix to successfully
+    // calculate a unique folder name. Afterwards, we can safely remove the
+    // prefix from the title
+    const folderPrefix = "Survey-";
+    const title = getUniqueTitle(
+      `${folderPrefix}${originalTitle}`,
+      templateDictionary,
+      "user.folders"
+    ).replace(folderPrefix, "");
+    const thumbnailFile = blobToFile(blob, template.item.thumbnail);
+    const form = encodeSurveyForm(unencodedForm);
+    return {
+      description,
+      form,
+      portalUrl,
+      tags,
+      thumbnailFile,
+      title,
+      token,
+      typeKeywords,
+      username
+    };
+  });
+}

--- a/packages/form/src/helpers/build-create-params.ts
+++ b/packages/form/src/helpers/build-create-params.ts
@@ -8,6 +8,19 @@ import {
 } from "@esri/solution-common";
 import { encodeSurveyForm } from "./encode-survey-form";
 
+/**
+ * Utility method for creating Survey123 parameters
+ *
+ * @module build-create-params
+ */
+
+/**
+ * Builds the Survey123 create API parameters
+ * @param {IItemTemplate} template The template
+ * @param {any} templateDictionary The template dictionary
+ * @param {UserSession} destinationAuthentication The destination session info
+ * @returns {Promise<ISurvey123CreateParams>}
+ */
 export function buildCreateParams(
   template: IItemTemplate,
   templateDictionary: any,

--- a/packages/form/src/helpers/create-item-from-hub-template.ts
+++ b/packages/form/src/helpers/create-item-from-hub-template.ts
@@ -1,0 +1,84 @@
+import {
+  IItemTemplate,
+  UserSession,
+  IItemProgressCallback,
+  ICreateItemFromTemplateResponse,
+  EItemProgressStatus,
+  removeFolder,
+  replaceInTemplate,
+  ISurvey123CreateParams,
+  ISurvey123CreateResult,
+  getProp,
+  setCreateProp
+} from "@esri/solution-common";
+import { moveItem } from "@esri/arcgis-rest-portal";
+import { createSurvey } from "./create-survey";
+import { buildCreateParams } from "./build-create-params";
+
+export function createItemFromHubTemplate(
+  template: IItemTemplate,
+  templateDictionary: any,
+  destinationAuthentication: UserSession,
+  itemProgressCallback: IItemProgressCallback
+): Promise<ICreateItemFromTemplateResponse> {
+  const interpolatedTemplate = replaceInTemplate(template, templateDictionary);
+  const { survey123Url } = templateDictionary;
+  // TODO: Post processing/adding feature service template to deployed solution
+  // TODO: update any item details we couldn't pass to Survey123 API (extent, culture, title, etc)
+  // TODO: investigate CORS error for /rest/info request...
+
+  return buildCreateParams(
+    interpolatedTemplate,
+    templateDictionary,
+    destinationAuthentication
+  )
+    .then((params: ISurvey123CreateParams) => {
+      return createSurvey(params, destinationAuthentication, survey123Url);
+    })
+    .then((createSurveyResponse: ISurvey123CreateResult) => {
+      const { formId, folderId, featureServiceId } = createSurveyResponse;
+      // Survey123 API creates Form & Feature Service in a different directory,
+      // so move those items to the deployed solution folder
+      const movePromises = [formId, featureServiceId].map((id: string) => {
+        return moveItem({
+          itemId: id,
+          folderId: templateDictionary.folderId as string,
+          authentication: destinationAuthentication
+        });
+      });
+      return Promise.all(movePromises)
+        .then(_ => {
+          // then remove the folder that Survey123 created
+          return removeFolder(folderId, destinationAuthentication);
+        })
+        .then(_ => {
+          templateDictionary[interpolatedTemplate.itemId] = {
+            itemId: formId
+          };
+          templateDictionary[
+            interpolatedTemplate.properties.info.serviceInfo.itemId
+          ] = {
+            itemId: featureServiceId
+          };
+          itemProgressCallback(
+            interpolatedTemplate.itemId,
+            EItemProgressStatus.Finished,
+            interpolatedTemplate.estimatedDeploymentCostFactor,
+            formId
+          );
+          return {
+            id: formId,
+            type: "Form",
+            postProcess: false
+          };
+        });
+    })
+    .catch(e => {
+      itemProgressCallback(
+        interpolatedTemplate.itemId,
+        EItemProgressStatus.Failed,
+        0
+      );
+      throw e;
+    });
+}

--- a/packages/form/src/helpers/create-item-from-hub-template.ts
+++ b/packages/form/src/helpers/create-item-from-hub-template.ts
@@ -7,14 +7,27 @@ import {
   removeFolder,
   replaceInTemplate,
   ISurvey123CreateParams,
-  ISurvey123CreateResult,
-  getProp,
-  setCreateProp
+  ISurvey123CreateResult
 } from "@esri/solution-common";
 import { moveItem } from "@esri/arcgis-rest-portal";
 import { createSurvey } from "./create-survey";
 import { buildCreateParams } from "./build-create-params";
 
+/**
+ * Manages the creation of Surveys from Hub Templates
+ * via the Survey123 API
+ *
+ * @module create-item-from-hub-template
+ */
+
+/**
+ * Orchestrates creation of Surveys from Hub templates
+ * @param {IItemTemplate} template The template
+ * @param {any} templateDictionary The template dictionary
+ * @param {UserSession} destinationAuthentication The destination session info
+ * @param {Function} itemProgressCallback A progress callback
+ * @returns {Promise<ICreateItemFromTemplateResponse>}
+ */
 export function createItemFromHubTemplate(
   template: IItemTemplate,
   templateDictionary: any,

--- a/packages/form/src/helpers/create-survey.ts
+++ b/packages/form/src/helpers/create-survey.ts
@@ -1,0 +1,42 @@
+import {
+  UserSession,
+  ISurvey123CreateParams,
+  ISurvey123CreateSuccess,
+  ISurvey123CreateError,
+  ISurvey123CreateResult
+} from "@esri/solution-common";
+import {
+  IRequestOptions,
+  request,
+  encodeFormData
+} from "@esri/arcgis-rest-request";
+
+export function createSurvey(
+  params: ISurvey123CreateParams,
+  authentication: UserSession,
+  survey123Url = "https://survey123.arcgis.com"
+): Promise<ISurvey123CreateResult> {
+  const createUrl = `${survey123Url}/api/survey/create`;
+  const requestOptions = {
+    httpMethod: "POST",
+    authentication,
+    params: {
+      f: "json",
+      ...params
+    }
+  } as IRequestOptions;
+  return request(createUrl, requestOptions).then(
+    (
+      response: ISurvey123CreateSuccess | ISurvey123CreateError
+    ): ISurvey123CreateResult => {
+      if (!response.success) {
+        throw new Error(`Failed to create survey: ${response.error.message}`);
+      }
+      return {
+        formId: response.id,
+        featureServiceId: response.featureService.source.itemId,
+        folderId: response.formItemInfo.ownerFolder
+      };
+    }
+  );
+}

--- a/packages/form/src/helpers/create-survey.ts
+++ b/packages/form/src/helpers/create-survey.ts
@@ -11,6 +11,20 @@ import {
   encodeFormData
 } from "@esri/arcgis-rest-request";
 
+/**
+ * Provides utility method to call Survey123 create endpoint
+ *
+ * @module create-survey
+ */
+
+/**
+ * Calls the Survey123 create API with the given parameters
+ * @param {ISurvey123CreateParams} params
+ * @param {UserSession} authentication
+ * @param {string} [survey123Url=https://survey123.arcgis.com] An optional, Survey123 base URL override
+ * @throws Will throw if the Survey123 API returns an error response
+ * @returns {Promise<ISurvey123CreateResult>}
+ */
 export function createSurvey(
   params: ISurvey123CreateParams,
   authentication: UserSession,

--- a/packages/form/src/helpers/encode-survey-form.ts
+++ b/packages/form/src/helpers/encode-survey-form.ts
@@ -1,0 +1,30 @@
+import { cloneObject } from "@esri/solution-common";
+
+export const encodeSurveyForm = function encodeForm(form: any) {
+  const clone = cloneObject(form);
+  const props = [
+    ["header", "content"],
+    ["subHeader", "content"],
+    ["footer", "content"],
+    ["settings", "thankYouScreenContent"]
+  ];
+  const encode = (
+    obj: { [key: string]: string },
+    key: string
+  ): { [key: string]: string } => {
+    if (obj && obj[key]) {
+      obj[key] = encodeURIComponent(obj[key]);
+    }
+    return obj;
+  };
+
+  // encode props from array above
+  props.forEach(([objKey, propKey]) => encode(clone[objKey], propKey));
+
+  // encode question descriptions
+  clone.questions = (clone.questions || []).map((question: any) =>
+    encode(question, "description")
+  );
+
+  return clone;
+};

--- a/packages/form/src/helpers/encode-survey-form.ts
+++ b/packages/form/src/helpers/encode-survey-form.ts
@@ -1,5 +1,17 @@
 import { cloneObject } from "@esri/solution-common";
 
+/**
+ * Manages Survey123 parameter encoding
+ *
+ * @module encode-survey-form
+ */
+
+/**
+ * URI Encodes Survey123 form content parameter
+ * values
+ * @param {any} form Unencoded form data
+ * @returns {any} Encoded form data
+ */
 export const encodeSurveyForm = function encodeForm(form: any) {
   const clone = cloneObject(form);
   const props = [

--- a/packages/form/src/helpers/is-hub-form-template.ts
+++ b/packages/form/src/helpers/is-hub-form-template.ts
@@ -1,5 +1,12 @@
 import * as common from "@esri/solution-common";
 
+/**
+ * Determines if the given template is a Hub Survey
+ * template vs Solutions.js Survey template.
+ * @param {IITemTemplate} template A template
+ * @returns {boolean}
+ */
 export function isHubFormTemplate(template: common.IItemTemplate): boolean {
+  // relying on basic duck typing vs adding extraneous props during migration
   return !!common.getProp(template, "properties.services.service");
 }

--- a/packages/form/test/helpers/build-create-params.test.ts
+++ b/packages/form/test/helpers/build-create-params.test.ts
@@ -1,0 +1,156 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from "@esri/solution-common";
+import { buildCreateParams } from "../../src/helpers/build-create-params";
+import * as surveyEncodingUtils from "../../src/helpers/encode-survey-form";
+import * as templates from "../../../common/test/mocks/templates";
+import * as utils from "../../../common/test/mocks/utils";
+import * as items from "../../../common/test/mocks/agolItems";
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("buildCreateParams", () => {
+  if (typeof window !== "undefined") {
+    it("should resolve a ISurvey123CreateParams", done => {
+      const templateDictionary = {
+        portalBaseUrl: utils.PORTAL_SUBSET.portalUrl,
+        user: items.getAGOLUser("myUser")
+      };
+      const credential = {
+        expires: 1591039350661,
+        server: "https://some.arcgis.com/sharing/rest",
+        ssl: true,
+        token: "my-token",
+        userId: "myUser"
+      };
+      const unencodedForm = {
+        header: {
+          content: "<p title='Whos the best cat'>Whos the best cat</p>"
+        },
+        subHeader: {
+          content: "This is encoded"
+        },
+        footer: {
+          content: "This is encoded"
+        },
+        questions: [
+          {
+            description: "This is encoded"
+          }
+        ],
+        settings: {
+          thankYouScreenContent: "This is encoded"
+        }
+      };
+      const encodedForm = {
+        header: {
+          content:
+            "%3Cp%20title%3D'Whos%20the%20best%20cat'%3EWhos%20the%20best%20cat%3C%2Fp%3E"
+        },
+        subHeader: {
+          content: "This%20is%20encoded"
+        },
+        footer: {
+          content: "This%20is%20encoded"
+        },
+        questions: [
+          {
+            description: "This%20is%20encoded"
+          }
+        ],
+        settings: {
+          thankYouScreenContent: "This%20is%20encoded"
+        }
+      };
+      const baseTemplate = templates.getItemTemplate("Form");
+      const template = {
+        ...baseTemplate,
+        item: {
+          ...baseTemplate.item,
+          thumbnail: "thumbnail/ago_downloaded.png"
+        },
+        properties: {
+          ...baseTemplate.properties,
+          form: unencodedForm
+        }
+      };
+      const thumbnailBlob = utils.getSampleImage();
+      const thumbnailFile = new File([thumbnailBlob], "thumbnail.png");
+      const toCredentialSpy = spyOn(
+        MOCK_USER_SESSION,
+        "toCredential"
+      ).and.returnValue(credential);
+      const getItemThumbnailSpy = spyOn(
+        common,
+        "getItemThumbnail"
+      ).and.resolveTo(thumbnailBlob);
+      const getUniqueTitleSpy = spyOn(common, "getUniqueTitle").and.returnValue(
+        ""
+      );
+      const blobToFileSpy = spyOn(common, "blobToFile").and.returnValue(
+        thumbnailFile
+      );
+      const encodeSurveyFormSpy = spyOn(
+        surveyEncodingUtils,
+        "encodeSurveyForm"
+      ).and.returnValue(encodedForm);
+      return buildCreateParams(template, templateDictionary, MOCK_USER_SESSION)
+        .then(results => {
+          expect(toCredentialSpy.calls.count()).toEqual(1);
+          expect(getItemThumbnailSpy.calls.count()).toEqual(1);
+          expect(getItemThumbnailSpy.calls.first().args).toEqual([
+            "frm1234567890",
+            "thumbnail/ago_downloaded.png",
+            false,
+            MOCK_USER_SESSION
+          ]);
+          expect(getUniqueTitleSpy.calls.count()).toEqual(1);
+          expect(getUniqueTitleSpy.calls.first().args).toEqual([
+            "Survey-An AGOL item",
+            templateDictionary,
+            "user.folders"
+          ]);
+          expect(blobToFileSpy.calls.count()).toEqual(1);
+          expect(blobToFileSpy.calls.first().args).toEqual([
+            thumbnailBlob,
+            "thumbnail/ago_downloaded.png"
+          ]);
+          expect(encodeSurveyFormSpy.calls.count()).toEqual(1);
+          expect(encodeSurveyFormSpy.calls.first().args).toEqual([
+            unencodedForm
+          ]);
+          expect(results).toEqual({
+            description: "Description of an AGOL item",
+            form: encodedForm,
+            portalUrl: "https://myorg.maps.arcgis.com",
+            tags: ["test"],
+            thumbnailFile,
+            title: "",
+            token: "my-token",
+            typeKeywords: ["JavaScript"],
+            username: "myUser"
+          });
+          done();
+        })
+        .catch(e => {
+          done.fail(e);
+        });
+    });
+  }
+});

--- a/packages/form/test/helpers/create-item-from-hub-template.test.ts
+++ b/packages/form/test/helpers/create-item-from-hub-template.test.ts
@@ -1,0 +1,398 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from "@esri/solution-common";
+import * as restPortal from "@esri/arcgis-rest-portal";
+import { createItemFromHubTemplate } from "../../src/helpers/create-item-from-hub-template";
+import * as createSurveyHelper from "../../src/helpers/create-survey";
+import * as buildParamsHelper from "../../src/helpers/build-create-params";
+import * as templates from "../../../common/test/mocks/templates";
+import * as utils from "../../../common/test/mocks/utils";
+import * as items from "../../../common/test/mocks/agolItems";
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+if (typeof window !== "undefined") {
+  describe("createItemFromHubTemplate", () => {
+    let templateDictionary: any;
+    let template: common.IItemTemplate;
+    let interpolatedTemplate: common.IItemTemplate;
+    let thumbnailBlob: Blob;
+    let thumbnailFile: File;
+    let paramResults: common.ISurvey123CreateParams;
+    let createResult: common.ISurvey123CreateResult;
+    let MOCK_USER_SESSION: common.UserSession;
+
+    beforeEach(() => {
+      MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+      templateDictionary = {
+        portalBaseUrl: utils.PORTAL_SUBSET.portalUrl,
+        user: items.getAGOLUser("myUser"),
+        folderId: "h7bf45f98d114c3ab85fd63bb44e240d"
+      };
+
+      const baseTemplate = templates.getItemTemplate("Form");
+      template = {
+        ...baseTemplate,
+        item: {
+          ...baseTemplate.item,
+          thumbnail: "thumbnail/ago_downloaded.png"
+        },
+        properties: {
+          ...baseTemplate.properties,
+          info: {
+            ...baseTemplate.properties.info,
+            serviceInfo: {
+              itemId: "i7bf45f98d114c3ab85fd63bb44e240d"
+            }
+          },
+          form: {
+            portalUrl: "{{portalBaseUrl}}",
+            header: {
+              content: "<p title='Whos the best cat'>Whos the best cat</p>"
+            },
+            subHeader: {
+              content: "This is encoded"
+            },
+            footer: {
+              content: "This is encoded"
+            },
+            questions: [
+              {
+                description: "This is encoded"
+              }
+            ],
+            settings: {
+              thankYouScreenContent: "This is encoded"
+            }
+          }
+        }
+      };
+
+      interpolatedTemplate = {
+        ...template,
+        properties: {
+          ...template.properties,
+          form: {
+            ...template.properties.form,
+            portalUrl: utils.PORTAL_SUBSET.portalUrl
+          }
+        }
+      };
+
+      thumbnailBlob = utils.getSampleImage();
+
+      thumbnailFile = new File([thumbnailBlob], "thumbnail.png");
+
+      paramResults = {
+        description: "Description of an AGOL item",
+        form: template.properties.form,
+        portalUrl: "https://myorg.maps.arcgis.com",
+        tags: ["test"],
+        thumbnailFile,
+        title: "An AGOL item",
+        token: "my-token",
+        typeKeywords: ["JavaScript"],
+        username: "myUser"
+      };
+
+      createResult = {
+        formId: "e7bf45f98d114c3ab85fd63bb44e240d",
+        featureServiceId: "f7bf45f98d114c3ab85fd63bb44e240d",
+        folderId: "g7bf45f98d114c3ab85fd63bb44e240d"
+      };
+    });
+
+    it("should resolve a ISurvey123CreateParams", done => {
+      const replaceInTemplateSpy = spyOn(
+        common,
+        "replaceInTemplate"
+      ).and.returnValue(interpolatedTemplate);
+      const buildCreateParamsSpy = spyOn(
+        buildParamsHelper,
+        "buildCreateParams"
+      ).and.resolveTo(paramResults);
+      const createSurveySpy = spyOn(
+        createSurveyHelper,
+        "createSurvey"
+      ).and.resolveTo(createResult);
+      const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
+      const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
+      const itemProgressCallbackSpy = jasmine.createSpy();
+      return createItemFromHubTemplate(
+        template,
+        templateDictionary,
+        MOCK_USER_SESSION,
+        itemProgressCallbackSpy
+      )
+        .then(results => {
+          expect(replaceInTemplateSpy.calls.count()).toEqual(1);
+          expect(replaceInTemplateSpy.calls.first().args).toEqual([
+            template,
+            templateDictionary
+          ]);
+          expect(buildCreateParamsSpy.calls.count()).toEqual(1);
+          expect(buildCreateParamsSpy.calls.first().args).toEqual([
+            interpolatedTemplate,
+            templateDictionary,
+            MOCK_USER_SESSION
+          ]);
+          expect(createSurveySpy.calls.count()).toEqual(1);
+          expect(createSurveySpy.calls.first().args).toEqual([
+            paramResults,
+            MOCK_USER_SESSION,
+            undefined
+          ]);
+          expect(moveItemSpy.calls.count()).toEqual(2);
+          expect(moveItemSpy.calls.argsFor(0)[0].itemId).toBe(
+            createResult.formId
+          );
+          expect(moveItemSpy.calls.argsFor(0)[0].folderId).toBe(
+            templateDictionary.folderId
+          );
+          expect(moveItemSpy.calls.argsFor(1)[0].itemId).toBe(
+            createResult.featureServiceId
+          );
+          expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
+            templateDictionary.folderId
+          );
+          expect(removeFolderSpy.calls.count()).toEqual(1);
+          expect(removeFolderSpy.calls.first().args).toEqual([
+            createResult.folderId,
+            MOCK_USER_SESSION
+          ]);
+          expect(templateDictionary[template.itemId]).toEqual({
+            itemId: createResult.formId
+          });
+          expect(
+            templateDictionary[template.properties.info.serviceInfo.itemId]
+          ).toEqual({ itemId: createResult.featureServiceId });
+          expect(itemProgressCallbackSpy.calls.count()).toEqual(1);
+          expect(itemProgressCallbackSpy.calls.first().args).toEqual([
+            template.itemId,
+            common.EItemProgressStatus.Finished,
+            template.estimatedDeploymentCostFactor,
+            createResult.formId
+          ]);
+          expect(results).toEqual({
+            id: createResult.formId,
+            type: "Form",
+            postProcess: false
+          });
+          done();
+        })
+        .catch(e => {
+          done.fail(e);
+        });
+    });
+
+    it("should resolve a ISurvey123CreateParams", done => {
+      const replaceInTemplateSpy = spyOn(
+        common,
+        "replaceInTemplate"
+      ).and.returnValue(interpolatedTemplate);
+      const buildCreateParamsSpy = spyOn(
+        buildParamsHelper,
+        "buildCreateParams"
+      ).and.resolveTo(paramResults);
+      const createSurveySpy = spyOn(
+        createSurveyHelper,
+        "createSurvey"
+      ).and.resolveTo(createResult);
+      const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
+      const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
+      const itemProgressCallbackSpy = jasmine.createSpy();
+      return createItemFromHubTemplate(
+        template,
+        templateDictionary,
+        MOCK_USER_SESSION,
+        itemProgressCallbackSpy
+      )
+        .then(results => {
+          expect(replaceInTemplateSpy.calls.count()).toEqual(1);
+          expect(replaceInTemplateSpy.calls.first().args).toEqual([
+            template,
+            templateDictionary
+          ]);
+          expect(buildCreateParamsSpy.calls.count()).toEqual(1);
+          expect(buildCreateParamsSpy.calls.first().args).toEqual([
+            interpolatedTemplate,
+            templateDictionary,
+            MOCK_USER_SESSION
+          ]);
+          expect(createSurveySpy.calls.count()).toEqual(1);
+          expect(createSurveySpy.calls.first().args).toEqual([
+            paramResults,
+            MOCK_USER_SESSION,
+            undefined
+          ]);
+          expect(moveItemSpy.calls.count()).toEqual(2);
+          expect(moveItemSpy.calls.argsFor(0)[0].itemId).toBe(
+            createResult.formId
+          );
+          expect(moveItemSpy.calls.argsFor(0)[0].folderId).toBe(
+            templateDictionary.folderId
+          );
+          expect(moveItemSpy.calls.argsFor(1)[0].itemId).toBe(
+            createResult.featureServiceId
+          );
+          expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
+            templateDictionary.folderId
+          );
+          expect(removeFolderSpy.calls.count()).toEqual(1);
+          expect(removeFolderSpy.calls.first().args).toEqual([
+            createResult.folderId,
+            MOCK_USER_SESSION
+          ]);
+          expect(templateDictionary[template.itemId]).toEqual({
+            itemId: createResult.formId
+          });
+          expect(
+            templateDictionary[template.properties.info.serviceInfo.itemId]
+          ).toEqual({ itemId: createResult.featureServiceId });
+          expect(itemProgressCallbackSpy.calls.count()).toEqual(1);
+          expect(itemProgressCallbackSpy.calls.first().args).toEqual([
+            template.itemId,
+            common.EItemProgressStatus.Finished,
+            template.estimatedDeploymentCostFactor,
+            createResult.formId
+          ]);
+          expect(results).toEqual({
+            id: createResult.formId,
+            type: "Form",
+            postProcess: false
+          });
+          done();
+        })
+        .catch(e => {
+          done.fail(e);
+        });
+    });
+
+    it("should allow survey123Url override from templateDictionary", done => {
+      const replaceInTemplateSpy = spyOn(
+        common,
+        "replaceInTemplate"
+      ).and.returnValue(interpolatedTemplate);
+      const buildCreateParamsSpy = spyOn(
+        buildParamsHelper,
+        "buildCreateParams"
+      ).and.resolveTo(paramResults);
+      const createSurveySpy = spyOn(
+        createSurveyHelper,
+        "createSurvey"
+      ).and.resolveTo(createResult);
+      const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
+      const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
+      const itemProgressCallbackSpy = jasmine.createSpy();
+      templateDictionary.survey123Url = "https://survey123qa.arcgis.com";
+      return createItemFromHubTemplate(
+        template,
+        templateDictionary,
+        MOCK_USER_SESSION,
+        itemProgressCallbackSpy
+      )
+        .then(results => {
+          expect(replaceInTemplateSpy.calls.count()).toEqual(1);
+          expect(replaceInTemplateSpy.calls.first().args).toEqual([
+            template,
+            templateDictionary
+          ]);
+          expect(buildCreateParamsSpy.calls.count()).toEqual(1);
+          expect(buildCreateParamsSpy.calls.first().args).toEqual([
+            interpolatedTemplate,
+            templateDictionary,
+            MOCK_USER_SESSION
+          ]);
+          expect(createSurveySpy.calls.count()).toEqual(1);
+          expect(createSurveySpy.calls.first().args).toEqual([
+            paramResults,
+            MOCK_USER_SESSION,
+            "https://survey123qa.arcgis.com"
+          ]);
+          expect(moveItemSpy.calls.count()).toEqual(2);
+          expect(moveItemSpy.calls.argsFor(0)[0].itemId).toBe(
+            createResult.formId
+          );
+          expect(moveItemSpy.calls.argsFor(0)[0].folderId).toBe(
+            templateDictionary.folderId
+          );
+          expect(moveItemSpy.calls.argsFor(1)[0].itemId).toBe(
+            createResult.featureServiceId
+          );
+          expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
+            templateDictionary.folderId
+          );
+          expect(removeFolderSpy.calls.count()).toEqual(1);
+          expect(removeFolderSpy.calls.first().args).toEqual([
+            createResult.folderId,
+            MOCK_USER_SESSION
+          ]);
+          expect(templateDictionary[template.itemId]).toEqual({
+            itemId: createResult.formId
+          });
+          expect(
+            templateDictionary[template.properties.info.serviceInfo.itemId]
+          ).toEqual({ itemId: createResult.featureServiceId });
+          expect(itemProgressCallbackSpy.calls.count()).toEqual(1);
+          expect(itemProgressCallbackSpy.calls.first().args).toEqual([
+            template.itemId,
+            common.EItemProgressStatus.Finished,
+            template.estimatedDeploymentCostFactor,
+            createResult.formId
+          ]);
+          expect(results).toEqual({
+            id: createResult.formId,
+            type: "Form",
+            postProcess: false
+          });
+          done();
+        })
+        .catch(e => {
+          done.fail(e);
+        });
+    });
+
+    it("should clal itemProgressCallback with Failed then reject", done => {
+      const error = new Error("Failed to build params");
+      spyOn(common, "replaceInTemplate").and.returnValue(interpolatedTemplate);
+      spyOn(buildParamsHelper, "buildCreateParams").and.rejectWith(error);
+      spyOn(createSurveyHelper, "createSurvey").and.resolveTo(createResult);
+      spyOn(restPortal, "moveItem").and.resolveTo();
+      spyOn(common, "removeFolder").and.resolveTo();
+      const itemProgressCallbackSpy = jasmine.createSpy();
+      return createItemFromHubTemplate(
+        template,
+        templateDictionary,
+        MOCK_USER_SESSION,
+        itemProgressCallbackSpy
+      )
+        .then(_ => {
+          done.fail("Should have rejected");
+        })
+        .catch(e => {
+          expect(itemProgressCallbackSpy.calls.count()).toEqual(1);
+          expect(itemProgressCallbackSpy.calls.first().args).toEqual([
+            template.itemId,
+            common.EItemProgressStatus.Failed,
+            0
+          ]);
+          expect(e).toBe(error);
+          done();
+        });
+    });
+  });
+}

--- a/packages/form/test/helpers/create-survey.test.ts
+++ b/packages/form/test/helpers/create-survey.test.ts
@@ -1,0 +1,145 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ISurvey123CreateSuccess,
+  ISurvey123CreateParams,
+  ISurvey123CreateError
+} from "@esri/solution-common";
+import * as restRequest from "@esri/arcgis-rest-request";
+import { createSurvey } from "../../src/helpers/create-survey";
+import * as utils from "../../../common/test/mocks/utils";
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+describe("createSurvey", () => {
+  // atob is undefined in node
+  if (typeof window !== "undefined") {
+    const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+    const params = {
+      title: "My title",
+      tags: ["myTag"],
+      typeKeywords: ["myTypekeyword"],
+      description: "My description",
+      form: {},
+      username: "myusername",
+      token: "mytoken",
+      portalUrl: "https://myportal.arcgis.com",
+      thumbnailFile: utils.getSampleImage()
+    } as ISurvey123CreateParams;
+
+    it("should resolve a ISurvey123CreateResult when successful", done => {
+      const response = {
+        success: true,
+        id: "2c36d3679e7f4934ac599051df22daf6",
+        featureService: {
+          source: {
+            itemId: "3c36d3679e7f4934ac599051df22daf6"
+          }
+        },
+        formItemInfo: {
+          ownerFolder: "4c36d3679e7f4934ac599051df22daf6"
+        }
+      } as ISurvey123CreateSuccess;
+      const expected = {
+        formId: "2c36d3679e7f4934ac599051df22daf6",
+        featureServiceId: "3c36d3679e7f4934ac599051df22daf6",
+        folderId: "4c36d3679e7f4934ac599051df22daf6"
+      };
+      const requestSpy = spyOn(restRequest, "request").and.resolveTo(response);
+      return createSurvey(params, MOCK_USER_SESSION)
+        .then(result => {
+          expect(requestSpy.calls.count()).toEqual(1);
+          expect(requestSpy.calls.first().args).toEqual([
+            "https://survey123.arcgis.com/api/survey/create",
+            {
+              httpMethod: "POST",
+              authentication: MOCK_USER_SESSION,
+              params: {
+                f: "json",
+                ...params
+              }
+            }
+          ]);
+          expect(result).toEqual(expected);
+          done();
+        })
+        .catch(e => done.fail(e));
+    });
+
+    it("should support overriding survey123 url", done => {
+      const response = {
+        success: true,
+        id: "2c36d3679e7f4934ac599051df22daf6",
+        featureService: {
+          source: {
+            itemId: "3c36d3679e7f4934ac599051df22daf6"
+          }
+        },
+        formItemInfo: {
+          ownerFolder: "4c36d3679e7f4934ac599051df22daf6"
+        }
+      } as ISurvey123CreateSuccess;
+      const expected = {
+        formId: "2c36d3679e7f4934ac599051df22daf6",
+        featureServiceId: "3c36d3679e7f4934ac599051df22daf6",
+        folderId: "4c36d3679e7f4934ac599051df22daf6"
+      };
+      const requestSpy = spyOn(restRequest, "request").and.resolveTo(response);
+      return createSurvey(
+        params,
+        MOCK_USER_SESSION,
+        "https://survey123qa.arcgis.com"
+      )
+        .then(result => {
+          expect(requestSpy.calls.first().args).toEqual([
+            "https://survey123qa.arcgis.com/api/survey/create",
+            {
+              httpMethod: "POST",
+              authentication: MOCK_USER_SESSION,
+              params: {
+                f: "json",
+                ...params
+              }
+            }
+          ]);
+          expect(result).toEqual(expected);
+          done();
+        })
+        .catch(e => done.fail(e));
+    });
+
+    it("should reject with an error when unsuccessful", done => {
+      const response = {
+        success: false,
+        error: { message: "Something went awry" }
+      } as ISurvey123CreateError;
+      const requestSpy = spyOn(restRequest, "request").and.resolveTo(response);
+      return createSurvey(params, MOCK_USER_SESSION).then(
+        _ => {
+          done.fail("should have rejected");
+        },
+        e => {
+          expect(e.message).toEqual(
+            "Failed to create survey: Something went awry"
+          );
+          done();
+        }
+      );
+    });
+  }
+});

--- a/packages/form/test/helpers/encode-survey-form.test.ts
+++ b/packages/form/test/helpers/encode-survey-form.test.ts
@@ -1,0 +1,101 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getProp, cloneObject } from "@esri/solution-common";
+import { encodeSurveyForm } from "../../src/helpers/encode-survey-form";
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+describe("encodeSurveyForm", () => {
+  let form: any;
+  beforeEach(() => {
+    form = {
+      header: {
+        encoded:
+          "%3Cp%20title%3D'Whos%20the%20best%20cat'%3EWhos%20the%20best%20cat%3C%2Fp%3E",
+        content: "<p title='Whos the best cat'>Whos the best cat</p>"
+      },
+      subHeader: {
+        encoded: "This%20is%20encoded",
+        content: "This is encoded"
+      },
+      footer: {
+        encoded: "This%20is%20encoded",
+        content: "This is encoded"
+      },
+      questions: [
+        {
+          encoded: "This%20is%20encoded",
+          description: "This is encoded"
+        }
+      ],
+      settings: {
+        encoded: "This%20is%20encoded",
+        thankYouScreenContent: "This is encoded"
+      }
+    };
+  });
+  it("should encode specific property values", () => {
+    const checks = [
+      { contentPath: "header.content", verifyPath: "header.encoded" },
+      { contentPath: "subHeader.content", verifyPath: "subHeader.encoded" },
+      { contentPath: "footer.content", verifyPath: "footer.encoded" },
+      {
+        contentPath: "settings.thankYouScreenContent",
+        verifyPath: "settings.encoded"
+      }
+    ];
+    const results = encodeSurveyForm(form);
+    expect(form).not.toEqual(results, "should not mutate the passed in form");
+    checks.forEach(e => {
+      expect(getProp(results, e.contentPath)).toEqual(
+        getProp(results, e.verifyPath),
+        `${e.contentPath} should be encoded`
+      );
+    });
+    const question = results.questions[0];
+    expect(question.description).toEqual(
+      question.encoded,
+      "Question descriptions should be encoded"
+    );
+  });
+
+  it("should set questions to an empty array when the property is missing", () => {
+    delete form.questions;
+    const results = encodeSurveyForm(form);
+    expect(results.questions).toEqual([]);
+  });
+
+  it("should not encode missing properties", () => {
+    const checks = [
+      { contentPath: "header.content", verifyPath: "header.encoded" },
+      { contentPath: "subHeader.content", verifyPath: "subHeader.encoded" },
+      { contentPath: "footer.content", verifyPath: "footer.encoded" }
+    ];
+    const cloned = cloneObject(form);
+    const expected = cloneObject(form);
+    delete cloned.settings;
+    delete expected.settings;
+    const results = encodeSurveyForm(cloned);
+    checks.forEach(e => {
+      expect(getProp(results, e.contentPath)).toEqual(
+        getProp(results, e.verifyPath),
+        `${e.contentPath} should be encoded`
+      );
+    });
+    expect(results.settings).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR brings in the bulk of the custom Hub Survey Solution processing logic. I'll be submitting one more survey-related PR to address the following:

1. Update the Feature Service & Form items to apply what couldn’t be passed through to the API
2. Investigate/resolve a CORS preflight error related to the S123 API create request (doesn't fail deployment)
3. add a processed template result entry for the Feature Service
4. test updates for 1 & 3