### PR TITLE
Changed folder handling to support Firefox

### DIFF
--- a/packages/common/src/libConnectors.ts
+++ b/packages/common/src/libConnectors.ts
@@ -29,14 +29,19 @@ export { Sanitizer } from "@esri/arcgis-html-sanitizer";
  *
  * @param zipFilename Name to use for zip File
  * @param files List of files to add to zip File
+ * @param folder Folder to contain the files
  * @return Promise resolving to a zip File
  */
-export function createZip(zipFilename: string, files: File[]): Promise<File> {
+export function createZip(zipFilename: string, files: File[], folder?: string): Promise<File> {
   return new Promise<File>((resolve, reject) => {
     const zip = new JSZip();
+    let container = zip;
+    if (folder) {
+      container = zip.folder(folder);
+    }
 
     // Add the files
-    files.forEach(file => zip.file(file.name, file, { binary: true }));
+    files.forEach(file => container.file(file.name, file, { binary: true }));
 
     // Create the ZIP
     zip

--- a/packages/common/test/libConnectors.test.ts
+++ b/packages/common/test/libConnectors.test.ts
@@ -60,7 +60,7 @@ describe("Module `JSZip`: JavaScript-based zip utility", () => {
 
       it("handles one file in a folder", done => {
         libConnectors
-          .createZip("zipfile", [getSampleMetadataAsFile("info/metadata")])
+          .createZip("zipfile", [getSampleMetadataAsFile("metadata")], "info")
           .then(zipfile => {
             expect(zipfile.name)
               .withContext("zip created")


### PR DESCRIPTION
JSZip behaves differently creating folders in Chrome and Firefox. Changed approach so that it works in both.