### PR TITLE
Use ArcGIS-Html-Sanitizer v2.1.1

### DIFF
--- a/demos/addResource/package-lock.json
+++ b/demos/addResource/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/compareJSON/package-lock.json
+++ b/demos/compareJSON/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/convertExtent/package-lock.json
+++ b/demos/convertExtent/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/copyItemInfo/package-lock.json
+++ b/demos/copyItemInfo/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/copySolutions/package-lock.json
+++ b/demos/copySolutions/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/createFolder/package-lock.json
+++ b/demos/createFolder/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/createSolution/package-lock.json
+++ b/demos/createSolution/package-lock.json
@@ -98,9 +98,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "dev": true,
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
@@ -113,81 +113,81 @@
       }
     },
     "@esri/solution-creator": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.16.6.tgz",
-      "integrity": "sha512-CGUjQLUZX/ditbovJQl70zVyLt52DKGS9FChBNbCZYH8Z5otCv6JkJm7OhQPpXDzcFt80HR8p6DA3yrOJD3aLw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.16.7.tgz",
+      "integrity": "sha512-w94Sp/lKyAqX7XsdTy+MxKBhuTQfAC629LDUwL4ASrlX5wjYGoWxyK09DNOjd5r/ijJJlXFFpGHglB5XUm2Muw==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-feature-layer": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.16.6.tgz",
-      "integrity": "sha512-CgCA5srtl1Ad1m83xbKMI11Etw3dfHOckOk3QiAhl/FME4JyJ1N/PLpY42b6KPqPa1uYeWcfrxHj7HMChmjFPA==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.16.7.tgz",
+      "integrity": "sha512-ZF8iZU5OhQnpD76i4C6Ijg40s8zOsSL4T2dhSvOGCAo46zjxe8fhoA2YaOMWq3w6un9C+dC/AcM6AYcVzVgG9w==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-file": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.16.6.tgz",
-      "integrity": "sha512-6hF8CvKRQqD+gG5p0IYMhwPFaNN24NA/05rPf3MFuBWJ/NDfk5KiN3ddg6gdrM7TMX18lpLZjuGjtp3XF2BgsQ==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.16.7.tgz",
+      "integrity": "sha512-Omh0FDBRmPOAH6rGbhGkdpyGQUOKDDRIAWyE69iZ5u5c8oxFOvjbuV70QNrCd3TQ0obe+QBSsCK8nomlHtinSw==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-form": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.16.6.tgz",
-      "integrity": "sha512-/S7Ex14Iy3dvKw9Crf+cD6X12ac4OXF1NfV1oAwoloJ7eLBZyt5raiERu/VbHGnekhshEC3MTjNVw0ke+Be92A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.16.7.tgz",
+      "integrity": "sha512-272wsarz8K88iSP4qfXz+8yYwbQL58uYTv2NwU0yb8I8WPBxJFlobqjmWgaSchX2FwQoyTPYABok1PzB0NTERg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-group": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.16.6.tgz",
-      "integrity": "sha512-br/hNhLCJO9uBCPvQD1sEv4hEHmn/XQ34o3wHaGp2NXb6mIK4NVs0e8LvP2z4rLd/cdcEzTxFEXmjtNkgHlG0g==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.16.7.tgz",
+      "integrity": "sha512-IGJwi++9w4mbl1oTymxPOrTrsyqsszCwJjOxBpsz8Z3zxNcK1fu5ij9Cnckb403QpVUny/vbmjtwG17m+rAtNg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-hub-types": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.16.6.tgz",
-      "integrity": "sha512-PovLku0J9oucSAOyfRJLL5jRExlqM/0AcuVOXBc/VAHisE6m1S6H69qpBJuCIq9nfatCIZjGBTBRfFsuw7QFKw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.16.7.tgz",
+      "integrity": "sha512-mPfagFklESaJgD1XTbCSP2c7dVF3BYzzIBAKBv5xqew396Z63h85CtQylG5/Wrpsb3nOrpjLNJrNDKcZUJeTNQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-simple-types": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.16.6.tgz",
-      "integrity": "sha512-x2JXp/MfyJbXVkuIkI+zGrvMULG3J9Xw7ZzRkxW1bPQW39hhMJEVjzfmzNik+GeYLOLBdJ1jExfjjTLbhO24vg==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.16.7.tgz",
+      "integrity": "sha512-3mod/8Fcrh4j163dmS1HvJhLncOLPRRluviHgRihmhs7/CYwq9/aZfxMPS7Hz7c8YSpGX+tSJR+yCo7cgyqX5g==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-storymap": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.16.6.tgz",
-      "integrity": "sha512-ls+b4QJ4dcuGWXg0L4HIPybtZrmHta5Uq8kARZ76DA5+MFMOmWNjPRKpYoo50oyKEFdtp/gLOI6wee01DkY6sQ==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.16.7.tgz",
+      "integrity": "sha512-a+JPesFMaI29naGc62Nh6DnReL3pDIvXqBRqu+M4P92QXsCmW8cvaYeIo2HvM9oP6meYR1juQPxixQ+KVyj0Ew==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-web-experience": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.16.6.tgz",
-      "integrity": "sha512-biQ8xPxOLje/vPiAW0VAMFBh2oaYu+27bCQgxOkEozf/aDmotiWSho56U05fcW0EIjNQ3qTt4vijME0HXHWAag==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.16.7.tgz",
+      "integrity": "sha512-UBZCkpgrtiqlpgH+XZcFCeAd40qag2llUws5o5cA5DGNxjdiSxq8mmM/+ttgdQ9E8tnsD4phawDZpeYEwScoXg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -314,13 +314,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/deploySolution/index.html
+++ b/demos/deploySolution/index.html
@@ -119,21 +119,20 @@
               password: document.getElementById("password").value,
               portal: document.getElementById("portal").value
             }),
-            (percentDone, jobId, progressEvent) => {
+            function (percentDone, jobId, progressEvent) {
               if (progressEvent) {
                 createdItems.push(progressEvent.data)
               }
               var html = "Deploying..." + percentDone.toFixed().toString() + "%" + "<br><br>Finished items:<ol>";
-              createdItems.forEach(item => html += "<li>" + item + "</li>");
+              createdItems.forEach(function (item) { return html += "<li>" + item + "</li>" });
               html += "</ol>";
               document.getElementById("output").innerHTML = html;
             }
-          ).then(
-            html => {
+          ).then(function (html){
               reportElapsedTime(startTime);
               document.getElementById("output").innerHTML = html;
             },
-            error => {
+            function (error) {
               var message = error.error || JSON.stringify(error);
               reportElapsedTime(startTime);
               document.getElementById("output").innerHTML = "<span style=\"color:red\">" + message + "</span>";

--- a/demos/deploySolution/index.html
+++ b/demos/deploySolution/index.html
@@ -65,7 +65,7 @@
       </div>
     </div>
   </div>
-
+  <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=fetch%2Ces2015"></script>
   <script src="https://requirejs.org/docs/release/2.3.6/minified/require.js"></script>
   <script>
     var goFcn;

--- a/demos/deploySolution/package-lock.json
+++ b/demos/deploySolution/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@esri/arcgis-html-sanitizer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.2.0.tgz",
-      "integrity": "sha512-PR9cRBC7Za3x6Il6GMDjbqDoUDoBCdQHRSIv8WNdoJaVCQ+BPz13GJiWk560UNa6zFYTJm6bvrffui2kGL25rw==",
-      "dev": true,
-      "requires": {
-        "lodash.isplainobject": "^4.0.6",
-        "xss": "^1.0.6"
-      }
-    },
     "@esri/arcgis-rest-auth": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.13.2.tgz",
@@ -98,12 +88,10 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
-        "@esri/arcgis-html-sanitizer": "^2.2.0",
+        "@esri/arcgis-html-sanitizer": "~2.1.0",
         "@types/lodash.isplainobject": "^4.0.6",
         "adlib": "^3.0.4",
         "jszip": "3.4.0",
@@ -113,81 +101,63 @@
       }
     },
     "@esri/solution-deployer": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.16.6.tgz",
-      "integrity": "sha512-69EsUEwOe1V20z9V0JO7j0nbGan7P+X80jpyV3Ps+ruieOdrtdh1Qlr5u1CJwWNwfZboV/Jw7yeBgN89K0R6xg==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-feature-layer": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.16.6.tgz",
-      "integrity": "sha512-CgCA5srtl1Ad1m83xbKMI11Etw3dfHOckOk3QiAhl/FME4JyJ1N/PLpY42b6KPqPa1uYeWcfrxHj7HMChmjFPA==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-file": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.16.6.tgz",
-      "integrity": "sha512-6hF8CvKRQqD+gG5p0IYMhwPFaNN24NA/05rPf3MFuBWJ/NDfk5KiN3ddg6gdrM7TMX18lpLZjuGjtp3XF2BgsQ==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-form": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.16.6.tgz",
-      "integrity": "sha512-/S7Ex14Iy3dvKw9Crf+cD6X12ac4OXF1NfV1oAwoloJ7eLBZyt5raiERu/VbHGnekhshEC3MTjNVw0ke+Be92A==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-group": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.16.6.tgz",
-      "integrity": "sha512-br/hNhLCJO9uBCPvQD1sEv4hEHmn/XQ34o3wHaGp2NXb6mIK4NVs0e8LvP2z4rLd/cdcEzTxFEXmjtNkgHlG0g==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-hub-types": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.16.6.tgz",
-      "integrity": "sha512-PovLku0J9oucSAOyfRJLL5jRExlqM/0AcuVOXBc/VAHisE6m1S6H69qpBJuCIq9nfatCIZjGBTBRfFsuw7QFKw==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-simple-types": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.16.6.tgz",
-      "integrity": "sha512-x2JXp/MfyJbXVkuIkI+zGrvMULG3J9Xw7ZzRkxW1bPQW39hhMJEVjzfmzNik+GeYLOLBdJ1jExfjjTLbhO24vg==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-storymap": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.16.6.tgz",
-      "integrity": "sha512-ls+b4QJ4dcuGWXg0L4HIPybtZrmHta5Uq8kARZ76DA5+MFMOmWNjPRKpYoo50oyKEFdtp/gLOI6wee01DkY6sQ==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-web-experience": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.16.6.tgz",
-      "integrity": "sha512-biQ8xPxOLje/vPiAW0VAMFBh2oaYu+27bCQgxOkEozf/aDmotiWSho56U05fcW0EIjNQ3qTt4vijME0HXHWAag==",
+      "version": "0.16.7",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -198,21 +168,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
       "integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
       "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.155",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz",
-      "integrity": "sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==",
-      "dev": true
-    },
-    "@types/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/node": {
       "version": "14.0.13",
@@ -256,28 +211,10 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
     "corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
-      "dev": true
-    },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
       "dev": true
     },
     "debug": {
@@ -357,55 +294,10 @@
         "union": "~0.5.0"
       }
     },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "jszip": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
-      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
-      "dev": true,
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "mime": {
@@ -441,12 +333,6 @@
       "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
       "dev": true
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
-    },
     "portfinder": {
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
@@ -458,32 +344,11 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "qs": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
       "dev": true
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -502,32 +367,11 @@
         "acorn": "^7.1.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "secure-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "tslib": {
       "version": "1.13.0",
@@ -554,22 +398,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
       "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "xss": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.7.tgz",
-      "integrity": "sha512-A9v7tblGvxu8TWXQC9rlpW96a+LN1lyw6wyhpTmmGW+FwRMactchBR3ROKSi33UPCUcUHSu8s9YP6F+K3Mw//w==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      }
     }
   }
 }

--- a/demos/deploySolution/package-lock.json
+++ b/demos/deploySolution/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@esri/arcgis-html-sanitizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.2.0.tgz",
+      "integrity": "sha512-PR9cRBC7Za3x6Il6GMDjbqDoUDoBCdQHRSIv8WNdoJaVCQ+BPz13GJiWk560UNa6zFYTJm6bvrffui2kGL25rw==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6",
+        "xss": "^1.0.6"
+      }
+    },
     "@esri/arcgis-rest-auth": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.13.2.tgz",
@@ -89,9 +99,11 @@
     },
     "@esri/solution-common": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "dev": true,
       "requires": {
-        "@esri/arcgis-html-sanitizer": "~2.1.0",
+        "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
         "adlib": "^3.0.4",
         "jszip": "3.4.0",
@@ -102,6 +114,8 @@
     },
     "@esri/solution-deployer": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.16.7.tgz",
+      "integrity": "sha512-LijMotqKEw0kauLN+2pUdY8VoW7We0C+EVEiEbBwqSrOYuBPGXfrcQsWwsBiVoIqBfZyK38+b8QooZ5/ZdzV1Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -109,6 +123,8 @@
     },
     "@esri/solution-feature-layer": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.16.7.tgz",
+      "integrity": "sha512-ZF8iZU5OhQnpD76i4C6Ijg40s8zOsSL4T2dhSvOGCAo46zjxe8fhoA2YaOMWq3w6un9C+dC/AcM6AYcVzVgG9w==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -116,6 +132,8 @@
     },
     "@esri/solution-file": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.16.7.tgz",
+      "integrity": "sha512-Omh0FDBRmPOAH6rGbhGkdpyGQUOKDDRIAWyE69iZ5u5c8oxFOvjbuV70QNrCd3TQ0obe+QBSsCK8nomlHtinSw==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -123,6 +141,8 @@
     },
     "@esri/solution-form": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.16.7.tgz",
+      "integrity": "sha512-272wsarz8K88iSP4qfXz+8yYwbQL58uYTv2NwU0yb8I8WPBxJFlobqjmWgaSchX2FwQoyTPYABok1PzB0NTERg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -130,6 +150,8 @@
     },
     "@esri/solution-group": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.16.7.tgz",
+      "integrity": "sha512-IGJwi++9w4mbl1oTymxPOrTrsyqsszCwJjOxBpsz8Z3zxNcK1fu5ij9Cnckb403QpVUny/vbmjtwG17m+rAtNg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -137,6 +159,8 @@
     },
     "@esri/solution-hub-types": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.16.7.tgz",
+      "integrity": "sha512-mPfagFklESaJgD1XTbCSP2c7dVF3BYzzIBAKBv5xqew396Z63h85CtQylG5/Wrpsb3nOrpjLNJrNDKcZUJeTNQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -144,6 +168,8 @@
     },
     "@esri/solution-simple-types": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.16.7.tgz",
+      "integrity": "sha512-3mod/8Fcrh4j163dmS1HvJhLncOLPRRluviHgRihmhs7/CYwq9/aZfxMPS7Hz7c8YSpGX+tSJR+yCo7cgyqX5g==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -151,6 +177,8 @@
     },
     "@esri/solution-storymap": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.16.7.tgz",
+      "integrity": "sha512-a+JPesFMaI29naGc62Nh6DnReL3pDIvXqBRqu+M4P92QXsCmW8cvaYeIo2HvM9oP6meYR1juQPxixQ+KVyj0Ew==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -158,6 +186,8 @@
     },
     "@esri/solution-web-experience": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.16.7.tgz",
+      "integrity": "sha512-UBZCkpgrtiqlpgH+XZcFCeAd40qag2llUws5o5cA5DGNxjdiSxq8mmM/+ttgdQ9E8tnsD4phawDZpeYEwScoXg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -168,6 +198,21 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
       "integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
       "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.155",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz",
+      "integrity": "sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==",
+      "dev": true
+    },
+    "@types/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/node": {
       "version": "14.0.13",
@@ -211,10 +256,28 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
       "dev": true
     },
     "debug": {
@@ -251,13 +314,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",
@@ -294,10 +354,55 @@
         "union": "~0.5.0"
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
+      "dev": true,
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "mime": {
@@ -333,6 +438,12 @@
       "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
       "dev": true
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "portfinder": {
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
@@ -344,11 +455,32 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
     "qs": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -367,11 +499,32 @@
         "acorn": "^7.1.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "secure-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "tslib": {
       "version": "1.13.0",
@@ -398,6 +551,22 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
       "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "xss": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.7.tgz",
+      "integrity": "sha512-A9v7tblGvxu8TWXQC9rlpW96a+LN1lyw6wyhpTmmGW+FwRMactchBR3ROKSi33UPCUcUHSu8s9YP6F+K3Mw//w==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      }
     }
   }
 }

--- a/demos/getGUID/package-lock.json
+++ b/demos/getGUID/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/getGroupInfo/package-lock.json
+++ b/demos/getGroupInfo/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/getItemInfo/package-lock.json
+++ b/demos/getItemInfo/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/getSolutions/package-lock.json
+++ b/demos/getSolutions/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/implementedTypes/package-lock.json
+++ b/demos/implementedTypes/package-lock.json
@@ -98,9 +98,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "dev": true,
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
@@ -113,90 +113,90 @@
       }
     },
     "@esri/solution-creator": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.16.6.tgz",
-      "integrity": "sha512-CGUjQLUZX/ditbovJQl70zVyLt52DKGS9FChBNbCZYH8Z5otCv6JkJm7OhQPpXDzcFt80HR8p6DA3yrOJD3aLw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.16.7.tgz",
+      "integrity": "sha512-w94Sp/lKyAqX7XsdTy+MxKBhuTQfAC629LDUwL4ASrlX5wjYGoWxyK09DNOjd5r/ijJJlXFFpGHglB5XUm2Muw==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-deployer": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.16.6.tgz",
-      "integrity": "sha512-69EsUEwOe1V20z9V0JO7j0nbGan7P+X80jpyV3Ps+ruieOdrtdh1Qlr5u1CJwWNwfZboV/Jw7yeBgN89K0R6xg==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.16.7.tgz",
+      "integrity": "sha512-LijMotqKEw0kauLN+2pUdY8VoW7We0C+EVEiEbBwqSrOYuBPGXfrcQsWwsBiVoIqBfZyK38+b8QooZ5/ZdzV1Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-feature-layer": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.16.6.tgz",
-      "integrity": "sha512-CgCA5srtl1Ad1m83xbKMI11Etw3dfHOckOk3QiAhl/FME4JyJ1N/PLpY42b6KPqPa1uYeWcfrxHj7HMChmjFPA==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.16.7.tgz",
+      "integrity": "sha512-ZF8iZU5OhQnpD76i4C6Ijg40s8zOsSL4T2dhSvOGCAo46zjxe8fhoA2YaOMWq3w6un9C+dC/AcM6AYcVzVgG9w==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-file": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.16.6.tgz",
-      "integrity": "sha512-6hF8CvKRQqD+gG5p0IYMhwPFaNN24NA/05rPf3MFuBWJ/NDfk5KiN3ddg6gdrM7TMX18lpLZjuGjtp3XF2BgsQ==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.16.7.tgz",
+      "integrity": "sha512-Omh0FDBRmPOAH6rGbhGkdpyGQUOKDDRIAWyE69iZ5u5c8oxFOvjbuV70QNrCd3TQ0obe+QBSsCK8nomlHtinSw==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-form": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.16.6.tgz",
-      "integrity": "sha512-/S7Ex14Iy3dvKw9Crf+cD6X12ac4OXF1NfV1oAwoloJ7eLBZyt5raiERu/VbHGnekhshEC3MTjNVw0ke+Be92A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.16.7.tgz",
+      "integrity": "sha512-272wsarz8K88iSP4qfXz+8yYwbQL58uYTv2NwU0yb8I8WPBxJFlobqjmWgaSchX2FwQoyTPYABok1PzB0NTERg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-group": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.16.6.tgz",
-      "integrity": "sha512-br/hNhLCJO9uBCPvQD1sEv4hEHmn/XQ34o3wHaGp2NXb6mIK4NVs0e8LvP2z4rLd/cdcEzTxFEXmjtNkgHlG0g==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.16.7.tgz",
+      "integrity": "sha512-IGJwi++9w4mbl1oTymxPOrTrsyqsszCwJjOxBpsz8Z3zxNcK1fu5ij9Cnckb403QpVUny/vbmjtwG17m+rAtNg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-hub-types": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.16.6.tgz",
-      "integrity": "sha512-PovLku0J9oucSAOyfRJLL5jRExlqM/0AcuVOXBc/VAHisE6m1S6H69qpBJuCIq9nfatCIZjGBTBRfFsuw7QFKw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.16.7.tgz",
+      "integrity": "sha512-mPfagFklESaJgD1XTbCSP2c7dVF3BYzzIBAKBv5xqew396Z63h85CtQylG5/Wrpsb3nOrpjLNJrNDKcZUJeTNQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-simple-types": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.16.6.tgz",
-      "integrity": "sha512-x2JXp/MfyJbXVkuIkI+zGrvMULG3J9Xw7ZzRkxW1bPQW39hhMJEVjzfmzNik+GeYLOLBdJ1jExfjjTLbhO24vg==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.16.7.tgz",
+      "integrity": "sha512-3mod/8Fcrh4j163dmS1HvJhLncOLPRRluviHgRihmhs7/CYwq9/aZfxMPS7Hz7c8YSpGX+tSJR+yCo7cgyqX5g==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-storymap": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.16.6.tgz",
-      "integrity": "sha512-ls+b4QJ4dcuGWXg0L4HIPybtZrmHta5Uq8kARZ76DA5+MFMOmWNjPRKpYoo50oyKEFdtp/gLOI6wee01DkY6sQ==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.16.7.tgz",
+      "integrity": "sha512-a+JPesFMaI29naGc62Nh6DnReL3pDIvXqBRqu+M4P92QXsCmW8cvaYeIo2HvM9oP6meYR1juQPxixQ+KVyj0Ew==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
       }
     },
     "@esri/solution-web-experience": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.16.6.tgz",
-      "integrity": "sha512-biQ8xPxOLje/vPiAW0VAMFBh2oaYu+27bCQgxOkEozf/aDmotiWSho56U05fcW0EIjNQ3qTt4vijME0HXHWAag==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.16.7.tgz",
+      "integrity": "sha512-UBZCkpgrtiqlpgH+XZcFCeAd40qag2llUws5o5cA5DGNxjdiSxq8mmM/+ttgdQ9E8tnsD4phawDZpeYEwScoXg==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
@@ -323,13 +323,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/polyfillExplorer/package-lock.json
+++ b/demos/polyfillExplorer/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/sanitizeGroupItems/package-lock.json
+++ b/demos/sanitizeGroupItems/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/sanitizer/package-lock.json
+++ b/demos/sanitizer/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-      "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+      "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "^2.2.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",

--- a/demos/searchGroupCategories/package-lock.json
+++ b/demos/searchGroupCategories/package-lock.json
@@ -88,9 +88,9 @@
    }
   },
   "@esri/solution-common": {
-   "version": "0.16.6",
-   "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.6.tgz",
-   "integrity": "sha512-tGrvAB9069hE1+9YAMK97G3wvrb/1rFfxPbEgNKNGk06XAkY/jLSEmn5csvem/9vTKQ5roSAyAPLUKQmYm5E4A==",
+   "version": "0.16.7",
+   "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.16.7.tgz",
+   "integrity": "sha512-cVftlTC4gU1Ziz61tfqTUoGbTbO/3jn425PBCI15qWhEeSfRwba197n2XB/GFusDgEZxmrOByjHKgooCfJg/XQ==",
    "requires": {
     "@esri/arcgis-html-sanitizer": "^2.2.0",
     "@types/lodash.isplainobject": "^4.0.6",
@@ -197,13 +197,10 @@
    "dev": true
   },
   "follow-redirects": {
-   "version": "1.11.0",
-   "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-   "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-   "dev": true,
-   "requires": {
-    "debug": "^3.0.0"
-   }
+   "version": "1.12.0",
+   "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+   "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+   "dev": true
   },
   "he": {
    "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,25 +2198,14 @@
       },
       "dependencies": {
         "@octokit/request-error": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.1.tgz",
-          "integrity": "sha512-5lqBDJ9/TOehK82VvomQ6zFiZjPeSom8fLkFVLuYL3sKiIb5RB8iN/lenLkY7oBmyQcGP7FBMGiIZTO8jufaRQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+          "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
           "dev": true,
           "requires": {
-            "@octokit/types": "^4.0.1",
+            "@octokit/types": "^5.0.1",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
-          },
-          "dependencies": {
-            "@octokit/types": {
-              "version": "4.1.10",
-              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
-              "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
-              "dev": true,
-              "requires": {
-                "@types/node": ">= 8"
-              }
-            }
           }
         },
         "is-plain-object": {
@@ -2292,9 +2281,9 @@
       }
     },
     "@octokit/types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.0.tgz",
-      "integrity": "sha512-3LVS+MbeqwSd5G4KS8123cZz+hWomsiGeMnQ/QJIBFDwL/YHX8kkr0FZXrgWEMO7Fgi2/VOrhbiFnk9sZ+s4qA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
+      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -2454,9 +2443,9 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-          "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -5175,9 +5164,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001081",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz",
-      "integrity": "sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==",
+      "version": "1.0.30001084",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001084.tgz",
+      "integrity": "sha512-ftdc5oGmhEbLUuMZ/Qp3mOpzfZLCxPYKcvGv6v2dJJ+8EdqcvZRbAGOiLmkM/PV1QGta/uwBs8/nCl6sokDW6w==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -7405,9 +7394,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.469",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.469.tgz",
-      "integrity": "sha512-O9JM6ZsFhS0uy0S2Y3G8EoNfqio3srdxCuwuJh8tKgQKa6rf7je/xQ3TIoiEaEtpf2/qFFLAGt/xB4MjuUZqRw==",
+      "version": "1.3.475",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.475.tgz",
+      "integrity": "sha512-vcTeLpPm4+ccoYFXnepvkFt0KujdyrBU19KNEO40Pnkhta6mUi2K0Dn7NmpRcNz7BvysnSqeuIYScP003HWuYg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7726,22 +7715,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       },
       "dependencies": {
         "object-keys": {
@@ -11668,9 +11657,9 @@
       }
     },
     "jszip": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
-      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
+      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -22337,28 +22326,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -22667,9 +22634,9 @@
       }
     },
     "terser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
-      "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -22739,9 +22706,9 @@
       }
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0"

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@esri/arcgis-html-sanitizer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.2.0.tgz",
-			"integrity": "sha512-PR9cRBC7Za3x6Il6GMDjbqDoUDoBCdQHRSIv8WNdoJaVCQ+BPz13GJiWk560UNa6zFYTJm6bvrffui2kGL25rw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+			"integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
 			"requires": {
 				"lodash.isplainobject": "^4.0.6",
 				"xss": "^1.0.6"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -36,7 +36,7 @@
     "@esri/hub-sites": "^4.2.0"
   },
   "dependencies": {
-    "@esri/arcgis-html-sanitizer": "^2.2.0",
+    "@esri/arcgis-html-sanitizer": "~2.1.0",
     "@types/lodash.isplainobject": "^4.0.6",
     "adlib": "^3.0.4",
     "jszip": "3.4.0",


### PR DESCRIPTION
Back in February, `arcgis-html-sanitizer` [changed it's build system](https://github.com/Esri/arcgis-html-sanitizer/pull/51) to output ES6 modules instead of ES5 modules.

This has some upsides when all consumers of the library are able to drop IE11 support, but most packages will ship ES5 modules, not ES6.

While the Solutions App itself does not need to support IE11, Hub currently does. In order to bring Solution.js into Hub, we need to use the 2.1.1 version, which is what this PR does.

It also uses ES5 syntax in `index.html` in the `/demos/deploySolution` app so that it can run in IE11 (and is how I tested this)