### PR TITLE
Ensure Solutions can load and migrate the oldest hub templates

### DIFF
--- a/packages/common/src/migrations/apply-schema.ts
+++ b/packages/common/src/migrations/apply-schema.ts
@@ -1,0 +1,57 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ISolutionItem,
+  ISolutionItemData,
+  UserSession,
+  IItemGeneralized,
+  IItemTemplate
+} from "../interfaces";
+import { getProp, cloneObject } from "@esri/hub-common";
+
+/**
+ * Apply the initial schema for old Hub Solutions
+ * @param model
+ * @param authentication
+ */
+export function _applySchema(
+  model: ISolutionItem,
+  authentication: UserSession
+): ISolutionItem {
+  if (getProp(model, "item.properties.schemaVersion") >= 1) {
+    return model;
+  }
+
+  const clone = cloneObject(model);
+  if (!clone.item.properties) {
+    clone.item.properties = {};
+  }
+
+  // upgrade the schema of the Templates
+  const templates = getProp(clone, "data.templates") || [];
+  clone.data.templates = templates.map((entry: any) => {
+    return {
+      key: entry.fieldName || entry.key,
+      type: entry.type,
+      item: entry.item as IItemGeneralized,
+      data: entry.data,
+      itemId: entry.itemId || entry.fieldName || entry.key,
+      resources: entry.resources || []
+    } as IItemTemplate;
+  });
+  clone.item.properties.schemaVersion = 1;
+  return clone;
+}

--- a/packages/common/src/migrations/upgrade-two-dot-one.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-one.ts
@@ -1,0 +1,36 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UserSession } from "../interfaces";
+import { getProp, cloneObject } from "@esri/hub-common";
+
+/**
+ *
+ * @param model
+ * @param authentication
+ * @private
+ */
+export function _upgradeTwoDotOne(model: any, authentication: UserSession) {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.1) {
+    return model;
+  }
+  model.data.templates = model.data.templates.map((entry: any) => {
+    entry.key = entry.fieldName || entry.key;
+    entry.itemId = entry.itemId || entry.key;
+    return entry;
+  });
+  model.item.properties.schemaVersion = 2.1;
+  return model;
+}

--- a/packages/common/src/migrations/upgrade-two-dot-zero.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-zero.ts
@@ -1,0 +1,96 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UserSession } from "../interfaces";
+import { getProp, cloneObject } from "@esri/hub-common";
+
+/**
+ * Convert indicator "definitions" from the CAS style to the Indicator schema
+ * see https://github.com/ArcGIS/Hub/blob/master/indicators.md
+ * @param model
+ * @param authentication
+ * @private
+ */
+export function _upgradeTwoDotZero(
+  model: any,
+  authentication: UserSession
+): any {
+  if (getProp(model, "item.properties.schemaVersion") >= 2) {
+    return model;
+  }
+  // get the indicators from the .configurationSettings...
+  const clone = cloneObject(model);
+  const configSettings = getProp(clone, "data.configurationSettings") || [];
+
+  const indicatorsHash = configSettings.find(
+    (e: any) => e.category === "Indicators"
+  );
+  clone.data.indicators = _convertIndicatorsToDefinitions(indicatorsHash);
+  // remove CAS structure
+  delete clone.data.configurationSettings;
+
+  // set the schemaVersion...
+  clone.item.properties.schemaVersion = 2;
+  return clone;
+}
+
+/**
+ * Given the Indicators entry from a CAS configurationSettings array,
+ * convert to an indicators object in the new schema
+ * @private
+ */
+export function _convertIndicatorsToDefinitions(indicatorsHash: any = {}) {
+  // the incoming structure should have a .fields property, and what we want will be in there...
+  if (!indicatorsHash.fields || !Array.isArray(indicatorsHash.fields)) {
+    indicatorsHash.fields = [];
+  }
+  const defs = indicatorsHash.fields.map(_convertIndicatorToDefinition);
+  // now we need to create an object which has props for each def
+  return defs;
+}
+
+/**
+ * Convert a CAS formatted indicator to the .definition in the new schama
+ * @private
+ */
+export const _convertIndicatorToDefinition = function(ind: any) {
+  const def = {
+    id: ind.fieldName,
+    type: "Data",
+    name: ind.label || ind.fieldName,
+    optional: ind.optional || false,
+    definition: {
+      description: ind.label || ind.fieldName,
+      supportedTypes: [...ind.layerOptions.supportedTypes],
+      geometryTypes: [...ind.layerOptions.geometryTypes],
+      fields: ind.fields.map(_convertIndicatorField)
+    }
+  };
+  return def;
+};
+
+/**
+ * Convert the CAS formatted "field" into the new schema
+ * @private
+ */
+export const _convertIndicatorField = function(field: any) {
+  return {
+    id: field.fieldName,
+    name: field.label,
+    optional: field.optional || false,
+    description: field.tooltip,
+    supportedTypes: [...field.supportedTypes]
+  };
+};

--- a/packages/common/src/migrator.ts
+++ b/packages/common/src/migrator.ts
@@ -16,13 +16,17 @@
 
 import { ISolutionItem, UserSession } from "./interfaces";
 import { _isLegacySolution } from "./migrations/is-legacy-solution";
-import { _upgradeThreeDotOne } from "./migrations/upgrade-three-dot-one";
-import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
+import { _applySchema } from "./migrations/apply-schema";
+import { _upgradeTwoDotZero } from "./migrations/upgrade-two-dot-zero";
+import { _upgradeTwoDotOne } from "./migrations/upgrade-two-dot-one";
 import { _upgradeTwoDotTwo } from "./migrations/upgrade-two-dot-two";
 import { _upgradeTwoDotThree } from "./migrations/upgrade-two-dot-three";
 import { _upgradeTwoDotFour } from "./migrations/upgrade-two-dot-four";
 import { _upgradeTwoDotFive } from "./migrations/upgrade-two-dot-five";
 import { _upgradeTwoDotSix } from "./migrations/upgrade-two-dot-six";
+import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
+import { _upgradeThreeDotOne } from "./migrations/upgrade-three-dot-one";
+
 import { getProp } from "@esri/hub-common";
 
 // Starting at 3.0 because Hub has been versioning Solution items up to 2.x
@@ -61,21 +65,21 @@ export function migrateSchema(
     } else {
       // Hub created a set of Solution items that are not 100% compatible
       // with the Solution.js deployer.
-      // The schemaVersion of these items is 2.1 - prior to that we used
-      // Web Mapping Application items, which are deprecated
-      if (modelVersion >= 2.1 && modelVersion < 3) {
-        schemaUpgrades.push(
-          _upgradeTwoDotTwo,
-          _upgradeTwoDotThree,
-          _upgradeTwoDotFour,
-          _upgradeTwoDotFive,
-          _upgradeTwoDotSix
-        );
-      }
+      schemaUpgrades.push(
+        _applySchema,
+        _upgradeTwoDotZero,
+        _upgradeTwoDotOne,
+        _upgradeTwoDotTwo,
+        _upgradeTwoDotThree,
+        _upgradeTwoDotFour,
+        _upgradeTwoDotFive,
+        _upgradeTwoDotSix
+      );
       // Apply the 3.x upgrades
-      // TEMP to allow merge to develop w/o breaking things
-      schemaUpgrades.push(_upgradeThreeDotZero);
-      // schemaUpgrades.push(_upgradeThreeDotZero, _upgradeThreeDotOne);
+      schemaUpgrades.push(
+        _upgradeThreeDotZero
+        // _upgradeThreeDotOne // Not ready for prod yet
+      );
     }
     // Run any migrations serially. Since we start with a promise,
     // individual migrations are free to return either ISolutionItem

--- a/packages/common/test/migrations/apply-schema.test.ts
+++ b/packages/common/test/migrations/apply-schema.test.ts
@@ -1,0 +1,122 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _applySchema } from "../../src/migrations/apply-schema";
+import * as utils from "../mocks/utils";
+import {
+  ISolutionItem,
+  IItemGeneralized,
+  IItemTemplate
+} from "../../src/interfaces";
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("applySchema :: ", () => {
+  it("passes same object through if schema >= 1", () => {
+    const m = {
+      item: {
+        properties: {
+          schemaVersion: 1
+        }
+      }
+    } as ISolutionItem;
+    const chk = _applySchema(m, MOCK_USER_SESSION);
+    expect(chk).toBe(m, "should pass model through without cloning");
+  });
+
+  it("adds properties if missing", () => {
+    const m = {
+      item: {},
+      data: {}
+    } as ISolutionItem;
+    const chk = _applySchema(m, MOCK_USER_SESSION);
+    expect(chk).not.toBe(m, "should clone model");
+    expect(chk.item.properties).toBeDefined("should add item.properties");
+  });
+
+  it("converts template entries", () => {
+    const m = ({
+      item: {
+        properties: {
+          otherProp: "exists"
+        }
+      },
+      data: {
+        templates: [
+          {
+            fieldName: "becomesKey",
+            type: "staysType",
+            item: {
+              id: "staysItem"
+            } as IItemGeneralized,
+            data: {}
+          },
+          {
+            key: "remainsKey",
+            type: "staysType",
+            item: {
+              id: "staysItem"
+            } as IItemGeneralized,
+            data: {},
+            resources: ["theresources"]
+          },
+          {
+            fieldName: "becomesKey",
+            itemId: "remainsItemId",
+            type: "staysType",
+            item: {
+              id: "staysItem"
+            } as IItemGeneralized,
+            data: {},
+            resources: ["theresources"]
+          }
+        ]
+      }
+    } as unknown) as ISolutionItem;
+    const chk = _applySchema(m, MOCK_USER_SESSION);
+    expect(chk).not.toBe(m, "should clone model");
+    expect(chk.item.properties).toBeDefined("should add item.properties");
+    const tmpl0 = chk.data.templates[0];
+    const convertedTmpl0 = {
+      key: "becomesKey",
+      type: "staysType",
+      item: ({ id: "staysItem" } as unknown) as IItemGeneralized,
+      data: {},
+      itemId: "becomesKey",
+      resources: []
+    } as IItemTemplate;
+    expect(tmpl0).toEqual(convertedTmpl0, "should transform first template");
+    const tmpl1 = chk.data.templates[1];
+    const convertedTmpl1 = {
+      key: "remainsKey",
+      type: "staysType",
+      item: ({ id: "staysItem" } as unknown) as IItemGeneralized,
+      data: {},
+      itemId: "remainsKey",
+      resources: ["theresources"]
+    } as IItemTemplate;
+    expect(tmpl1).toEqual(convertedTmpl1, "should transform second template");
+    const tmpl2 = chk.data.templates[2];
+    const convertedTmpl2 = {
+      key: "becomesKey",
+      type: "staysType",
+      item: ({ id: "staysItem" } as unknown) as IItemGeneralized,
+      data: {},
+      itemId: "remainsItemId",
+      resources: ["theresources"]
+    } as IItemTemplate;
+    expect(tmpl2).toEqual(convertedTmpl2, "should transform third template");
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-one.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-one.test.ts
@@ -1,0 +1,75 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { _upgradeTwoDotOne } from "../../src/migrations/upgrade-two-dot-one";
+import * as utils from "../mocks/utils";
+import {
+  ISolutionItem,
+  IItemGeneralized,
+  IItemTemplate
+} from "../../src/interfaces";
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("upgradeTwoDotOne :: ", () => {
+  it("passes same object through if schema >= 2.1", () => {
+    const m = {
+      item: {
+        properties: {
+          schemaVersion: 2.1
+        }
+      }
+    } as ISolutionItem;
+    const chk = _upgradeTwoDotOne(m, MOCK_USER_SESSION);
+    expect(chk).toBe(m, "should pass model through without cloning");
+  });
+
+  it("remaps templates", () => {
+    const m = ({
+      item: {
+        properties: {
+          schemaVersion: 2.0
+        }
+      },
+      data: {
+        templates: [
+          {
+            fieldName: "becomesKey"
+          },
+          {
+            key: "staysKey"
+          },
+          {
+            key: "staysKey",
+            itemId: "staysItemId"
+          }
+        ]
+      }
+    } as unknown) as ISolutionItem;
+    const chk = _upgradeTwoDotOne(m, MOCK_USER_SESSION);
+    expect(chk.item.properties.schemaVersion).toBe(
+      2.1,
+      "should set schemaVersion to 2.1"
+    );
+    const chkTmpl0 = chk.data.templates[0];
+    expect(chkTmpl0.key).toBe("becomesKey", "should use fieldName if present");
+    expect(chkTmpl0.itemId).toBe("becomesKey", "should use key if present");
+    const chkTmpl1 = chk.data.templates[1];
+    expect(chkTmpl1.key).toBe("staysKey", "should keep key if present");
+    expect(chkTmpl1.itemId).toBe("staysKey", "should use key if present");
+    const chkTmpl2 = chk.data.templates[2];
+    expect(chkTmpl2.key).toBe("staysKey", "should keep key if present");
+    expect(chkTmpl2.itemId).toBe("staysItemId", "should use itemId if present");
+  });
+});

--- a/packages/common/test/migrations/upgrade-two-dot-zero.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-zero.test.ts
@@ -1,0 +1,305 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  _upgradeTwoDotZero,
+  _convertIndicatorField,
+  _convertIndicatorToDefinition,
+  _convertIndicatorsToDefinitions
+} from "../../src/migrations/upgrade-two-dot-zero";
+import * as utils from "../mocks/utils";
+import {
+  ISolutionItem,
+  IItemGeneralized,
+  IItemTemplate
+} from "../../src/interfaces";
+const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+
+describe("_upgradeTwoDotZero :: ", () => {
+  describe("upgrade :: ", () => {
+    it("passes same object through if schema >= 1", () => {
+      const m = {
+        item: {
+          properties: {
+            schemaVersion: 2
+          }
+        }
+      } as ISolutionItem;
+      const chk = _upgradeTwoDotZero(m, MOCK_USER_SESSION);
+      expect(chk).toBe(m, "should pass model through without cloning");
+    });
+
+    it("removes configurationSettings", () => {
+      const m = ({
+        item: {
+          properties: {
+            schemaVersion: 1
+          }
+        },
+        data: {
+          configurationSettings: []
+        }
+      } as unknown) as ISolutionItem;
+      const chk = _upgradeTwoDotZero(m, MOCK_USER_SESSION);
+      expect(chk).not.toBe(m, "should clone model");
+      expect(chk.item.properties.schemaVersion).toBe(
+        2,
+        "should set schemaVersion to 2"
+      );
+      expect(chk.data.configurationSettings).not.toBeDefined(
+        "should remove config settings"
+      );
+    });
+
+    it("handles missing configurationSettings", () => {
+      const m = ({
+        item: {
+          properties: {
+            schemaVersion: 1
+          }
+        },
+        data: {}
+      } as unknown) as ISolutionItem;
+      const chk = _upgradeTwoDotZero(m, MOCK_USER_SESSION);
+      expect(chk).not.toBe(m, "should clone model");
+      expect(chk.item.properties.schemaVersion).toBe(
+        2,
+        "should set schemaVersion to 2"
+      );
+      expect(chk.data.configurationSettings).not.toBeDefined(
+        "should remove config settings"
+      );
+    });
+
+    it("converts indicators", () => {
+      const m = ({
+        item: {
+          properties: {
+            schemaVersion: 1
+          }
+        },
+        data: {
+          configurationSettings: [
+            {
+              category: "Indicators"
+            }
+          ]
+        }
+      } as unknown) as ISolutionItem;
+      const chk = _upgradeTwoDotZero(m, MOCK_USER_SESSION);
+      expect(chk).not.toBe(m, "should clone model");
+      expect(chk.item.properties.schemaVersion).toBe(
+        2,
+        "should set schemaVersion to 2"
+      );
+      expect(chk.data.configurationSettings).not.toBeDefined(
+        "should remove config settings"
+      );
+    });
+  });
+
+  describe("helper functions", () => {
+    it("can convert cas indicator to definition", done => {
+      const ind = {
+        label: "Collision Data",
+        type: "layerAndFieldSelector",
+        fieldName: "collisionLayer",
+        layerOptions: {
+          geometryTypes: [
+            "esriGeometryPoint",
+            "esriGeometryLine",
+            "esriGeometryPolygon"
+          ],
+          supportedTypes: ["FeatureLayer", "FeatureCollection"]
+        },
+        fields: [
+          {
+            tooltip: "Count of people…",
+            label: "Number of Injuries",
+            fieldName: "numInjuries",
+            supportedTypes: ["esriFieldTypeInteger"]
+          },
+          {
+            tooltip: "Count of deaths…",
+            label: "Number of Fatalities",
+            fieldName: "numFatalities",
+            supportedTypes: ["esriFieldTypeInteger"]
+          }
+        ]
+      } as any;
+      const c = _convertIndicatorToDefinition(ind);
+      expect(c).not.toBe(ind, "returned field should not be the same object");
+      expect(c.id).toEqual(ind.fieldName, "fieldName becomes id");
+      expect(c.name).toEqual(ind.label, "label becomes name");
+      expect(c.definition.description).toEqual(
+        ind.label,
+        "label becomes description"
+      );
+      expect(c.definition.supportedTypes.length).toEqual(
+        ind.layerOptions.supportedTypes.length,
+        "supported types have same contents"
+      );
+      expect(c.definition.geometryTypes).not.toBe(
+        ind.layerOptions.geometryTypes,
+        "geometryTypes should not be same instance"
+      );
+      expect(c.definition.geometryTypes.length).toEqual(
+        ind.layerOptions.geometryTypes.length,
+        "geometryTypes have same contents"
+      );
+      expect(c.definition.fields.length).toEqual(
+        ind.fields.length,
+        "fields have same contents"
+      );
+      done();
+    });
+    it("can convert cas indicator without label to definition", done => {
+      const ind = {
+        // label: "Collision Data",
+        type: "layerAndFieldSelector",
+        fieldName: "collisionLayer",
+        layerOptions: {
+          geometryTypes: [
+            "esriGeometryPoint",
+            "esriGeometryLine",
+            "esriGeometryPolygon"
+          ],
+          supportedTypes: ["FeatureLayer", "FeatureCollection"]
+        },
+        fields: [
+          {
+            tooltip: "Count of people…",
+            label: "Number of Injuries",
+            fieldName: "numInjuries",
+            supportedTypes: ["esriFieldTypeInteger"]
+          },
+          {
+            tooltip: "Count of deaths…",
+            label: "Number of Fatalities",
+            fieldName: "numFatalities",
+            supportedTypes: ["esriFieldTypeInteger"]
+          }
+        ]
+      } as any;
+      const c = _convertIndicatorToDefinition(ind);
+      expect(c).not.toBe(ind, "returned field should not be the same object");
+      expect(c.id).toEqual(ind.fieldName, "fieldName becomes id");
+      expect(c.name).toEqual(
+        ind.fieldName,
+        "fieldName becomes name if not label"
+      );
+      expect(c.definition.description).toEqual(
+        ind.fieldName,
+        "field becomes description if no label"
+      );
+      expect(c.definition.supportedTypes.length).toEqual(
+        ind.layerOptions.supportedTypes.length,
+        "supported types have same contents"
+      );
+      expect(c.definition.geometryTypes).not.toBe(
+        ind.layerOptions.geometryTypes,
+        "geometryTypes should not be same instance"
+      );
+      expect(c.definition.geometryTypes.length).toEqual(
+        ind.layerOptions.geometryTypes.length,
+        "geometryTypes have same contents"
+      );
+      expect(c.definition.fields.length).toEqual(
+        ind.fields.length,
+        "fields have same contents"
+      );
+      done();
+    });
+    it("can convert cas field to definition field", done => {
+      const fld = {
+        tooltip: "Count of people…",
+        label: "Number of Injuries",
+        fieldName: "numInjuries",
+        supportedTypes: ["esriFieldTypeInteger"]
+      } as any;
+      const c = _convertIndicatorField(fld);
+      expect(c).not.toEqual(
+        fld,
+        "returned field should not be the same object"
+      );
+      expect(c.id).toEqual(fld.fieldName, "fieldName becomes id");
+      expect(c.name).toEqual(fld.label, "label becomes name");
+      expect(c.supportedTypes).not.toBe(
+        fld.supportedTypes,
+        "supported types should not be same instance"
+      );
+      expect(c.supportedTypes.length).toEqual(
+        fld.supportedTypes.length,
+        "supported types have same contents"
+      );
+      done();
+    });
+    it("can convert configSettings indicator structure to indicators hash", done => {
+      const cs = {
+        category: "Indicators",
+        fields: [
+          {
+            fieldName: "collisionLayer",
+            label: "Collision Data",
+            type: "layerAndFieldSelector",
+            layerOptions: {
+              geometryTypes: [
+                "esriGeometryPoint",
+                "esriGeometryLine",
+                "esriGeometryPolygon"
+              ],
+              supportedTypes: ["FeatureLayer", "FeatureCollection"]
+            },
+            fields: [
+              {
+                tooltip: "Count of people…",
+                label: "Number of Injuries",
+                fieldName: "numInjuries",
+                supportedTypes: ["esriFieldTypeInteger"]
+              },
+              {
+                tooltip: "Count of deaths…",
+                label: "Number of Fatalities",
+                fieldName: "numFatalities",
+                supportedTypes: ["esriFieldTypeInteger"]
+              }
+            ]
+          }
+        ]
+      } as any;
+
+      // now pass this into the converter...
+      const c = _convertIndicatorsToDefinitions(cs);
+      expect(Array.isArray(c)).toBeTruthy("should return an array");
+      expect(c[0].id).toEqual(
+        "collisionLayer",
+        "collisionLayer should be the id of the first entry"
+      );
+      done();
+    });
+    it("handles configSettings with no fields", done => {
+      const cs = {
+        category: "Indicators"
+      } as any;
+
+      // now pass this into the converter...
+      const c = _convertIndicatorsToDefinitions(cs);
+      expect(Array.isArray(c)).toBeTruthy("should return an array");
+      expect(c.length).toEqual(0, "should have no entries");
+      done();
+    });
+  });
+});

--- a/packages/deployer/src/deployerUtils.ts
+++ b/packages/deployer/src/deployerUtils.ts
@@ -44,7 +44,8 @@ export function _getSolutionTemplateItem(
   } else {
     // check if it is a "Model"
     if (_isModel(idOrObject)) {
-      return Promise.resolve(idOrObject);
+      // run migrations
+      return common.migrateSchema(idOrObject, authentication);
     } else {
       return Promise.reject(
         common.fail(


### PR DESCRIPTION
This adds more migrations to allow Hub to send the oldest of hub "solution" templates through this processing chain.

It also applies migrations to any solution model objects passed into `deploySolution(maybeModel, ...)`. This greatly streamlines things for applications which need to pre-process the solution i.e. translating content in the templates

I'm going to try to "link" this branch into the opendata-ui app, to verify, but these are the same fn's we run in the Hub app, so I'm pretty confident :)