### PR TITLE
Report a failing item id as soon as possible

### DIFF
--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -95,12 +95,13 @@ export function _addContentToSolution(
       }
 
       if (status === EItemProgressStatus.Failed) {
+        let error = "";
         solutionTemplates.some(t => {
           /* istanbul ignore else */
           if (t.itemId === itemId) {
             /* istanbul ignore else */
             if (getProp(t, "properties.error")) {
-              let error = t.properties.error;
+              error = t.properties.error;
               try {
                 // parse for better console logging if we can
                 error = JSON.parse(error);
@@ -108,7 +109,6 @@ export function _addContentToSolution(
                 /* istanbul ignore next */
                 // do nothing and show the error as is
               }
-              console.error(error);
             }
             return true;
           }
@@ -117,6 +117,7 @@ export function _addContentToSolution(
         if (failedItemIds.indexOf(itemId) < 0) {
           failedItemIds.push(itemId);
         }
+        console.error("Item " + itemId + " has failed " + error);
         statusOK = false;
       } else if (status === EItemProgressStatus.Ignored) {
         removeTemplate(solutionTemplates, itemId);

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -859,6 +859,7 @@ describe("Module `creator`", () => {
             "/content/users/casey/items/sln1234567890/delete",
           utils.getFailureResponse({ itemId: solutionId })
         );
+      // tslint:disable-next-line: no-empty
       spyOn(console, "error").and.callFake(() => {});
 
       creator._createSolutionFromItemIds(itemIds, MOCK_USER_SESSION, {}).then(

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -859,6 +859,7 @@ describe("Module `creator`", () => {
             "/content/users/casey/items/sln1234567890/delete",
           utils.getFailureResponse({ itemId: solutionId })
         );
+      spyOn(console, "error").and.callFake(() => {});
 
       creator._createSolutionFromItemIds(itemIds, MOCK_USER_SESSION, {}).then(
         () => done.fail(),

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -98,6 +98,7 @@ export function deploySolutionItems(
         deployedItemIds.push(createdItemId);
       } else if (status === common.EItemProgressStatus.Failed) {
         failedTemplateItemIds.push(itemId);
+        console.error("Item " + itemId + " has failed");
         statusOK = false;
       }
 

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -51,6 +51,7 @@ describe("Module `deploySolutionItems`", () => {
     it("can handle unimplemented item type gracefully", done => {
       // tslint:disable-next-line: no-empty
       spyOn(console, "log").and.callFake(() => {});
+      // tslint:disable-next-line: no-empty
       spyOn(console, "error").and.callFake(() => {});
       deploySolution
         .deploySolutionItems(
@@ -807,6 +808,7 @@ describe("Module `deploySolutionItems`", () => {
             groupId: "aa4a6047326243b290f625e80ebe6531"
           })
         );
+      // tslint:disable-next-line: no-empty
       spyOn(console, "error").and.callFake(() => {});
 
       const expected: any[] = [

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -51,6 +51,7 @@ describe("Module `deploySolutionItems`", () => {
     it("can handle unimplemented item type gracefully", done => {
       // tslint:disable-next-line: no-empty
       spyOn(console, "log").and.callFake(() => {});
+      spyOn(console, "error").and.callFake(() => {});
       deploySolution
         .deploySolutionItems(
           "",
@@ -806,6 +807,7 @@ describe("Module `deploySolutionItems`", () => {
             groupId: "aa4a6047326243b290f625e80ebe6531"
           })
         );
+      spyOn(console, "error").and.callFake(() => {});
 
       const expected: any[] = [
         {

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -1663,6 +1663,7 @@ describe("Module `deployer`", () => {
             "/content/users/casey/items/map1234567890/delete",
             testUtils.getSuccessResponse({ itemId: "map1234567890" })
           );
+        // tslint:disable-next-line: no-empty
         spyOn(console, "error").and.callFake(() => {});
 
         const options: common.IDeploySolutionOptions = {

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -1663,6 +1663,7 @@ describe("Module `deployer`", () => {
             "/content/users/casey/items/map1234567890/delete",
             testUtils.getSuccessResponse({ itemId: "map1234567890" })
           );
+        spyOn(console, "error").and.callFake(() => {});
 
         const options: common.IDeploySolutionOptions = {
           progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK


### PR DESCRIPTION
During the creation and deployment processes, report a failing item id to the console when the progress function learns about it rather than waiting to the end.