### PR TITLE
Fix `createHubRequestOptions` for Portal`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ TODO.md
 demos/deploy-harness
 demos/**/index-local.html
 !demos/deploySolution/data/appConfig.js
+
+demos/ember-build-harness 

--- a/packages/hub-types/src/helpers/create-hub-request-options.ts
+++ b/packages/hub-types/src/helpers/create-hub-request-options.ts
@@ -61,13 +61,17 @@ export function createHubRequestOptions(
 
   return orgUserPrms.then(([pSelf, user]) => {
     pSelf.user = user;
-    const hubApiUrl = getHubUrlFromPortal(pSelf);
 
-    return {
+    const ro = {
       authentication,
       portalSelf: pSelf,
-      isPortal: pSelf.isPortal,
-      hubApiUrl
+      isPortal: pSelf.isPortal
     } as IHubRequestOptions;
+
+    if (!pSelf.isPortal) {
+      ro.hubApiUrl = getHubUrlFromPortal(pSelf);
+    }
+
+    return ro;
   });
 }

--- a/packages/hub-types/test/helpers/create-hub-request-options.test.ts
+++ b/packages/hub-types/test/helpers/create-hub-request-options.test.ts
@@ -67,4 +67,35 @@ describe("createHubRequestOptions", () => {
       done();
     });
   });
+
+  it("does not sent hubApiUrl if portal", () => {
+    const td = {
+      organization: {
+        id: "somePortalId",
+        portalHostname: "www.arcgis.com",
+        isPortal: true
+      },
+      user: {
+        username: "vader"
+      }
+    };
+
+    return createHubRequestOptions(MOCK_USER_SESSION, td).then(hubRo => {
+      expect(hubRo.hubApiUrl).not.toBeDefined(
+        "should not return hubApiUrl for portal"
+      );
+      expect(hubRo.portalSelf.id).toBe(
+        "somePortalId",
+        "should copy organization to portalSelf"
+      );
+      expect(hubRo.portalSelf.user.username).toBe(
+        "vader",
+        "should copy user to portalSelf.user"
+      );
+      expect(hubRo.authentication).toBe(
+        MOCK_USER_SESSION,
+        "should pass thru the auth"
+      );
+    });
+  });
 });


### PR DESCRIPTION
The `createHubRequestOptions` helper function in `hub-types` was not handling Portal correctly, resulting in an error being thrown from a underlying hub.js function.

Verified this works by running the Solution.js pipeline, in Hub, backed by a Portal 10.8.1 instance

Closes #439 