### PR TITLE
Allow older hub Solution Template items

### DIFF
--- a/packages/deployer/src/deployerUtils.ts
+++ b/packages/deployer/src/deployerUtils.ts
@@ -113,10 +113,22 @@ export function _isModel(obj: any): boolean {
  * @param item IItem
  */
 export function isSolutionTemplateItem(item: common.IItem): boolean {
-  return (
-    item.type === "Solution" &&
-    item.typeKeywords.indexOf("Solution") > -1 &&
-    (item.typeKeywords.indexOf("Template") > -1 ||
-      item.typeKeywords.indexOf("solutionTemplate") > -1)
-  );
+  const kwds = item.typeKeywords;
+  // Solution items
+  let result = false;
+  if (item.type === "Solution") {
+    if (
+      kwds.indexOf("Solution") > -1 &&
+      (kwds.indexOf("Template") > -1 || kwds.indexOf("solutionTemplate") > -1)
+    ) {
+      result = true;
+    }
+  }
+  // Older Hub Solutions used Web Mapping Application items
+  if (item.type === "Web Mapping Application") {
+    if (kwds.indexOf("hubSolutionTemplate") > -1) {
+      result = true;
+    }
+  }
+  return result;
 }

--- a/packages/deployer/test/deployerUtils.test.ts
+++ b/packages/deployer/test/deployerUtils.test.ts
@@ -66,6 +66,27 @@ describe("Module: `_deployerUtils`", () => {
       } as common.IItem;
       expect(isSolutionTemplateItem(i)).toBe(true);
     });
+    it("returns true for hub solution stored in web mapping applications", () => {
+      const i = {
+        type: "Web Mapping Application",
+        typeKeywords: ["hubSolutionTemplate", "hubSolutionType|something"]
+      } as common.IItem;
+      expect(isSolutionTemplateItem(i)).toBe(true);
+    });
+    it("returns false for web mapping applications w/o hub keywords", () => {
+      const i = {
+        type: "Web Mapping Application",
+        typeKeywords: ["bargle", "garble"]
+      } as common.IItem;
+      expect(isSolutionTemplateItem(i)).toBe(false);
+    });
+    it("returns false for other types", () => {
+      const i = {
+        type: "Web Map",
+        typeKeywords: ["bargle", "garble"]
+      } as common.IItem;
+      expect(isSolutionTemplateItem(i)).toBe(false);
+    });
     it("returns false if missing item type or keywords", () => {
       const i = {
         type: "Solution",


### PR DESCRIPTION
Before the `Solution` item type was available Hub used `Web Mapping Application` with the `hubSolutionTemplate` keyword. Turns out there are a lot of these in PROD, so we need to allow them into the deployer.

This just opens up `isSolutionTemplateItem` to allow these through.