### PR TITLE
Update Doc Site Generator

### DIFF
--- a/packages/common/src/migrations/is-legacy-solution.ts
+++ b/packages/common/src/migrations/is-legacy-solution.ts
@@ -21,6 +21,7 @@ import { getProp } from "../generalHelpers";
  * Determine if the Solution is a legacy item created by Hub
  * vs one that is 100% compatible with Solution.js
  * @param model ISolutionModel
+ * @private
  */
 export function _isLegacySolution(model: ISolutionItem): boolean {
   let result = false;

--- a/packages/common/src/migrations/upgrade-three-dot-zero.ts
+++ b/packages/common/src/migrations/upgrade-three-dot-zero.ts
@@ -24,6 +24,7 @@ import { getProp, cloneObject } from "../generalHelpers";
  * If it is a legacy hub solution, it will apply the transforms
  * @param model ISolutionItem
  * @param authentication UserSession
+ * @private
  */
 export function _upgradeThreeDotZero(
   model: ISolutionItem,

--- a/packages/common/src/migrations/upgrade-two-dot-five.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-five.ts
@@ -22,6 +22,7 @@ import { getProp, cloneObject } from "../generalHelpers";
  * @param {ISolutionItem} model A Solution model
  * @param {UserSession} authentication User session info
  * @returns {ISolutionItem}
+ * @private
  */
 export function _upgradeTwoDotFive(
   model: ISolutionItem,

--- a/packages/common/src/migrations/upgrade-two-dot-four.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-four.ts
@@ -22,6 +22,7 @@ import { deepStringReplace, getProp, cloneObject } from "@esri/hub-common";
  * but the Solution.js ones use the
  * @param model ISolutionItem
  * @param authentication UserSession
+ * @private
  */
 export function _upgradeTwoDotFour(
   model: ISolutionItem,

--- a/packages/common/src/migrations/upgrade-two-dot-six.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-six.ts
@@ -25,6 +25,7 @@ import { getProp, cloneObject, cleanItemId } from "../generalHelpers";
  * @param {ISolutionItem} model A Solution model
  * @param {UserSession} authentication The user session info
  * @returns {ISolutionItem}
+ * @private
  */
 export function _upgradeTwoDotSix(
   model: ISolutionItem,

--- a/packages/common/src/migrations/upgrade-two-dot-three.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-three.ts
@@ -18,6 +18,12 @@ import { ISolutionItem, UserSession } from "../interfaces";
 import { getProp } from "../generalHelpers";
 import { cloneObject } from "@esri/hub-common";
 
+/**
+ * Migrate Hub assets structure to resource paths
+ * @param model
+ * @param authentication
+ * @private
+ */
 export function _upgradeTwoDotThree(
   model: ISolutionItem,
   authentication: UserSession

--- a/packages/common/src/migrations/upgrade-two-dot-two.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-two.ts
@@ -18,6 +18,12 @@ import { ISolutionItem, ISolutionItemData, UserSession } from "../interfaces";
 import { getProp } from "../generalHelpers";
 import { deepStringReplace, cloneObject } from "@esri/hub-common";
 
+/**
+ * Swap tokens from Hub Solutions
+ * @param model
+ * @param authentication
+ * @private
+ */
 export function _upgradeTwoDotTwo(
   model: ISolutionItem,
   authentication: UserSession

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -242,7 +242,7 @@ export function addToServiceDefinition(
  *
  * @param extent the extent to validate
  * @return the provided extent or a default global extent if some coordinates are not numbers
- * @protected
+ * @private
  */
 export function _validateExtent(extent: IExtent): IExtent {
   // in some cases orgs can have invalid extents defined
@@ -275,7 +275,7 @@ export function _validateExtent(extent: IExtent): IExtent {
  * @param authentication the credentials for the requests
  * @return the extent projected to the provided spatial reference
  * or the world extent projected to the provided spatial reference
- * @protected
+ * @private
  */
 export function convertExtentWithFallback(
   extent: IExtent,
@@ -854,7 +854,7 @@ export function getLayers(
  *
  * @param args The IPostProcessArgs for the request(s)
  * @return An array of update instructions
- * @protected
+ * @private
  */
 export function getLayerUpdates(args: IPostProcessArgs): IUpdate[] {
   const adminUrl: string = args.itemTemplate.item.url.replace(
@@ -901,7 +901,7 @@ export function getLayerUpdates(args: IPostProcessArgs): IUpdate[] {
  *
  * @param Update will contain either add, update, or delete from service definition call
  * @return A promise that will resolve when service definition call has completed
- * @protected
+ * @private
  */
 export function getRequest(update: IUpdate): Promise<void> {
   return new Promise((resolveFn, rejectFn) => {
@@ -922,7 +922,7 @@ export function getRequest(update: IUpdate): Promise<void> {
  * @param itemTemplate Feature service item, data, dependencies definition to be modified
  * @param authentication Credentials for the request to AGOL
  * @return A promise that will resolve when fullItem has been updated
- * @protected
+ * @private
  */
 export function getServiceLayersAndTables(
   itemTemplate: IItemTemplate,
@@ -1315,7 +1315,7 @@ export function updateItemURL(
  * @param dataFile Data to be added
  * @param authentication Credentials for the request
  * @return Promise reporting success or failure
- * @protected
+ * @private
  */
 export function _addItemDataFile(
   itemId: string,
@@ -1350,7 +1350,7 @@ export function _addItemDataFile(
  * @param metadataFile Metadata to be added
  * @param authentication Credentials for the request
  * @return Promise reporting success or failure
- * @protected
+ * @private
  */
 export function _addItemMetadataFile(
   itemId: string,
@@ -1378,7 +1378,7 @@ export function _addItemMetadataFile(
  *
  * @param List of layers to examine
  * @return The number of relationships
- * @protected
+ * @private
  */
 export function _countRelationships(layers: any[]): number {
   const reducer = (accumulator: number, currentLayer: any) =>
@@ -1395,7 +1395,7 @@ export function _countRelationships(layers: any[]): number {
  * @param layerList List of layers at that service...must contain id
  * @param authentication Credentials for the request
  * @return A promise that will resolve with a list of the layers from the admin api
- * @protected
+ * @private
  */
 export function _getCreateServiceOptions(
   newItemTemplate: IItemTemplate,
@@ -1465,7 +1465,7 @@ export function _getCreateServiceOptions(
  *
  * @param args The IPostProcessArgs for the request(s)
  * @return Any relationships that should be updated for the service
- * @protected
+ * @private
  */
 export function _getRelationshipUpdates(args: IPostProcessArgs): any {
   const rels: any = {
@@ -1494,7 +1494,7 @@ export function _getRelationshipUpdates(args: IPostProcessArgs): any {
  * @param args various arguments to help support the request
  * @param type type of update the request will handle
  * @return IUpdate that has the request url and arguments
- * @protected
+ * @private
  */
 export function _getUpdate(
   url: string,


### PR DESCRIPTION
Two doc changes:
- hide anything marked `@private` from being shown in the docs
- sort the lists in the doc. Due to some other aspects of the doc system, this sort is not "perfect" but much better than it was. Really addressing this requires a more intensive refactor of `docs/build-typedoc.ts` which I don't have time for now.

Also marks the migration functions as `@private`

![image](https://user-images.githubusercontent.com/119129/87192880-a5d01200-c2b4-11ea-820b-0f921f63be9a.png)

*Note* the `getItemBase` is above `_cacheFieldInfo`

As far as building + deploying doc on merge to master - that's something we have to do in Github and I'll try to peek at that over the weekend