### PR TITLE
Guard against non-templated items in Group deps

### DIFF
--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -28,7 +28,7 @@ import {
   SItemProgressStatus,
   updateItem
 } from "@esri/solution-common";
-import { getProp } from "@esri/hub-common";
+import { getProp, getWithDefault } from "@esri/hub-common";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import {
   createItemTemplate,
@@ -203,14 +203,22 @@ export function _postProcessGroupDependencies(
           templates,
           dependencyId
         );
-        const gIndex = dependantTemplate.dependencies.indexOf(id);
-        /* istanbul ignore else */
-        if (gIndex > -1) {
-          removeDependencies = true;
-        }
-        /* istanbul ignore else */
-        if (dependantTemplate.groups.indexOf(id) < 0) {
-          dependantTemplate.groups.push(id);
+        // Not all items shared to the group will exist in the templates array
+        // i.e. Hub Initiative items or any other unsupported types
+        if (dependantTemplate) {
+          const gIndex = getWithDefault(
+            dependantTemplate,
+            "dependencies",
+            []
+          ).indexOf(id);
+          /* istanbul ignore else */
+          if (gIndex > -1) {
+            removeDependencies = true;
+          }
+          /* istanbul ignore else */
+          if (dependantTemplate.groups.indexOf(id) < 0) {
+            dependantTemplate.groups.push(id);
+          }
         }
       });
       if (removeDependencies) {

--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -206,18 +206,23 @@ export function _postProcessGroupDependencies(
         // Not all items shared to the group will exist in the templates array
         // i.e. Hub Initiative items or any other unsupported types
         if (dependantTemplate) {
+          // check if the group is in the dependantTemplate's list of dependencies
           const gIndex = getWithDefault(
             dependantTemplate,
             "dependencies",
             []
           ).indexOf(id);
+
           /* istanbul ignore else */
           if (gIndex > -1) {
             removeDependencies = true;
           }
-          /* istanbul ignore else */
-          if (dependantTemplate.groups.indexOf(id) < 0) {
-            dependantTemplate.groups.push(id);
+          // if the dependant template does not have the group id
+          // in it's groups array, add it
+          const groups = getWithDefault(dependantTemplate, "groups", []);
+          if (groups.indexOf(id) === -1) {
+            groups.push(id);
+            dependantTemplate.groups = groups;
           }
         }
       });

--- a/packages/creator/test/helpers/add-content-to-solution.test.ts
+++ b/packages/creator/test/helpers/add-content-to-solution.test.ts
@@ -200,7 +200,7 @@ describe("_postProcessGroupDependencies", () => {
       {
         type: "Group",
         itemId: "bc3-group",
-        dependencies: ["3ef-webmap", "cb7-initiative"],
+        dependencies: ["3ef-webmap", "cb7-initiative", "3ef-webmap2"],
         groups: []
       } as common.IItemTemplate,
       {
@@ -217,12 +217,16 @@ describe("_postProcessGroupDependencies", () => {
       } as common.IItemTemplate,
       {
         type: "Web Map",
-        itemId: "3ef-webmap",
-        groups: []
+        itemId: "3ef-webmap"
+      } as common.IItemTemplate,
+      {
+        type: "Web Map",
+        itemId: "3ef-webmap2",
+        groups: ["bc3-group"]
       } as common.IItemTemplate
     ];
     const result = _postProcessGroupDependencies(tmpls);
-    expect(result.length).toBe(4, "should have 4 templates");
+    expect(result.length).toBe(5, "should have 5 templates");
     const webappEntry = findBy(result, "itemId", "3ef-webapp");
     expect(webappEntry.groups.length).toBe(
       0,

--- a/packages/creator/test/helpers/add-content-to-solution.test.ts
+++ b/packages/creator/test/helpers/add-content-to-solution.test.ts
@@ -26,6 +26,7 @@ import * as mockItems from "../../../common/test/mocks/agolItems";
 import * as utils from "../../../common/test/mocks/utils";
 import * as templates from "../../../common/test/mocks/templates";
 import * as staticRelatedItemsMocks from "../../../common/test/mocks/staticRelatedItemsMocks";
+import { findBy } from "@esri/hub-common";
 // Set up a UserSession to use in all these tests
 const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
 
@@ -190,6 +191,47 @@ describe("_postProcessGroupDependencies", () => {
     const actual = _postProcessGroupDependencies(_templates);
     expect(actual).toEqual(expected);
     done();
+  });
+
+  it("allows for items without dependencies", () => {
+    // Make the most minimal object graph to verify
+    // the specific functionality of this test
+    const tmpls = [
+      {
+        type: "Group",
+        itemId: "bc3-group",
+        dependencies: ["3ef-webmap", "cb7-initiative"],
+        groups: []
+      } as common.IItemTemplate,
+      {
+        type: "Web App",
+        itemId: "3ef-webapp",
+        dependencies: ["bc3-group"],
+        groups: []
+      } as common.IItemTemplate,
+      {
+        type: "Hub Site Application",
+        itemId: "3ef-site",
+        dependencies: ["3ef-webapp"],
+        groups: []
+      } as common.IItemTemplate,
+      {
+        type: "Web Map",
+        itemId: "3ef-webmap",
+        groups: []
+      } as common.IItemTemplate
+    ];
+    const result = _postProcessGroupDependencies(tmpls);
+    expect(result.length).toBe(4, "should have 4 templates");
+    const webappEntry = findBy(result, "itemId", "3ef-webapp");
+    expect(webappEntry.groups.length).toBe(
+      0,
+      "should not add group to web app"
+    );
+    const siteEntry = findBy(result, "itemId", "3ef-site");
+    expect(siteEntry.groups.length).toBe(0, "should not add groups site");
+    const mapEntry = findBy(result, "itemId", "3ef-webmap");
+    expect(mapEntry.groups.length).toBe(1, "should add groups map");
   });
 
   it("add group dependencies to groups array", done => {

--- a/packages/hub-types/package.json
+++ b/packages/hub-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@esri/solution-hub-types",
   "version": "0.17.3",
-  "description": "Manages the creation and deployment of Hub Site and Hub Page item types for @esri/solution.js.",
+  "description": "Manages the creation and deployment of Hub Site and Hub Page item types for @esri/solution.js..",
   "main": "dist/node/index.js",
   "unpkg": "dist/umd/hub-types.umd.min.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
When a group is included in the templating process, the system attempts to include all the items shared to the group. However, not all items can be templated - i.e. `Hub Initiative` items. 

This PR just adds a guard into the `_postProcessGroupDependencies` function so it does not attempt to process the dependantTemplate if it's not found in the templates array.