### PR TITLE
Escaped text displayed in demos

### DIFF
--- a/demos/deploySolution/src/getItemInfo.ts
+++ b/demos/deploySolution/src/getItemInfo.ts
@@ -80,7 +80,7 @@ export function getItemInfo(
       async responses => {
         const [
           itemBase,
-          itemDataFile,
+          itemDataBlob,
           itemThumbnail,
           itemMetadataBlob,
           itemResourceFiles,
@@ -89,15 +89,15 @@ export function getItemInfo(
         ] = responses;
         // Summarize what we have
         // ----------------------
-        // (itemBase: any)  text/plain JSON
-        // (itemData: File)  */*
+        // (itemBase: common.IItem)  text/plain JSON
+        // (itemDataBlob: Blob)  */*
         // (itemThumbnail: Blob)  image/*
         // (itemMetadata: Blob)  application/xml
         // (itemResources: File[])  list of */*
         // (itemFwdRelatedItems: common.IRelatedItems[])  list of forward relationshipType/relatedItems[] pairs
         // (itemRevRelatedItems: common.IRelatedItems[])  list of reverse relationshipType/relatedItems[] pairs
         console.log("itemBase", itemBase);
-        console.log("itemData", itemDataFile);
+        console.log("itemData", itemDataBlob);
         console.log("itemThumbnail", itemThumbnail);
         console.log("itemMetadata", itemMetadataBlob);
         console.log("itemResources", JSON.stringify(itemResourceFiles));
@@ -107,28 +107,19 @@ export function getItemInfo(
         const portalUrl = common.getPortalUrlFromAuth(authentication);
 
         // Show item and data sections
-        let html =
-          "<h3>" +
-          itemBase.type +
-          ' "' +
-          itemBase.title +
-          '" (<a href="' +
-          portalUrl +
-          "/home/item.html?id=" +
-          itemBase.id +
-          '" target="_blank">' +
-          itemBase.id +
-          "</a>)</h3>";
+        let html =`
+          <h3>${itemBase.type} "${itemBase.title}" ( <a href="${portalUrl}/home/item.html?id=${itemBase.id}" target="_blank">${itemBase.id}</a> )</h3>
+          `;
 
         html +=
           '<div style="width:48%;display:inline-block;">Item</div>' +
           '<div style="width:2%;display:inline-block;"></div>' +
           '<div style="width:48%;display:inline-block;">Data</div>' +
           '<div style="width:48%;display:inline-block;">' +
-          textAreaHtml(JSON.stringify(itemBase, null, 2)) +
+          textAreaHtmlFromJSON(itemBase) +
           '</div><div style="width:2%;display:inline-block;"></div>' +
-          '<div style="width:48%;display:inline-block;vertical-align: top;">';
-        html += await showBlob(itemDataFile);
+          '<div style="width:48%;display:inline-block;vertical-align:top;">';
+        html += await showBlob(itemDataBlob);
         html += "</div>";
 
         // Show thumbnail section
@@ -147,6 +138,7 @@ export function getItemInfo(
           html += "<p><i>none</i>";
         } else {
           html += "<ol>";
+          // tslint:disable-next-line: prefer-for-of
           for (let i: number = 0; i < itemResourceFiles.length; ++i) {
             html += "<li><div>";
             html += await showBlob(itemResourceFiles[i]);
@@ -199,20 +191,20 @@ export function getItemInfo(
 
                   html +=
                     "<p><i>Service description</i><br/>" +
-                    textAreaHtml(JSON.stringify(properties.service, null, 2)) +
+                    textAreaHtmlFromJSON(properties.service) +
                     "</p>";
 
                   html += "<p><i>Layers</i>";
                   properties.layers.forEach(
                     layer =>
-                      (html += textAreaHtml(JSON.stringify(layer, null, 2)))
+                      (html += textAreaHtmlFromJSON(layer))
                   );
                   html += "</p>";
 
                   html += "<p><i>Tables</i>";
                   properties.tables.forEach(
                     layer =>
-                      (html += textAreaHtml(JSON.stringify(layer, null, 2)))
+                      (html += textAreaHtmlFromJSON(layer))
                   );
                   html += "</p>";
 
@@ -236,7 +228,7 @@ export function getItemInfo(
           )
             .then(results => results.filter(result => !!result))
             .then(
-              // (itemFormInfoFiles: Blob[3])  list of a Form's "form.json", "forminfo.json", & "form.webform" info files
+              // (formFiles: Blob[3])  list of a Form's "form.json", "forminfo.json", & "form.webform" info files
               async formFiles => {
                 formFiles = formFiles.filter(result => !!result);
                 console.log("formFiles", formFiles);
@@ -245,6 +237,7 @@ export function getItemInfo(
                   html += "<p><i>none</i>";
                 } else {
                   html += "<ol>";
+                  // tslint:disable-next-line: prefer-for-of
                   for (let i: number = 0; i < formFiles.length; ++i) {
                     html += "<li><div>";
                     html += await showBlob(formFiles[i]);
@@ -266,12 +259,27 @@ export function getItemInfo(
 }
 
 /**
+ * Creates the HTML for a textarea using the supplied JSON.
+ *
+ * @param json JSON to insert into textarea
+ * @return textarea HTML
+ */
+function textAreaHtmlFromJSON(json: any): string {
+  return textAreaHtmlFromText(
+    JSON.stringify(
+      common.sanitizeJSON(json), 
+      null, 2
+    )
+  );
+}
+
+/**
  * Creates the HTML for a textarea using the supplied text.
  *
  * @param text Text to insert into textarea
  * @return textarea HTML
  */
-function textAreaHtml(text: any): string {
+function textAreaHtmlFromText(text: string): string {
   return (
     '<textarea rows="10" style="width:99%;font-size:x-small">' +
     text +
@@ -308,7 +316,7 @@ function showBlob(blob: Blob): Promise<string> {
       common.blobToJson(blob).then(
         text =>
           resolve(
-            textAreaHtml(JSON.stringify(text, null, 2)) + addFilename(filename)
+            textAreaHtmlFromJSON(text) + addFilename(filename)
           ),
         error => resolve("<i>problem extracting JSON: " + error + "</i>")
       );
@@ -318,7 +326,7 @@ function showBlob(blob: Blob): Promise<string> {
       blob.type === "application/xml"
     ) {
       common.blobToText(blob).then(
-        text => resolve(textAreaHtml(text) + addFilename(filename)),
+        text => resolve(textAreaHtmlFromText(text) + addFilename(filename)),
         error => resolve("<i>problem extracting text: " + error + "</i>")
       );
     } else if (blob.type.startsWith("image/")) {

--- a/demos/getItemInfo/src/main.ts
+++ b/demos/getItemInfo/src/main.ts
@@ -107,25 +107,16 @@ export function getItemInfo(
         const portalUrl = common.getPortalUrlFromAuth(authentication);
 
         // Show item and data sections
-        let html =
-          "<h3>" +
-          itemBase.type +
-          ' "' +
-          itemBase.title +
-          '" (<a href="' +
-          portalUrl +
-          "/home/item.html?id=" +
-          itemBase.id +
-          '" target="_blank">' +
-          itemBase.id +
-          "</a>)</h3>";
+        let html =`
+          <h3>${itemBase.type} "${itemBase.title}" ( <a href="${portalUrl}/home/item.html?id=${itemBase.id}" target="_blank">${itemBase.id}</a> )</h3>
+          `;
 
         html +=
           '<div style="width:48%;display:inline-block;">Item</div>' +
           '<div style="width:2%;display:inline-block;"></div>' +
           '<div style="width:48%;display:inline-block;">Data</div>' +
           '<div style="width:48%;display:inline-block;">' +
-          textAreaHtml(JSON.stringify(itemBase, null, 2)) +
+          textAreaHtmlFromJSON(itemBase) +
           '</div><div style="width:2%;display:inline-block;"></div>' +
           '<div style="width:48%;display:inline-block;vertical-align:top;">';
         html += await showBlob(itemDataBlob);
@@ -200,20 +191,20 @@ export function getItemInfo(
 
                   html +=
                     "<p><i>Service description</i><br/>" +
-                    textAreaHtml(JSON.stringify(properties.service, null, 2)) +
+                    textAreaHtmlFromJSON(properties.service) +
                     "</p>";
 
                   html += "<p><i>Layers</i>";
                   properties.layers.forEach(
                     layer =>
-                      (html += textAreaHtml(JSON.stringify(layer, null, 2)))
+                      (html += textAreaHtmlFromJSON(layer))
                   );
                   html += "</p>";
 
                   html += "<p><i>Tables</i>";
                   properties.tables.forEach(
                     layer =>
-                      (html += textAreaHtml(JSON.stringify(layer, null, 2)))
+                      (html += textAreaHtmlFromJSON(layer))
                   );
                   html += "</p>";
 
@@ -268,12 +259,27 @@ export function getItemInfo(
 }
 
 /**
+ * Creates the HTML for a textarea using the supplied JSON.
+ *
+ * @param json JSON to insert into textarea
+ * @return textarea HTML
+ */
+function textAreaHtmlFromJSON(json: any): string {
+  return textAreaHtmlFromText(
+    JSON.stringify(
+      common.sanitizeJSON(json), 
+      null, 2
+    )
+  );
+}
+
+/**
  * Creates the HTML for a textarea using the supplied text.
  *
  * @param text Text to insert into textarea
  * @return textarea HTML
  */
-function textAreaHtml(text: any): string {
+function textAreaHtmlFromText(text: string): string {
   return (
     '<textarea rows="10" style="width:99%;font-size:x-small">' +
     text +
@@ -310,7 +316,7 @@ function showBlob(blob: Blob): Promise<string> {
       common.blobToJson(blob).then(
         text =>
           resolve(
-            textAreaHtml(JSON.stringify(text, null, 2)) + addFilename(filename)
+            textAreaHtmlFromJSON(text) + addFilename(filename)
           ),
         error => resolve("<i>problem extracting JSON: " + error + "</i>")
       );
@@ -320,7 +326,7 @@ function showBlob(blob: Blob): Promise<string> {
       blob.type === "application/xml"
     ) {
       common.blobToText(blob).then(
-        text => resolve(textAreaHtml(text) + addFilename(filename)),
+        text => resolve(textAreaHtmlFromText(text) + addFilename(filename)),
         error => resolve("<i>problem extracting text: " + error + "</i>")
       );
     } else if (blob.type.startsWith("image/")) {
@@ -344,20 +350,20 @@ function showBlob(blob: Blob): Promise<string> {
       if (filename) {
         resolve(
           '<a href="' +
-          window.URL.createObjectURL(file) +
-          '" download="' +
-          filename +
-          '">' +
-          filename +
-          "</a>"
+            window.URL.createObjectURL(file) +
+            '" download="' +
+            filename +
+            '">' +
+            filename +
+            "</a>"
         );
       } else {
         resolve(
           '<a href="' +
-          window.URL.createObjectURL(blob) +
-          '">' +
-          blob.type +
-          "</a>"
+            window.URL.createObjectURL(blob) +
+            '">' +
+            blob.type +
+            "</a>"
         );
       }
     }

--- a/demos/searchGroupCategories/src/main.ts
+++ b/demos/searchGroupCategories/src/main.ts
@@ -153,7 +153,7 @@ export function runQuery(): void {
       err => {
         document.getElementById("queryResults").innerHTML = colorize(
           "red",
-          textAreaHtml(JSON.stringify(err, null, 2))
+          textAreaHtmlFromJSON(err)
         );
       }
     );
@@ -272,14 +272,29 @@ function colorize(color: string, text: string): string {
 }
 
 /**
+ * Creates the HTML for a textarea using the supplied JSON.
+ *
+ * @param json JSON to insert into textarea
+ * @return textarea HTML
+ */
+function textAreaHtmlFromJSON(json: any): string {
+  return textAreaHtmlFromText(
+    JSON.stringify(
+      common.sanitizeJSON(json), 
+      null, 2
+    )
+  );
+}
+
+/**
  * Creates the HTML for a textarea using the supplied text.
  *
  * @param text Text to insert into textarea
  * @return textarea HTML
  */
-function textAreaHtml(text: string): string {
+function textAreaHtmlFromText(text: string): string {
   return (
-    '<textarea rows="30" style="width:99%;font-size:x-small">' +
+    '<textarea rows="10" style="width:99%;font-size:x-small">' +
     text +
     "</textarea>"
   );


### PR DESCRIPTION
Some items contain HTML in their JSON, which can interfere with the display of demos such as getItemInfo. Escaped the HTML in JSON to fix this problem and for general safety.