### PR TITLE
ExB and Hub packages at 100% coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14048,7 +14048,7 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "dev": true,
           "requires": {
@@ -14058,13 +14058,13 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "agent-base": {
           "version": "4.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "dev": true,
           "requires": {
@@ -14073,7 +14073,7 @@
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "dev": true,
           "requires": {
@@ -14082,7 +14082,7 @@
         },
         "ajv": {
           "version": "5.5.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
@@ -14094,7 +14094,7 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
@@ -14103,13 +14103,13 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -14118,31 +14118,31 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
@@ -14152,7 +14152,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -14167,7 +14167,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -14178,13 +14178,13 @@
         },
         "asap": {
           "version": "2.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
@@ -14193,37 +14193,37 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "optional": true,
@@ -14233,7 +14233,7 @@
         },
         "bin-links": {
           "version": "1.1.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/eaLaTu7G7/o7PV04QPy1HRT65zf+1tFkPGv0sPTV0tRwufooYBQO3zrcyGgm+ja+ZtBf2GEuKjDRJ2pPG+yqA==",
           "dev": true,
           "requires": {
@@ -14247,13 +14247,13 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
@@ -14268,7 +14268,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -14278,31 +14278,31 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
           "dev": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
           "dev": true
         },
         "cacache": {
           "version": "12.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "dev": true,
           "requires": {
@@ -14325,31 +14325,31 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
@@ -14360,19 +14360,19 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "dev": true,
           "requires": {
@@ -14381,13 +14381,13 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "dev": true,
           "requires": {
@@ -14397,7 +14397,7 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "dev": true,
           "requires": {
@@ -14408,7 +14408,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
@@ -14419,13 +14419,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -14436,13 +14436,13 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "dev": true,
           "requires": {
@@ -14452,19 +14452,19 @@
         },
         "co": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "dev": true,
           "requires": {
@@ -14473,20 +14473,20 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "colors": {
           "version": "1.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
@@ -14496,7 +14496,7 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
@@ -14505,13 +14505,13 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
@@ -14523,7 +14523,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -14538,7 +14538,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -14549,7 +14549,7 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "dev": true,
           "requires": {
@@ -14559,7 +14559,7 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "dev": true,
           "requires": {
@@ -14573,13 +14573,13 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "dev": true,
           "requires": {
@@ -14593,13 +14593,13 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
@@ -14607,13 +14607,13 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
@@ -14622,7 +14622,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -14633,7 +14633,7 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "dev": true,
               "requires": {
@@ -14643,7 +14643,7 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
@@ -14651,19 +14651,19 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
@@ -14672,7 +14672,7 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -14681,7 +14681,7 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
@@ -14689,31 +14689,31 @@
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "dev": true,
           "requires": {
@@ -14722,7 +14722,7 @@
         },
         "define-properties": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
@@ -14731,31 +14731,31 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
@@ -14765,7 +14765,7 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
@@ -14774,19 +14774,19 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "dev": true,
           "requires": {
@@ -14798,7 +14798,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -14813,7 +14813,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -14824,7 +14824,7 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "optional": true,
@@ -14835,13 +14835,13 @@
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "encoding": {
           "version": "0.1.12",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "dev": true,
           "requires": {
@@ -14850,7 +14850,7 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
@@ -14859,19 +14859,19 @@
         },
         "env-paths": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "dev": true
         },
         "err-code": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
           "dev": true
         },
         "errno": {
           "version": "0.1.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "dev": true,
           "requires": {
@@ -14880,7 +14880,7 @@
         },
         "es-abstract": {
           "version": "1.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "dev": true,
           "requires": {
@@ -14893,7 +14893,7 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "dev": true,
           "requires": {
@@ -14904,13 +14904,13 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
           "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "requires": {
@@ -14919,13 +14919,13 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -14940,7 +14940,7 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
@@ -14948,43 +14948,43 @@
         },
         "extend": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -14993,7 +14993,7 @@
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "dev": true,
           "requires": {
@@ -15003,7 +15003,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -15018,7 +15018,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -15029,13 +15029,13 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
@@ -15046,7 +15046,7 @@
         },
         "from2": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "dev": true,
           "requires": {
@@ -15056,7 +15056,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -15071,7 +15071,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -15082,7 +15082,7 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "requires": {
@@ -15091,7 +15091,7 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
@@ -15103,7 +15103,7 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
@@ -15114,7 +15114,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
@@ -15126,13 +15126,13 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -15147,7 +15147,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -15158,19 +15158,19 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
@@ -15186,13 +15186,13 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -15205,13 +15205,13 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
           "dev": true
         },
         "gentle-fs": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3k2CgAmPxuz7S6nKK+AqFE2AdM1QuwqKLPKzIET3VRwK++3q96MsNFobScDjlCrq97ZJ8y5R725MOlm6ffUCjg==",
           "dev": true,
           "requires": {
@@ -15230,13 +15230,13 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
@@ -15244,13 +15244,13 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
@@ -15259,7 +15259,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
@@ -15268,7 +15268,7 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
@@ -15282,7 +15282,7 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
@@ -15291,7 +15291,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -15310,7 +15310,7 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
@@ -15318,19 +15318,19 @@
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "dev": true,
           "requires": {
@@ -15340,7 +15340,7 @@
         },
         "has": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
@@ -15349,37 +15349,37 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
           "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "dev": true,
           "requires": {
@@ -15389,7 +15389,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
@@ -15400,7 +15400,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "dev": true,
           "requires": {
@@ -15410,7 +15410,7 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "dev": true,
           "requires": {
@@ -15419,7 +15419,7 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
@@ -15428,13 +15428,13 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "requires": {
@@ -15443,25 +15443,25 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -15471,19 +15471,19 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "dev": true,
           "requires": {
@@ -15499,31 +15499,31 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "ip": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
           "dev": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
@@ -15532,7 +15532,7 @@
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
               "dev": true
             }
@@ -15540,7 +15540,7 @@
         },
         "is-cidr": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "dev": true,
           "requires": {
@@ -15549,13 +15549,13 @@
         },
         "is-date-object": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -15564,7 +15564,7 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
@@ -15574,19 +15574,19 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
@@ -15595,13 +15595,13 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
@@ -15610,19 +15610,19 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "dev": true,
           "requires": {
@@ -15631,68 +15631,68 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
@@ -15704,7 +15704,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
@@ -15713,13 +15713,13 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
@@ -15728,7 +15728,7 @@
         },
         "libcipm": {
           "version": "4.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fTq33otU3PNXxxCTCYCYe7V96o59v/o7bvtspmbORXpgFk+wcWrGf5x6tBgui5gCed/45/wtPomBsZBYm5KbIw==",
           "dev": true,
           "requires": {
@@ -15751,7 +15751,7 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "dev": true,
           "requires": {
@@ -15779,7 +15779,7 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "dev": true,
           "requires": {
@@ -15791,7 +15791,7 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "dev": true,
           "requires": {
@@ -15802,7 +15802,7 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "dev": true,
               "requires": {
@@ -15811,7 +15811,7 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "dev": true,
               "requires": {
@@ -15821,7 +15821,7 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "dev": true,
               "requires": {
@@ -15830,7 +15830,7 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "dev": true,
               "requires": {
@@ -15839,7 +15839,7 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "dev": true
             }
@@ -15847,7 +15847,7 @@
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "dev": true,
           "requires": {
@@ -15859,7 +15859,7 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "dev": true,
           "requires": {
@@ -15871,7 +15871,7 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "dev": true,
           "requires": {
@@ -15888,7 +15888,7 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "dev": true,
           "requires": {
@@ -15899,7 +15899,7 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "dev": true,
           "requires": {
@@ -15911,7 +15911,7 @@
         },
         "libnpx": {
           "version": "10.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
           "dev": true,
           "requires": {
@@ -15927,7 +15927,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -15937,7 +15937,7 @@
         },
         "lock-verify": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "dev": true,
           "requires": {
@@ -15947,7 +15947,7 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "dev": true,
           "requires": {
@@ -15956,13 +15956,13 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
@@ -15972,19 +15972,19 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
@@ -15993,61 +15993,61 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
           "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
@@ -16056,7 +16056,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
@@ -16065,7 +16065,7 @@
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "dev": true,
           "requires": {
@@ -16084,7 +16084,7 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
@@ -16093,13 +16093,13 @@
         },
         "meant": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
           "dev": true
         },
         "mem": {
           "version": "4.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
@@ -16110,7 +16110,7 @@
           "dependencies": {
             "mimic-fn": {
               "version": "2.1.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
               "dev": true
             }
@@ -16118,13 +16118,13 @@
         },
         "mime-db": {
           "version": "1.35.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "dev": true,
           "requires": {
@@ -16133,7 +16133,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -16142,7 +16142,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "requires": {
@@ -16151,7 +16151,7 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
@@ -16163,7 +16163,7 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
@@ -16181,7 +16181,7 @@
         },
         "mkdirp": {
           "version": "0.5.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
@@ -16190,7 +16190,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
@@ -16198,7 +16198,7 @@
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
@@ -16212,7 +16212,7 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
@@ -16220,25 +16220,25 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "dev": true,
           "requires": {
@@ -16249,7 +16249,7 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "dev": true,
           "requires": {
@@ -16268,7 +16268,7 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "dev": true,
           "requires": {
@@ -16278,7 +16278,7 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
@@ -16290,7 +16290,7 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "dev": true,
               "requires": {
@@ -16301,7 +16301,7 @@
         },
         "npm-audit-report": {
           "version": "1.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
           "dev": true,
           "requires": {
@@ -16311,7 +16311,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "requires": {
@@ -16320,13 +16320,13 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "dev": true,
           "requires": {
@@ -16335,7 +16335,7 @@
         },
         "npm-lifecycle": {
           "version": "3.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
           "dev": true,
           "requires": {
@@ -16351,19 +16351,19 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
           "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "dev": true,
           "requires": {
@@ -16375,7 +16375,7 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "dev": true,
           "requires": {
@@ -16386,7 +16386,7 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "dev": true,
           "requires": {
@@ -16397,7 +16397,7 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "dev": true,
           "requires": {
@@ -16408,7 +16408,7 @@
         },
         "npm-registry-fetch": {
           "version": "4.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6jb34hX/iYNQebqWUHtU8YF6Cjb1H6ouTFPClYsyiW6lpFkljTpdeftm53rRojtja1rKAvKNIIiTS5Sjpw4wsA==",
           "dev": true,
           "requires": {
@@ -16423,7 +16423,7 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
@@ -16431,7 +16431,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -16440,13 +16440,13 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
@@ -16458,31 +16458,31 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "dev": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "dev": true,
           "requires": {
@@ -16492,7 +16492,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -16501,19 +16501,19 @@
         },
         "opener": {
           "version": "1.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
@@ -16524,7 +16524,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
               "requires": {
@@ -16537,7 +16537,7 @@
             },
             "execa": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "dev": true,
               "requires": {
@@ -16554,13 +16554,13 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
@@ -16570,25 +16570,25 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
@@ -16597,7 +16597,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -16606,13 +16606,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
@@ -16624,7 +16624,7 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "dev": true,
           "requires": {
@@ -16662,7 +16662,7 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
@@ -16674,7 +16674,7 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "dev": true,
           "requires": {
@@ -16685,7 +16685,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -16700,7 +16700,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -16711,67 +16711,67 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "dev": true,
           "requires": {
@@ -16781,7 +16781,7 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             }
@@ -16789,7 +16789,7 @@
         },
         "promzard": {
           "version": "0.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "dev": true,
           "requires": {
@@ -16798,13 +16798,13 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
           "dev": true
         },
         "protoduck": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "dev": true,
           "requires": {
@@ -16813,25 +16813,25 @@
         },
         "prr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
@@ -16841,7 +16841,7 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
@@ -16852,7 +16852,7 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "dev": true,
               "requires": {
@@ -16864,25 +16864,25 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "query-string": {
           "version": "6.8.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "dev": true,
           "requires": {
@@ -16893,13 +16893,13 @@
         },
         "qw": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "dev": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
@@ -16911,7 +16911,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
@@ -16919,7 +16919,7 @@
         },
         "read": {
           "version": "1.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
@@ -16928,7 +16928,7 @@
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "dev": true,
           "requires": {
@@ -16937,7 +16937,7 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
@@ -16952,7 +16952,7 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "dev": true,
           "requires": {
@@ -16965,7 +16965,7 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "dev": true,
           "requires": {
@@ -16976,7 +16976,7 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -16987,7 +16987,7 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "dev": true,
           "requires": {
@@ -16999,7 +16999,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "dev": true,
           "requires": {
@@ -17009,7 +17009,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
@@ -17018,7 +17018,7 @@
         },
         "request": {
           "version": "2.88.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "dev": true,
           "requires": {
@@ -17046,31 +17046,31 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
@@ -17079,7 +17079,7 @@
         },
         "run-queue": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "dev": true,
           "requires": {
@@ -17088,7 +17088,7 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
@@ -17096,25 +17096,25 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
@@ -17123,13 +17123,13 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "sha": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "dev": true,
           "requires": {
@@ -17138,7 +17138,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -17147,31 +17147,31 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
           "dev": true
         },
         "socks": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "dev": true,
           "requires": {
@@ -17181,7 +17181,7 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "dev": true,
           "requires": {
@@ -17191,7 +17191,7 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "dev": true,
               "requires": {
@@ -17202,13 +17202,13 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
@@ -17218,7 +17218,7 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
@@ -17228,13 +17228,13 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
@@ -17246,7 +17246,7 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             }
@@ -17254,7 +17254,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
@@ -17264,13 +17264,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
@@ -17280,19 +17280,19 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
           "dev": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
           "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "dev": true,
           "requires": {
@@ -17309,7 +17309,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
@@ -17318,7 +17318,7 @@
         },
         "stream-each": {
           "version": "1.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "dev": true,
           "requires": {
@@ -17328,7 +17328,7 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "dev": true,
           "requires": {
@@ -17338,7 +17338,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -17353,7 +17353,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -17364,19 +17364,19 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
@@ -17386,19 +17386,19 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -17409,7 +17409,7 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
@@ -17418,7 +17418,7 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
@@ -17426,13 +17426,13 @@
         },
         "stringify-package": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -17441,19 +17441,19 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
@@ -17462,7 +17462,7 @@
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "requires": {
@@ -17477,7 +17477,7 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
@@ -17489,7 +17489,7 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
@@ -17498,19 +17498,19 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
@@ -17520,7 +17520,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
@@ -17535,7 +17535,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -17546,19 +17546,19 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
@@ -17568,7 +17568,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -17577,32 +17577,32 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "dev": true,
           "requires": {
@@ -17611,7 +17611,7 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "dev": true,
           "requires": {
@@ -17620,7 +17620,7 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
@@ -17629,19 +17629,19 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "dev": true,
           "requires": {
@@ -17659,7 +17659,7 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
@@ -17668,19 +17668,19 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
           "dev": true
         },
         "util-promisify": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "dev": true,
           "requires": {
@@ -17689,13 +17689,13 @@
         },
         "uuid": {
           "version": "3.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
@@ -17705,7 +17705,7 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
@@ -17714,7 +17714,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
@@ -17725,7 +17725,7 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "dev": true,
           "requires": {
@@ -17734,7 +17734,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
@@ -17743,13 +17743,13 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
@@ -17758,7 +17758,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -17771,7 +17771,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "dev": true,
           "requires": {
@@ -17780,7 +17780,7 @@
         },
         "worker-farm": {
           "version": "1.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "dev": true,
           "requires": {
@@ -17789,7 +17789,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -17799,7 +17799,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -17812,13 +17812,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "requires": {
@@ -17829,31 +17829,31 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         },
         "yargs": {
           "version": "11.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "dev": true,
           "requires": {
@@ -17873,7 +17873,7 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
@@ -17881,7 +17881,7 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {

--- a/packages/hub-types/src/helpers/_post-process-page.ts
+++ b/packages/hub-types/src/helpers/_post-process-page.ts
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { IModel, IHubRequestOptions, interpolate } from "@esri/hub-common";
+import { updatePage } from "@esri/hub-sites";
 
-import { IModel, getProp, maybePush } from "@esri/hub-common";
-
-/**
- * Given an Web Experience model, extract out all the
- * items it depends on from the `dataSources` hash
- * @param model IModel
- */
-export function getWebExperienceDependencies(model: IModel): any[] {
-  const dataSources = getProp(model, "data.dataSources") || {};
-  return Object.keys(dataSources).reduce((acc, key) => {
-    return maybePush(getProp(dataSources, `${key}.itemId`), acc);
-  }, []);
+export function _postProcessPage(
+  pageModel: IModel,
+  itemInfos: any[],
+  templateDictionary: any,
+  hubRequestOptions: IHubRequestOptions
+): Promise<boolean> {
+  // re-interpolate the siteModel using the itemInfos
+  pageModel = interpolate(pageModel, templateDictionary, {});
+  return updatePage(pageModel, hubRequestOptions).then(() => {
+    return true;
+  });
 }

--- a/packages/hub-types/src/helpers/_post-process-site.ts
+++ b/packages/hub-types/src/helpers/_post-process-site.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IModel, IHubRequestOptions } from "@esri/hub-common";
+import { IModel, IHubRequestOptions, interpolate } from "@esri/hub-common";
 
 import {
   _getSecondPassSharingOptions,
@@ -24,10 +24,21 @@ import {
 
 import { _updateSitePages } from "./_update-site-pages";
 
-// TODO Implement in Hub.js
+/**
+ * Post Process a Site
+ * - share all items to the Hub teams created as part of the site
+ * - link any created page to the site item
+ * - re-interpolate any remaining item ids that were not direct deps of the site
+ *
+ * @param siteModel
+ * @param itemInfos
+ * @param templateDictionary
+ * @param hubRequestOptions
+ */
 export function _postProcessSite(
   siteModel: IModel,
   itemInfos: any[],
+  templateDictionary: any,
   hubRequestOptions: IHubRequestOptions
 ): Promise<boolean> {
   // convert the itemInfo's into things that look enough like a model
@@ -60,6 +71,10 @@ export function _postProcessSite(
   // need to get all the child items and add into site.item.properties.children
   const childItemIds = itemInfos.map(i => i.id);
   siteModel.item.properties.children = childItemIds;
+
+  // re-interpolate the siteModel using the itemInfos
+  siteModel = interpolate(siteModel, templateDictionary, {});
+  // and update the model
   secondPassPromises.push(updateSite(siteModel, null, hubRequestOptions));
 
   return Promise.all(secondPassPromises).then(() => {

--- a/packages/hub-types/src/hub-site-processor.ts
+++ b/packages/hub-types/src/hub-site-processor.ts
@@ -213,7 +213,7 @@ export function postProcess(
   return getSiteById(id, hubRo)
     .then(siteModel => {
       // Hub.js does not expect the same structures, so we delegat to a local fn
-      return _postProcessSite(siteModel, itemInfos, hubRo);
+      return _postProcessSite(siteModel, itemInfos, templateDictionary, hubRo);
     })
     .then(() => {
       // resolve w/ a boolean
@@ -227,7 +227,6 @@ export function postProcess(
  * Site Application is for ArcGIS Enterprise
  * @param itemType
  */
-/* istanbul ignore next */
 export function isASite(itemType: string, itemUrl?: string): boolean {
   let result = false;
   if (itemType === "Hub Site Application" || itemType === "Site Application") {

--- a/packages/hub-types/test/helpers/_post-process-page.test.ts
+++ b/packages/hub-types/test/helpers/_post-process-page.test.ts
@@ -1,0 +1,52 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as hubCommon from "@esri/hub-common";
+import * as hubSites from "@esri/hub-sites";
+import * as postProcessPageModule from "../../src/helpers/_post-process-page";
+import { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
+
+describe("_postProcessPage :: ", () => {
+  let model: hubCommon.IModel;
+  beforeEach(() => {
+    model = {
+      item: {
+        id: "3ef",
+        properties: {
+          chk: "{{bc66.itemId}}"
+        }
+      },
+      data: {}
+    } as hubCommon.IModel;
+  });
+  it("does second-pass interpolatin", () => {
+    const fakeRo = {} as hubCommon.IHubRequestOptions;
+    const updatePageSpy = spyOn(hubSites, "updatePage").and.resolveTo(
+      {} as IUpdateItemResponse
+    );
+    return postProcessPageModule
+      ._postProcessPage(model, [], { bc66: { itemId: "ef66" } }, fakeRo)
+      .then(result => {
+        expect(result).toBe(true, "should return true");
+        expect(updatePageSpy.calls.count()).toBe(1, "should update the site");
+        const updateModel = updatePageSpy.calls.argsFor(0)[0];
+        expect(updateModel.item.properties.chk).toBe(
+          "ef66",
+          "it should do a second pass interpolation before updating"
+        );
+      });
+  });
+});

--- a/packages/hub-types/test/helpers/_post-process-site.test.ts
+++ b/packages/hub-types/test/helpers/_post-process-site.test.ts
@@ -17,10 +17,7 @@ import * as hubCommon from "@esri/hub-common";
 import * as hubSites from "@esri/hub-sites";
 import * as postProcessSiteModule from "../../src/helpers/_post-process-site";
 import * as updateSitePagesModule from "../../src/helpers/_update-site-pages";
-import {
-  IItemUpdate,
-  IUpdateItemResponse
-} from "../../../common/node_modules/@esri/arcgis-rest-portal/dist/esm";
+import { IUpdateItemResponse } from "@esri/arcgis-rest-portal";
 
 describe("_postProcessSite :: ", () => {
   let model: hubCommon.IModel;
@@ -31,7 +28,8 @@ describe("_postProcessSite :: ", () => {
         id: "3ef",
         properties: {
           collaborationGroupId: "bc1-collab",
-          contentGroupId: "bc1-collab"
+          contentGroupId: "bc1-collab",
+          chk: "{{bc66.itemId}}"
         }
       },
       data: {}
@@ -61,7 +59,7 @@ describe("_postProcessSite :: ", () => {
       {} as IUpdateItemResponse
     );
     return postProcessSiteModule
-      ._postProcessSite(model, infos, fakeRo)
+      ._postProcessSite(model, infos, { bc66: { itemId: "ef66" } }, fakeRo)
       .then(result => {
         expect(result).toBe(true, "should return true");
         expect(shareSpy.calls.count()).toBe(1, "should call share fn once");
@@ -74,6 +72,11 @@ describe("_postProcessSite :: ", () => {
           "should call _updateSitePages"
         );
         expect(updateSiteSpy.calls.count()).toBe(1, "should update the site");
+        const updateModel = updateSiteSpy.calls.argsFor(0)[0];
+        expect(updateModel.item.properties.chk).toBe(
+          "ef66",
+          "it should do a second pass interpolation before updating"
+        );
       });
   });
 });

--- a/packages/hub-types/test/hub-site-processor.test.ts
+++ b/packages/hub-types/test/hub-site-processor.test.ts
@@ -296,4 +296,17 @@ describe("HubSiteProcessor: ", () => {
       });
     });
   });
+  describe("isASite :: ", () => {
+    it("recognizes both types", () => {
+      expect(HubSiteProcessor.isASite("Hub Site Application")).toBe(
+        true,
+        "Ago Type"
+      );
+      expect(HubSiteProcessor.isASite("Site Application")).toBe(
+        true,
+        "Portal type"
+      );
+      expect(HubSiteProcessor.isASite("Web Map")).toBe(false, "other type");
+    });
+  });
 });

--- a/packages/web-experience/package-lock.json
+++ b/packages/web-experience/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@esri/solution-web-experience",
-	"version": "0.16.2",
+	"version": "0.16.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/web-experience/src/helpers/convert-web-experience-to-template.ts
+++ b/packages/web-experience/src/helpers/convert-web-experience-to-template.ts
@@ -31,11 +31,14 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 import { getWebExperienceDependencies } from "./get-web-experience-dependencies";
 
 /**
+ * Convert an Experience item into a template
+ *
+ * Pretty simpler conversion - remove extra item props, extract out
+ * items from the data.dataSources hash.
  *
  * @param model
  * @param authentication
  */
-/* istanbul ignore next */
 export function convertWebExperienceToTemplate(
   model: IModel,
   authentication: UserSession // not currently used

--- a/packages/web-experience/src/helpers/create-web-experience-model-from-template.ts
+++ b/packages/web-experience/src/helpers/create-web-experience-model-from-template.ts
@@ -23,7 +23,6 @@ import { UserSession } from "@esri/arcgis-rest-auth";
  * @param transforms Hash of transform functions to use in the interpolation
  * @param authentication UserSession
  */
-/* istanbul ignore next */
 export function createWebExperienceModelFromTemplate(
   templateModel: IModelTemplate,
   settings: any,

--- a/packages/web-experience/src/helpers/create-web-experience.ts
+++ b/packages/web-experience/src/helpers/create-web-experience.ts
@@ -17,7 +17,6 @@ import {
   IModel,
   cloneObject,
   failSafe,
-  failSafeUpdate,
   serializeModel,
   interpolateItemId,
   stringToBlob
@@ -27,11 +26,17 @@ import { UserSession } from "@esri/arcgis-rest-auth";
 
 import {
   createItem,
+  updateItem,
   addItemResource,
   ICreateItemResponse
 } from "@esri/arcgis-rest-portal";
 
-/* istanbul ignore next */
+/**
+ * Given a Model for a Web Experience, create the item in the Portal API
+ * @param model
+ * @param options
+ * @param authentication
+ */
 export function createWebExperience(
   model: IModel,
   options: any,
@@ -69,7 +74,10 @@ export function createWebExperience(
         delete model.properties;
         // update the experience with the newly interpolated model
         return Promise.all([
-          failSafeUpdate(model, { authentication }),
+          updateItem({
+            item: serializeModel(model),
+            authentication
+          }),
           authentication.getUsername()
         ]);
       })

--- a/packages/web-experience/src/helpers/get-experience-subdomain.ts
+++ b/packages/web-experience/src/helpers/get-experience-subdomain.ts
@@ -1,9 +1,30 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { UserSession } from "@esri/arcgis-rest-auth";
-/* istanbul ignore next */
-export function getExperieceSubdomain(authentication: UserSession): string {
+
+/**
+ * Returns the subdomain for an experience based on the  api the session is
+ * authenticated against
+ *
+ * @param authentication UserSession
+ */
+export function getExperienceSubdomain(authentication: UserSession): string {
   const portalUrl =
     authentication.portal || "https://www.arcgis.com/sharing/rest";
-  // TODO: Sort out how we locate storymaps on portal?
+  // TODO: Sort out how we locate experiences on portal?
   let result;
   if (portalUrl.match(/(qaext|\.mapsqa)\.arcgis.com/)) {
     result = "experienceqa";

--- a/packages/web-experience/test/fixtures/exb-map-and-images.ts
+++ b/packages/web-experience/test/fixtures/exb-map-and-images.ts
@@ -1,0 +1,1155 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IModel } from "@esri/hub-common";
+
+export const ExBee = {
+  item: {
+    id: "c87cb08010db4e88aa90f612cba7f6f2",
+    owner: "dbouwman_dc",
+    created: 1591125474000,
+    isOrgItem: true,
+    modified: 1591641968000,
+    guid: null,
+    name: null,
+    title: "ExBee DC",
+    type: "Web Experience",
+    typeKeywords: [
+      "EXB Experience",
+      "hubSolution",
+      "JavaScript",
+      "Ready To Use",
+      "status: Changed",
+      "Web Application",
+      "Web Experience",
+      "Web Mapping Application",
+      "Web Page",
+      "Web Site"
+    ],
+    description: null,
+    tags: [],
+    snippet: null,
+    thumbnail: null,
+    documentation: null,
+    extent: [],
+    categories: [],
+    spatialReference: null,
+    accessInformation: null,
+    licenseInfo: null,
+    culture: "en-us",
+    properties: {
+      parentId: "dd1fe4c8772f477fb2b3d9bf0a15689f",
+      source: "dd1fe4c8772f477fb2b3d9bf0a15689f",
+      children: ["8644de121e434a368a6221c0498e4e47"]
+    },
+    url: null,
+    proxyFilter: null,
+    access: "shared",
+    size: 159492,
+    appCategories: [],
+    industries: [],
+    languages: [],
+    largeThumbnail: null,
+    banner: null,
+    screenshots: [],
+    listed: false,
+    ownerFolder: null,
+    protected: false,
+    commentsEnabled: true,
+    numComments: 0,
+    numRatings: 0,
+    avgRating: 0,
+    numViews: 8,
+    itemControl: "admin",
+    scoreCompleteness: 16,
+    groupDesignations: null
+  },
+  data: {
+    pages: {
+      home: {
+        type: "NORMAL",
+        mode: "FIT_WINDOW",
+        layout: {
+          LARGE: "home-layout-large",
+          SMALL: "layout_5",
+          MEDIUM: "layout_10"
+        },
+        isVisible: true,
+        id: "home",
+        isDefault: true,
+        label: "Page 1"
+      }
+    },
+    layouts: {
+      "home-layout-large": {
+        type: "FIXED",
+        order: ["0", "1", "2", "3", "4"],
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: "0px",
+              top: "0px",
+              width: "71.3715%",
+              height: "60px",
+              right: "0px"
+            },
+            widgetId: "widget_1",
+            setting: {
+              vCenter: false,
+              hCenter: false,
+              autoProps: {
+                width: true
+              }
+            }
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {
+              left: 0,
+              top: "60px",
+              width: "76.6101%",
+              height: "92.5000%",
+              right: "299px",
+              bottom: 0
+            },
+            widgetId: "widget_6",
+            setting: {
+              autoProps: {
+                width: true,
+                height: true,
+                left: false,
+                bottom: false
+              },
+              vCenter: false,
+              hCenter: false,
+              order: 0,
+              lockParent: false,
+              lockLayout: false
+            },
+            isPending: true
+          },
+          "2": {
+            type: "WIDGET",
+            bbox: {
+              left: 668,
+              top: 156,
+              width: "43.0469%",
+              height: "62.5000%",
+              right: 61,
+              bottom: 144
+            },
+            widgetId: "widget_11",
+            setting: {
+              autoProps: {
+                right: false,
+                left: false,
+                bottom: false,
+                top: false,
+                height: true,
+                width: true
+              },
+              vCenter: false,
+              hCenter: false,
+              order: 0,
+              lockParent: false,
+              lockLayout: false
+            },
+            isPending: true
+          },
+          "3": {
+            type: "WIDGET",
+            bbox: {
+              left: "76.5625%",
+              top: "7.5000%",
+              width: "23.4375%",
+              height: "37.5000%",
+              right: 0,
+              bottom: "55.0000%"
+            },
+            widgetId: "widget_12",
+            setting: {
+              autoProps: {
+                right: false,
+                left: true,
+                top: false,
+                bottom: true
+              },
+              vCenter: false,
+              hCenter: false
+            },
+            isPending: false
+          },
+          "4": {
+            type: "WIDGET",
+            bbox: {
+              left: 0,
+              top: "7.5000%",
+              width: "76.7340%",
+              height: "82.5283%",
+              bottom: "9.9717%",
+              right: 297.8046875
+            },
+            widgetId: "widget_13",
+            setting: {
+              autoProps: {
+                right: true,
+                left: false,
+                top: false,
+                bottom: true
+              },
+              order: 0,
+              lockParent: false,
+              lockLayout: false
+            }
+          }
+        }
+      },
+      layout_1: {
+        type: "FIXED",
+        order: ["0", "1", "2", "3"],
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: "14px",
+              top: "11px",
+              width: "36px",
+              height: "36px"
+            },
+            widgetId: "widget_2",
+            isPending: false,
+            setting: {
+              vCenter: true,
+              hCenter: false
+            }
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {
+              left: "90px",
+              top: "0px",
+              width: "279px",
+              height: "42px",
+              bottom: "0px"
+            },
+            widgetId: "widget_3",
+            setting: {
+              vCenter: true
+            }
+          },
+          "2": {
+            type: "WIDGET",
+            bbox: {
+              left: "392px",
+              top: "0px",
+              width: "210px",
+              height: "32px",
+              bottom: "0px"
+            },
+            widgetId: "widget_4",
+            isPending: false,
+            setting: {
+              vCenter: true,
+              hCenter: false
+            }
+          },
+          "3": {
+            type: "WIDGET",
+            bbox: {
+              left: "889px",
+              top: "0px",
+              width: "300px",
+              height: "50px",
+              right: "0px",
+              bottom: "0px"
+            },
+            widgetId: "widget_5",
+            setting: {
+              autoProps: {
+                left: true,
+                height: true
+              }
+            }
+          }
+        },
+        label: "Default"
+      },
+      layout_2: {
+        type: "FIXED",
+        order: ["0", "1"],
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {},
+            widgetId: "widget_8"
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {},
+            widgetId: "widget_9"
+          }
+        },
+        label: "Controller layout"
+      },
+      layout_3: {
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: 0,
+              top: 0,
+              bottom: 0,
+              right: 0
+            }
+          }
+        },
+        order: ["0"],
+        label: "Open widget layout"
+      },
+      layout_4: {
+        type: "FIXED",
+        label: "Map FixedLayout"
+      },
+      layout_5: {
+        type: "FIXED",
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: "0px",
+              top: "0px",
+              width: "71.3715%",
+              height: "60px",
+              right: "0px"
+            },
+            widgetId: "widget_7",
+            setting: {
+              vCenter: false,
+              hCenter: false,
+              autoProps: {
+                width: true
+              }
+            }
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {
+              left: "0px",
+              top: "60px",
+              width: "31.2500%",
+              height: "52%",
+              right: "0px",
+              bottom: "0px"
+            },
+            widgetId: "widget_6",
+            setting: {
+              autoProps: {
+                width: true,
+                height: true
+              }
+            }
+          }
+        },
+        order: ["0", "1"]
+      },
+      layout_6: {
+        type: "FIXED",
+        label: "Map FixedLayout"
+      },
+      layout_7: {
+        type: "FIXED",
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: "14px",
+              top: "11px",
+              width: "36px",
+              height: "36px"
+            },
+            widgetId: "widget_2",
+            isPending: false,
+            setting: {
+              vCenter: true,
+              hCenter: false
+            }
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {
+              left: "90px",
+              top: "3px",
+              width: "279px",
+              height: "48px",
+              bottom: "1px"
+            },
+            widgetId: "widget_3",
+            setting: {
+              autoProps: {
+                height: true
+              },
+              hCenter: false
+            },
+            isPending: true
+          },
+          "2": {
+            type: "WIDGET",
+            bbox: {
+              left: "392px",
+              top: "0px",
+              width: "210px",
+              height: "48px",
+              bottom: "0px"
+            },
+            widgetId: "widget_4",
+            isPending: true,
+            setting: {
+              vCenter: false,
+              hCenter: false,
+              autoProps: {
+                height: true
+              }
+            }
+          },
+          "3": {
+            type: "WIDGET",
+            bbox: {
+              left: "282px",
+              top: "0px",
+              width: "200px",
+              height: "46px",
+              right: "0px",
+              bottom: "0px"
+            },
+            widgetId: "widget_5",
+            setting: {
+              autoProps: {
+                left: true,
+                height: true
+              },
+              hCenter: false,
+              vCenter: false
+            },
+            isPending: false
+          }
+        },
+        order: ["0", "1", "2", "3"],
+        label: "Default"
+      },
+      layout_8: {
+        type: "FIXED",
+        order: ["0", "1"],
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {},
+            widgetId: "widget_8"
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {},
+            widgetId: "widget_9"
+          }
+        },
+        label: "Controller layout"
+      },
+      layout_9: {
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: 0,
+              top: 0,
+              bottom: 0,
+              right: 0
+            }
+          }
+        },
+        order: ["0"],
+        label: "Open widget layout"
+      },
+      layout_10: {
+        type: "FIXED",
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: "0px",
+              top: "0px",
+              width: "71.3715%",
+              height: "60px",
+              right: "0px"
+            },
+            widgetId: "widget_10",
+            setting: {
+              vCenter: false,
+              hCenter: false,
+              autoProps: {
+                width: true
+              }
+            }
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {
+              left: "0px",
+              top: "60px",
+              width: "31.2500%",
+              height: "52%",
+              right: "0px",
+              bottom: "0px"
+            },
+            widgetId: "widget_6",
+            setting: {
+              autoProps: {
+                width: true,
+                height: true
+              }
+            }
+          }
+        },
+        order: ["0", "1"]
+      },
+      layout_11: {
+        type: "FIXED",
+        label: "Map FixedLayout"
+      },
+      layout_12: {
+        type: "FIXED",
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: "14px",
+              top: "11px",
+              width: "36px",
+              height: "36px"
+            },
+            widgetId: "widget_2",
+            isPending: false,
+            setting: {
+              vCenter: true,
+              hCenter: false
+            }
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {
+              left: "90px",
+              top: "0px",
+              width: "279px",
+              height: "42px",
+              bottom: "0px"
+            },
+            widgetId: "widget_3",
+            setting: {
+              vCenter: true
+            }
+          },
+          "2": {
+            type: "WIDGET",
+            bbox: {
+              left: "392px",
+              top: "0px",
+              width: "210px",
+              height: "32px",
+              bottom: "0px"
+            },
+            widgetId: "widget_4",
+            isPending: true,
+            setting: {
+              vCenter: true,
+              hCenter: false
+            }
+          },
+          "3": {
+            type: "WIDGET",
+            bbox: {
+              left: "889px",
+              top: "0px",
+              width: "300px",
+              height: "50px",
+              right: "0px",
+              bottom: "0px"
+            },
+            widgetId: "widget_5",
+            setting: {
+              autoProps: {
+                left: true,
+                height: true
+              }
+            }
+          }
+        },
+        order: ["0", "1", "2", "3"],
+        label: "Default"
+      },
+      layout_13: {
+        type: "FIXED",
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {},
+            widgetId: "widget_8"
+          },
+          "1": {
+            type: "WIDGET",
+            bbox: {},
+            widgetId: "widget_9"
+          }
+        },
+        order: ["0", "1"],
+        label: "Controller layout"
+      },
+      layout_14: {
+        content: {
+          "0": {
+            type: "WIDGET",
+            bbox: {
+              left: 0,
+              top: 0,
+              bottom: 0,
+              right: 0
+            }
+          }
+        },
+        order: ["0"],
+        label: "Open widget layout"
+      },
+      layout_15: {
+        type: "FIXED",
+        label: "Map FixedLayout"
+      }
+    },
+    widgets: {
+      widget_1: {
+        id: "widget_1",
+        uri: "widgets/layout/fixed/",
+        config: {},
+        layouts: {
+          DEFAULT: {
+            LARGE: "layout_1"
+          }
+        },
+        style: {
+          background: {
+            image: {
+              url: ""
+            },
+            color: "var(--primary-700)"
+          },
+          boxShadow: {
+            offsetX: {
+              distance: 0,
+              unit: "px"
+            },
+            offsetY: {
+              distance: 2,
+              unit: "px"
+            },
+            blur: {
+              distance: 4,
+              unit: "px"
+            },
+            spread: {
+              distance: 0,
+              unit: "px"
+            },
+            color: "rgba(0,0,0,0.5)"
+          }
+        },
+        version: "1.0.0",
+        label: "Fixed Panel 2"
+      },
+      widget_2: {
+        id: "widget_2",
+        uri: "widgets/common/image/",
+        config: {
+          functionConfig: {
+            altText: "",
+            toolTip: "",
+            linkParam: {},
+            scale: "Fit",
+            imageParam: {
+              cropParam: {
+                cropShape: "circle",
+                svgPath:
+                  "M28 14c0 7.732-6.268 14-14 14S0 21.732 0 14 6.268 0 14 0s14 6.268 14 14z",
+                svgViewBox: "0 0 28 28"
+              }
+            }
+          },
+          styleConfig: {}
+        },
+        version: "1.0.0",
+        label: "Image 1"
+      },
+      widget_3: {
+        id: "widget_3",
+        uri: "widgets/common/text/",
+        config: {
+          text: "<p></p>",
+          placeholder:
+            '<p><span style="font-size: 24px; color: rgb(255, 255, 255);">Here is the title</span></p>',
+          style: {
+            verticalAlign: "center",
+            wrap: true,
+            overflow: "scroll",
+            padding: "p-1"
+          }
+        },
+        version: "1.0.0",
+        label: "Text 1"
+      },
+      widget_4: {
+        id: "widget_4",
+        uri: "widgets/common/text/",
+        config: {
+          text: "<p></p>",
+          placeholder:
+            '<p><span style="font-size: 16px; color: rgb(255, 255, 255);">Here is the subtitle</span></p>',
+          style: {
+            verticalAlign: "center",
+            wrap: true,
+            overflow: "scroll",
+            padding: "p-1"
+          }
+        },
+        version: "1.0.0",
+        label: "Text 2"
+      },
+      widget_5: {
+        id: "widget_5",
+        uri: "widgets/common/controller/",
+        config: {
+          behavior: {
+            onlyOpenOne: true,
+            displayType: "STACK",
+            vertical: false,
+            size: {}
+          },
+          appearance: {
+            space: 10,
+            advanced: false,
+            card: {
+              showLabel: false,
+              labelGrowth: 0,
+              avatar: {
+                type: "primary",
+                size: "default",
+                shape: "rectangle"
+              }
+            }
+          }
+        },
+        layouts: {
+          controller: {
+            LARGE: "layout_2",
+            SMALL: "layout_8",
+            MEDIUM: "layout_13"
+          },
+          _openwidget: {
+            LARGE: "layout_3",
+            SMALL: "layout_9",
+            MEDIUM: "layout_14"
+          }
+        },
+        widgets: ["widget_8", "widget_9"],
+        version: "1.0.0",
+        label: "Widget Controller 1"
+      },
+      widget_6: {
+        id: "widget_6",
+        uri: "widgets/arcgis/arcgis-map/",
+        config: {
+          toolConifg: {
+            canZoom: true,
+            canHome: true,
+            canSearch: true
+          },
+          initialMapDataSourceID: "dataSource_1",
+          isUseCustomMapState: true,
+          initialMapState: {
+            viewPoint: {
+              rotation: 0,
+              scale: 288895.277144,
+              targetGeometry: {
+                spatialReference: {
+                  latestWkid: 3857,
+                  wkid: 102100
+                },
+                x: -8574474.640490731,
+                y: 4705977.340806294
+              }
+            },
+            extent: {
+              spatialReference: {
+                latestWkid: 3857,
+                wkid: 102100
+              },
+              xmin: -8615024.483995963,
+              ymin: 4675402.529492265,
+              xmax: -8533924.7969855,
+              ymax: 4736552.152120324
+            },
+            rotation: 0,
+            viewType: "2d"
+          }
+        },
+        layouts: {
+          MapFixedLayout: {
+            LARGE: "layout_4",
+            SMALL: "layout_6",
+            MEDIUM: "layout_11"
+          }
+        },
+        version: "1.0.0",
+        label: "Map 1",
+        useDataSources: [
+          {
+            dataSourceId: "dataSource_1"
+          }
+        ]
+      },
+      widget_7: {
+        id: "widget_7",
+        uri: "widgets/layout/fixed/",
+        config: {},
+        layouts: {
+          DEFAULT: {
+            SMALL: "layout_7"
+          }
+        },
+        style: {
+          background: {
+            image: {
+              url: ""
+            },
+            color: "var(--primary-700)"
+          },
+          boxShadow: {
+            offsetX: {
+              distance: 0,
+              unit: "px"
+            },
+            offsetY: {
+              distance: 2,
+              unit: "px"
+            },
+            blur: {
+              distance: 4,
+              unit: "px"
+            },
+            spread: {
+              distance: 0,
+              unit: "px"
+            },
+            color: "rgba(0,0,0,0.5)"
+          }
+        },
+        version: "1.0.0",
+        label: "Fixed Panel 3"
+      },
+      widget_8: {
+        id: "widget_8",
+        uri: "widgets/arcgis/map-layers/",
+        config: {
+          useMapWidget: true
+        },
+        useMapWidgetIds: ["widget_6"],
+        version: "1.0.0",
+        label: "Map Layers 1"
+      },
+      widget_9: {
+        id: "widget_9",
+        uri: "widgets/arcgis/legend/",
+        config: {},
+        useMapWidgetIds: ["widget_6"],
+        version: "1.0.0",
+        label: "Legend 1"
+      },
+      widget_10: {
+        id: "widget_10",
+        uri: "widgets/layout/fixed/",
+        config: {},
+        layouts: {
+          DEFAULT: {
+            MEDIUM: "layout_12"
+          }
+        },
+        style: {
+          background: {
+            image: {
+              url: ""
+            },
+            color: "var(--primary-700)"
+          },
+          boxShadow: {
+            offsetX: {
+              distance: 0,
+              unit: "px"
+            },
+            offsetY: {
+              distance: 2,
+              unit: "px"
+            },
+            blur: {
+              distance: 4,
+              unit: "px"
+            },
+            spread: {
+              distance: 0,
+              unit: "px"
+            },
+            color: "rgba(0,0,0,0.5)"
+          }
+        },
+        version: "1.0.0",
+        label: "Fixed Panel 1"
+      },
+      widget_11: {
+        uri: "widgets/common/image/",
+        version: "1.0.0",
+        label: "Image 2",
+        config: {
+          functionConfig: {
+            altText: "",
+            toolTip: "",
+            linkParam: {},
+            scale: "Fit",
+            imageParam: {}
+          },
+          styleConfig: {}
+        },
+        id: "widget_11"
+      },
+      widget_12: {
+        uri: "widgets/common/image/",
+        version: "1.0.0",
+        label: "Image 3",
+        config: {
+          functionConfig: {
+            altText: "",
+            toolTip: "",
+            linkParam: {},
+            scale: "Fit",
+            imageParam: {
+              url: "${appResourceUrl}/images/widget_12/1591117415261.jpg",
+              originalUrl:
+                "${appResourceUrl}/images/widget_12/1591117415261.jpg",
+              fileName: "1591117415261.jpg",
+              originalName: "lego-dumpster-fire.jpg",
+              imgSourceType: "BY_UPLOAD",
+              fileFormat: "image/jpeg",
+              originalId: "1591117415261"
+            },
+            imgSourceType: "",
+            srcExpression: null
+          },
+          styleConfig: {}
+        },
+        id: "widget_12"
+      },
+      widget_13: {
+        uri: "widgets/arcgis/arcgis-map/",
+        version: "1.0.0",
+        label: "Map 2",
+        config: {
+          toolConifg: {
+            canZoom: true,
+            canHome: true,
+            canSearch: true
+          },
+          isUseCustomMapState: true,
+          initialMapDataSourceID: "dataSource_1",
+          initialMapState: {
+            viewPoint: {
+              rotation: 0,
+              scale: 288895.277144,
+              targetGeometry: {
+                spatialReference: {
+                  latestWkid: 3857,
+                  wkid: 102100
+                },
+                x: -8568377.085952524,
+                y: 4703332.779070709
+              }
+            },
+            extent: {
+              spatialReference: {
+                latestWkid: 3857,
+                wkid: 102100
+              },
+              xmin: -8613857.117782142,
+              ymin: 4672757.967756679,
+              xmax: -8522897.054122906,
+              ymax: 4733907.5903847385
+            },
+            rotation: 0,
+            viewType: "2d"
+          }
+        },
+        id: "widget_13",
+        layouts: {
+          MapFixedLayout: {
+            LARGE: "layout_15"
+          }
+        },
+        useDataSources: [
+          {
+            dataSourceId: "dataSource_1"
+          }
+        ]
+      }
+    },
+    exbVersion: "1.0.0",
+    mainSizeMode: "LARGE",
+    theme: "themes/default/",
+    forBuilderAttributes: {
+      lockLayout: false
+    },
+    template: "foldable",
+    attributes: {
+      portalUrl: "https://dc.mapsqa.arcgis.com"
+    },
+    themeManifest: {
+      name: "default",
+      label: "Default",
+      type: "theme",
+      "thumbnails ": [],
+      colors: {
+        primary: "#315dfc",
+        secondary: "#00c3cc",
+        success: "#00cca5",
+        info: "#09acf8",
+        warning: "#ffab21",
+        danger: "#f6146f",
+        light: "#fafbfc",
+        dark: "#2d3235"
+      },
+      font: {
+        fontFamily: "Avenir Next",
+        color: "#fff"
+      },
+      version: "1.0.0",
+      exbVersion: "1.0.0",
+      supportedLocales: [
+        "en",
+        "ar",
+        "bs",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fi",
+        "fr",
+        "he",
+        "hr",
+        "hu",
+        "id",
+        "it",
+        "ja",
+        "ko",
+        "lt",
+        "lv",
+        "nb",
+        "nl",
+        "pl",
+        "pt-br",
+        "pt-pt",
+        "ro",
+        "ru",
+        "sl",
+        "sr",
+        "sv",
+        "th",
+        "tr",
+        "zh-cn",
+        "uk",
+        "vi",
+        "zh-hk",
+        "zh-tw"
+      ],
+      translatedLocales: [
+        "en",
+        "ar",
+        "bs",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fi",
+        "fr",
+        "he",
+        "hr",
+        "hu",
+        "id",
+        "it",
+        "ja",
+        "ko",
+        "lt",
+        "lv",
+        "nb",
+        "nl",
+        "pl",
+        "pt-br",
+        "pt-pt",
+        "ro",
+        "ru",
+        "sl",
+        "sr",
+        "sv",
+        "th",
+        "tr",
+        "zh-cn",
+        "uk",
+        "vi",
+        "zh-hk",
+        "zh-tw"
+      ],
+      styleFiles: {
+        css: false,
+        js: false
+      }
+    },
+    widgetsManifest: {},
+    views: {},
+    sections: {},
+    dialogs: {},
+    dataSources: {
+      dataSource_1: {
+        type: "WEB_MAP",
+        itemId: "8644de121e434a368a6221c0498e4e47",
+        id: "dataSource_1",
+        label: "Museums in DC",
+        portalUrl: "https://dc.mapsqa.arcgis.com"
+      }
+    },
+    messageConfigs: {},
+    pageStructure: [
+      {
+        home: []
+      }
+    ]
+  }
+} as IModel;

--- a/packages/web-experience/test/helpers/convert-web-experience-to-template.test.ts
+++ b/packages/web-experience/test/helpers/convert-web-experience-to-template.test.ts
@@ -1,0 +1,71 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cloneObject, without } from "@esri/hub-common";
+
+import { convertWebExperienceToTemplate } from "../../src/helpers/convert-web-experience-to-template";
+import * as utils from "../../../common/test/mocks/utils";
+
+import { ExBee } from "../fixtures/exb-map-and-images";
+
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("convertWebExperienceToTemplate :: ", () => {
+  it("converts to a template and extracts dependencies", () => {
+    const model = cloneObject(ExBee);
+
+    return convertWebExperienceToTemplate(model, MOCK_USER_SESSION).then(
+      tmpl => {
+        ["itemId", "type", "item", "data", "dependencies"].forEach(p => {
+          expect(tmpl[p]).toBeDefined(`should have ${p} prop defined`);
+        });
+        expect(
+          tmpl.item.typeKeywords.indexOf(`status: Published`)
+        ).toBeGreaterThan(-1, "should have published keyword");
+        expect(tmpl.item.typeKeywords.indexOf(`status: Changed`)).toBe(
+          -1,
+          "should not have changed keyword"
+        );
+        expect(tmpl.dependencies.length).toBe(1, "should extract the webmap");
+        expect(tmpl.dependencies[0]).toBe(
+          "8644de121e434a368a6221c0498e4e47",
+          "should extract the webmap id"
+        );
+      }
+    );
+  });
+
+  it("other keyword paths", () => {
+    const model = cloneObject(ExBee);
+    // ExB's will always have either status: Changed OR status: Published
+    model.item.typeKeywords = without(
+      model.item.typeKeywords,
+      "status: Changed"
+    );
+    model.item.typeKeywords.push("status: Published");
+    return convertWebExperienceToTemplate(model, MOCK_USER_SESSION).then(
+      tmpl => {
+        expect(
+          tmpl.item.typeKeywords.indexOf(`status: Published`)
+        ).toBeGreaterThan(-1, "should have published keyword");
+        expect(tmpl.item.typeKeywords.indexOf(`status: Changed`)).toBe(
+          -1,
+          "should not have changed keyword"
+        );
+      }
+    );
+  });
+});

--- a/packages/web-experience/test/helpers/create-web-experience-model-from-template.test.ts
+++ b/packages/web-experience/test/helpers/create-web-experience-model-from-template.test.ts
@@ -1,0 +1,59 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createWebExperienceModelFromTemplate } from "../../src/helpers/create-web-experience-model-from-template";
+import * as hubModule from "@esri/hub-common";
+
+import * as utils from "@esri/solution-common/test/mocks/utils";
+import { IItem } from "@esri/solution-common";
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("createWebExperienceModelFromTemplate :: ", () => {
+  it("interpolates values", () => {
+    const adlibSpy = spyOn(hubModule, "interpolate").and.callThrough();
+    const tmpl = {
+      itemId: "bc3",
+      type: "Web Experience",
+      key: "foo",
+      item: {
+        properties: {
+          key: "{{val}}"
+        }
+      } as IItem,
+      data: {
+        chk: `{{val2}}`
+      }
+    } as hubModule.IModelTemplate;
+
+    const settings = {
+      val: "rabbit",
+      val2: "cat"
+    };
+    return createWebExperienceModelFromTemplate(
+      tmpl,
+      settings,
+      {},
+      MOCK_USER_SESSION
+    ).then(model => {
+      expect(model.item.properties.key).toBe(
+        "rabbit",
+        "should interpolate item"
+      );
+      expect(model.data.chk).toBe("cat", "should interpolate data");
+      expect(adlibSpy.calls.count()).toBe(1, "should interpolate");
+    });
+  });
+});

--- a/packages/web-experience/test/helpers/create-web-experience.test.ts
+++ b/packages/web-experience/test/helpers/create-web-experience.test.ts
@@ -1,0 +1,96 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as portalModule from "@esri/arcgis-rest-portal";
+import * as hubCommonModule from "@esri/hub-common";
+import * as utils from "../../../common/test/mocks/utils";
+import { createWebExperience } from "../../src/helpers/create-web-experience";
+
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("createWebExperience :: ", () => {
+  let createItemSpy: jasmine.Spy;
+  let interpolateIdSpy: jasmine.Spy;
+  let updateItemSpy: jasmine.Spy;
+  let addResSpy: jasmine.Spy;
+  beforeEach(() => {
+    createItemSpy = spyOn(portalModule, "createItem").and.resolveTo({
+      id: "bc3",
+      folder: "some-folder",
+      success: true
+    });
+    interpolateIdSpy = spyOn(
+      hubCommonModule,
+      "interpolateItemId"
+    ).and.callThrough();
+    updateItemSpy = spyOn(portalModule, "updateItem").and.resolveTo({
+      id: "bc3",
+      success: true
+    });
+    addResSpy = spyOn(portalModule, "addItemResource").and.resolveTo({
+      itemId: "bc3",
+      owner: "casey",
+      folder: "",
+      success: true
+    });
+  });
+
+  // Blobs are only available in the browser
+  if (typeof window !== "undefined") {
+    it("happy-path", () => {
+      const model = {
+        item: {} as portalModule.IItem,
+        data: {
+          some: "properties" // we don't care much what's in here
+        },
+        properties: {
+          imageResourcesList: {
+            another: "property" // again, can be whatever
+          }
+        }
+      } as hubCommonModule.IModel;
+
+      return createWebExperience(model, {}, MOCK_USER_SESSION).then(result => {
+        expect(createItemSpy.calls.count()).toBe(1, "should create the item");
+        expect(interpolateIdSpy.calls.count()).toBe(
+          1,
+          "should call interpolateId"
+        );
+        expect(updateItemSpy.calls.count()).toBe(1, "should call updateItem");
+        expect(addResSpy.calls.count()).toBe(2, "should add three resources");
+      });
+    });
+
+    it("no image resources", () => {
+      const model = {
+        item: {} as portalModule.IItem,
+        data: {
+          some: "properties" // we don't care much what's in here
+        },
+        properties: {}
+      } as hubCommonModule.IModel;
+
+      return createWebExperience(model, {}, MOCK_USER_SESSION).then(result => {
+        expect(createItemSpy.calls.count()).toBe(1, "should create the item");
+        expect(interpolateIdSpy.calls.count()).toBe(
+          1,
+          "should call interpolateId"
+        );
+        expect(updateItemSpy.calls.count()).toBe(1, "should call updateItem");
+        expect(addResSpy.calls.count()).toBe(1, "should add one resources");
+      });
+    });
+  }
+});

--- a/packages/web-experience/test/helpers/get-experience-subdomain.test.ts
+++ b/packages/web-experience/test/helpers/get-experience-subdomain.test.ts
@@ -1,0 +1,41 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getExperienceSubdomain } from "../../src/helpers/get-experience-subdomain";
+import { UserSession } from "@esri/arcgis-rest-auth";
+
+describe("getExperienceSubdomain :: ", () => {
+  it("works", () => {
+    const data = [
+      { portal: "https://qaext.arcgis.com", expected: "experienceqa" },
+      { portal: "https://dc.mapsqa.arcgis.com", expected: "experienceqa" },
+      { portal: "https://devext.arcgis.com", expected: "experiencedev" },
+      { portal: "https://dc.mapsdevext.arcgis.com", expected: "experiencedev" },
+      { portal: "https://www.arcgis.com", expected: "experience" },
+      { portal: "https://dc.maps.arcgis.com", expected: "experience" },
+      { portal: "https://some.com/portal", expected: undefined },
+      { portal: undefined, expected: "experience" }
+    ];
+
+    data.forEach(entry => {
+      const us = { portal: entry.portal } as UserSession;
+      expect(getExperienceSubdomain(us)).toBe(
+        entry.expected,
+        `Should convert ${entry.portal} to ${entry.expected}`
+      );
+    });
+  });
+});

--- a/packages/web-experience/test/helpers/get-web-experience-dependecies.test.ts
+++ b/packages/web-experience/test/helpers/get-web-experience-dependecies.test.ts
@@ -1,0 +1,60 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getWebExperienceDependencies } from "../../src/helpers/get-web-experience-dependencies";
+import { IModel } from "@esri/hub-common";
+import { IItem } from "@esri/arcgis-rest-portal";
+
+describe("getWebExperienceDependencies :: ", () => {
+  it("extracts itemIds from datasources", () => {
+    const input = {
+      item: {} as IItem,
+      data: {
+        dataSources: {
+          one: {
+            itemId: "bc1"
+          },
+          two: {
+            itemId: "bc2"
+          },
+          three: {
+            other: {
+              itemId: "notincluded"
+            }
+          }
+        }
+      }
+    } as IModel;
+
+    const chk = getWebExperienceDependencies(input);
+
+    expect(Array.isArray(chk)).toBe(true, "should return an array");
+    expect(chk.length).toBe(2, "should have two entries");
+    expect(chk.indexOf("bc1")).toBeGreaterThan(-1, "should have bc1");
+    expect(chk.indexOf("bc2")).toBeGreaterThan(-1, "should have bc2");
+  });
+
+  it("returns empty array if no datasources", () => {
+    const input = {
+      item: {} as IItem,
+      data: {}
+    } as IModel;
+
+    const chk = getWebExperienceDependencies(input);
+    expect(Array.isArray(chk)).toBe(true, "should return an array");
+    expect(chk.length).toBe(0, "should have no entries");
+  });
+});

--- a/packages/web-experience/test/web-experience-processor.test.ts
+++ b/packages/web-experience/test/web-experience-processor.test.ts
@@ -21,6 +21,12 @@
 import * as WebExperienceProcessor from "../src/web-experience-processor";
 import * as utils from "../../common/test/mocks/utils";
 import * as common from "@esri/solution-common";
+import * as hubCommon from "@esri/hub-common";
+import * as portalModule from "@esri/arcgis-rest-portal";
+import * as convertToTmplModule from "../src/helpers/convert-web-experience-to-template";
+
+import * as createFromTemplateModule from "../src/helpers/create-web-experience-model-from-template";
+import * as createExperienceModule from "../src/helpers/create-web-experience";
 
 let MOCK_USER_SESSION: common.UserSession;
 
@@ -30,56 +36,176 @@ beforeEach(() => {
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
-xdescribe("Module `web-experience`: ", () => {
+describe("Module `web-experience`: ", () => {
   describe("convertItemToTemplate :: ", () => {
-    it("should reject with an error response", done => {
-      const failSpy = spyOn(common, "fail").and.callThrough();
+    it("should fetch the data and delegate to convertToTemplate", () => {
+      const getItemDataSpy = spyOn(portalModule, "getItemData").and.resolveTo({
+        some: "prop"
+      });
+      const tmpl = {
+        item: {},
+        data: {}
+      } as common.IItemTemplate;
+      const convertSpy = spyOn(
+        convertToTmplModule,
+        "convertWebExperienceToTemplate"
+      ).and.resolveTo(tmpl);
+
       return WebExperienceProcessor.convertItemToTemplate(
         "2c36d3679e7f4934ac599051df22daf6",
-        {},
+        { id: "bc3" },
         MOCK_USER_SESSION,
         false
-      ).then(
-        _ => {
-          done.fail("convertItemToTemplate should have rejected");
-        },
-        e => {
-          const error =
-            "convertItemToTemplate not yet implemented for WebExperienceProcessor";
-          const expected = { success: false, error };
-          expect(failSpy.calls.count()).toBe(1);
-          expect(failSpy.calls.first().args).toEqual([error]);
-          expect(e).toEqual(expected);
-          done();
-        }
-      );
+      ).then(result => {
+        expect(getItemDataSpy.calls.count()).toBe(1, "should get the data");
+        expect(convertSpy.calls.count()).toBe(
+          1,
+          "should convert the model to template"
+        );
+      });
     });
   });
 
   describe("createItemFromTemplate", () => {
-    it("should reject with an error response", done => {
-      const failSpy = spyOn(common, "fail").and.callThrough();
-      const template = {} as common.IItemTemplate;
-      const progressCallback = jasmine.createSpy();
-      return WebExperienceProcessor.createItemFromTemplate(
-        template,
-        {},
-        MOCK_USER_SESSION,
-        progressCallback
-      ).then(
-        _ => {
-          done.fail("createItemFromTemplate should have rejected");
-        },
-        e => {
-          const error =
-            "createItemFromTemplate not yet implemented for WebExperienceProcessor";
-          const expected = { success: false, error };
-          expect(failSpy.calls.count()).toBe(1);
-          expect(failSpy.calls.first().args).toEqual([error]);
-          expect(e).toEqual(expected);
-          done();
-        }
+    it("it exists", () => {
+      expect(WebExperienceProcessor.createItemFromTemplate).toBeDefined(
+        "Should have createItemFromTemplate method"
       );
+    });
+
+    // objects used in following tests
+    const fakeExB = {
+      item: {
+        id: "FAKE3ef"
+      }
+    } as hubCommon.IModel;
+    const tmpl = {
+      itemId: "bc8",
+      type: "Web Experience",
+      item: {}
+    } as common.IItemTemplate;
+    const td = {
+      organization: {
+        id: "somePortalId",
+        portalHostname: "www.arcgis.com"
+      },
+      user: {
+        username: "vader"
+      },
+      solutionItemExtent: "10,10,20,20",
+      solution: {
+        title: "Some Title"
+      }
+    };
+    const cb = () => true;
+
+    it("happy-path", () => {
+      const createFromTmplSpy = spyOn(
+        createFromTemplateModule,
+        "createWebExperienceModelFromTemplate"
+      ).and.resolveTo({ item: {} });
+
+      const createSpy = spyOn(
+        createExperienceModule,
+        "createWebExperience"
+      ).and.resolveTo(fakeExB);
+      return WebExperienceProcessor.createItemFromTemplate(
+        tmpl,
+        td,
+        MOCK_USER_SESSION,
+        cb
+      ).then(result => {
+        expect(result.id).toBe("FAKE3ef", "should return the created item id");
+        expect(result.type).toBe("Web Experience", "should return the type");
+        expect(result.postProcess).toBe(false, "should not postProcess");
+        expect(createFromTmplSpy.calls.count()).toBe(
+          1,
+          "should call createFromTemplate"
+        );
+        expect(createSpy.calls.count()).toBe(
+          1,
+          "should call createWebExperience"
+        );
+      });
+    });
+    it("early-exits correctly", () => {
+      const cbFalse = () => false;
+      return WebExperienceProcessor.createItemFromTemplate(
+        tmpl,
+        td,
+        MOCK_USER_SESSION,
+        cbFalse
+      ).then(result => {
+        expect(result.id).toBe("", "should return empty result");
+        expect(result.postProcess).toBe(
+          false,
+          "should return postProcess false"
+        );
+      });
+    });
+    it("callsback on exception", done => {
+      spyOn(createExperienceModule, "createWebExperience").and.rejectWith(
+        "booom"
+      );
+      return WebExperienceProcessor.createItemFromTemplate(
+        tmpl,
+        td,
+        MOCK_USER_SESSION,
+        cb
+      )
+        .then(result => {
+          done.fail();
+        })
+        .catch(ex => {
+          expect(ex).toBe("booom", "should re-throw");
+          done();
+        });
+    });
+    it("cleans up if job is cancelled late", () => {
+      // fn that returns a fn that closes over a counter so that
+      // it can return false after the first call
+      const createCb = () => {
+        let calls = 0;
+        return () => {
+          calls = calls + 1;
+          return calls < 2;
+        };
+      };
+      const createFromTmplSpy = spyOn(
+        createFromTemplateModule,
+        "createWebExperienceModelFromTemplate"
+      ).and.resolveTo({ item: {} });
+
+      const createSpy = spyOn(
+        createExperienceModule,
+        "createWebExperience"
+      ).and.resolveTo(fakeExB);
+      const removeSpy = spyOn(portalModule, "removeItem").and.resolveTo({
+        success: true,
+        itemId: "3ef"
+      });
+      return WebExperienceProcessor.createItemFromTemplate(
+        tmpl,
+        td,
+        MOCK_USER_SESSION,
+        createCb()
+      ).then(result => {
+        expect(result.id).toBe("", "should return empty result");
+        expect(result.postProcess).toBe(
+          false,
+          "should return postProcess false"
+        );
+        expect(result.type).toBe("Web Experience", "should return the type");
+        expect(createFromTmplSpy.calls.count()).toBe(
+          1,
+          "should call createFromTemplate"
+        );
+        expect(createSpy.calls.count()).toBe(
+          1,
+          "should call createWebExperience"
+        );
+        expect(removeSpy.calls.count()).toBe(1, "should remove the item");
+      });
     });
   });
 });


### PR DESCRIPTION
Also lands "final pass" interpolation for Sites and Pages as per #366 

The only remaining `/* istanbul ignore next */`'s in the Hub-Types package is for the `convertItemToTemplate` functions, which have not been implemented yet. 