### PR TITLE
[StoryMap] Ensure uploading of actual blob vs undefined

### DIFF
--- a/packages/storymap/src/helpers/create-storymap.ts
+++ b/packages/storymap/src/helpers/create-storymap.ts
@@ -68,15 +68,15 @@ export function createStoryMap(
       // We'll just use the published data for the first "draft"
       resources.push({
         name: model.properties.draftFileName,
-        resource: stringToBlob(JSON.stringify(model.data))
+        file: stringToBlob(JSON.stringify(model.data))
       });
       resources.push({
         name: "oembed.json",
-        resource: stringToBlob(JSON.stringify(model.properties.oembed))
+        file: stringToBlob(JSON.stringify(model.properties.oembed))
       });
       resources.push({
         name: "oembed.xml",
-        resource: stringToBlob(model.properties.oembedXML)
+        file: stringToBlob(model.properties.oembedXML)
       });
       // remove the properties hash now that we've gotten what we need
       delete model.properties;

--- a/packages/storymap/test/helpers/create-storymap.test.ts
+++ b/packages/storymap/test/helpers/create-storymap.test.ts
@@ -78,6 +78,13 @@ describe("createStoryMap ::", () => {
           );
           expect(updateItemSpy.calls.count()).toBe(1, "should call updateItem");
           expect(addResSpy.calls.count()).toBe(3, "should add three resources");
+          if (typeof Blob !== "undefined") {
+            const draftArgs = addResSpy.calls.argsFor(0)[0];
+            expect(draftArgs.resource instanceof Blob).toBe(
+              true,
+              "should send a blob"
+            );
+          }
           expect(moveItemSpy.calls.count()).toBe(1, "should move the item");
           const moveOpts = moveItemSpy.calls.argsFor(0)[0];
           expect(moveOpts.folderId).toBe(


### PR DESCRIPTION
A typo resulted in the draft, and oembed resources uploading `undefined` vs the actual content. The platform would of course report success, but... nothing would actually be uploaded. 

The current PROD version of StoryMaps is not tolerant of a missing `draft-<datestamp>.json` file, and thus fails like this:

![image](https://user-images.githubusercontent.com/119129/88930988-7d935d80-d239-11ea-929f-4522a3f8ea0c.png)

By hacking in node_modules I was able to locate the issue and test the fix that is applied in this PR... here is an example of a StoryMap that was deployed via this code:

![image](https://user-images.githubusercontent.com/119129/88931095-9d2a8600-d239-11ea-8c7f-c8f7d31d7f27.png)
[https://storymaps.arcgis.com/stories/dd77c029b70148d7938ba567cdfd3c9f](https://storymaps.arcgis.com/stories/dd77c029b70148d7938ba567cdfd3c9f)

Not sure if we need to do some form of hotfix for Prod, but the Hub team needs this in a release asap fo we can move forward with our transition over to using Solution.js instead of our Ember version of this stuff. Sorry we missed this, but as you all know, testing anything around `Blob`s is messy at best.
