### PR TITLE
Tweak demo setup to fix `global` problem and symbolic links

### DIFF
--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -1,385 +1,385 @@
 {
-  "name": "demos",
-  "version": "0.19.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@esri/arcgis-html-sanitizer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
-      "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
-      "requires": {
-        "lodash.isplainobject": "^4.0.6",
-        "xss": "^1.0.6"
-      }
-    },
-    "@esri/arcgis-rest-auth": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.19.2.tgz",
-      "integrity": "sha512-74AJOldHCV6kNWzL/hh/VbGRrBNaZj3c080/yNTVagnqAUEoAtCAkhdEhT4M7cWsOEe8+lPGjL6MxAYfrD39PA==",
-      "requires": {
-        "@esri/arcgis-rest-types": "^2.19.2",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/arcgis-rest-feature-layer": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.19.2.tgz",
-      "integrity": "sha512-08kXUibefpwZrDu0EL0oh7yQ0NsGtqLJtJBPIFnX7w6XAPZ1SRYZ39O8BC9RJyUtYyfj2CBNz17r7fL0yxbOwg==",
-      "requires": {
-        "@esri/arcgis-rest-types": "^2.19.2",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/arcgis-rest-portal": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.19.2.tgz",
-      "integrity": "sha512-TQlpFbrIh2SwAcswg++OD0VskQrBpPnA/i2+UgA5lhEL2HxRZr0En3V4LRCP9RQ+B59oFvblhqTZraqo+CQW0w==",
-      "requires": {
-        "@esri/arcgis-rest-types": "^2.19.2",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/arcgis-rest-request": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.19.2.tgz",
-      "integrity": "sha512-zkYMZQBu5WvtSxlealNHOiRldyei6o7MGPCSjZoQ7mMDJ8jLpfBa985kXj9wutbKMrD7zVpMvoeFh7fErHFf8A==",
-      "requires": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "@esri/arcgis-rest-service-admin": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.19.2.tgz",
-      "integrity": "sha512-4jOVw7IoXHXZ6/TY98Bh2Z7XuR/oexd5JgY+NLVBP7rCPZhW5rfIGnLZNviFJHJiZC6brlurFiWoDbOn7NomWw==",
-      "requires": {
-        "@esri/arcgis-rest-types": "^2.19.2",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/arcgis-rest-types": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.19.2.tgz",
-      "integrity": "sha512-+Bamtdg4GH+Uf6VvIB2A+1G2UsFYmx6pKdjfFS8AAbb7t/7c/lnKpsQSguyw/NCvp4CiJCjfC5x1S91vp+bvuA=="
-    },
-    "@esri/hub-common": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-      "integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
-      "requires": {
-        "adlib": "3.0.5",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/hub-initiatives": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-      "integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
-      "requires": {
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/hub-sites": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-      "integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
-      "requires": {
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/hub-teams": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-      "integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
-      "requires": {
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-common": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.19.1.tgz",
-      "integrity": "sha512-TJfxKkVe6sv5xPMCn51GyNqbo0W+sxDtjtYmf1ux58M2VrBnBzMWKq1zNIjtG13df36AggaYwZt7o/78fTnq5Q==",
-      "requires": {
-        "@esri/arcgis-html-sanitizer": "~2.1.0",
-        "@types/lodash.isplainobject": "^4.0.6",
-        "adlib": "^3.0.4",
-        "jszip": "3.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "tslib": "^1.13.0",
-        "xss": "^1.0.6"
-      }
-    },
-    "@esri/solution-creator": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.19.1.tgz",
-      "integrity": "sha512-PfneciW3EVjblACw+kq7CXjWp9jd60RU1QuMvruGPxM9sjEBJ2PlqudPBeL7/7x0Y3upX8uTCVc/5dyKgxGWBg==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "@esri/solution-feature-layer": "^0.19.1",
-        "@esri/solution-file": "^0.19.1",
-        "@esri/solution-form": "^0.19.1",
-        "@esri/solution-group": "^0.19.1",
-        "@esri/solution-hub-types": "^0.19.1",
-        "@esri/solution-simple-types": "^0.19.1",
-        "@esri/solution-storymap": "^0.19.1",
-        "@esri/solution-web-experience": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-deployer": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.19.1.tgz",
-      "integrity": "sha512-fqGYnqVCzcC3+3jwisKY0c3i9t8MPx6GqD9VIxc2TavWfwd94QnqNj74nPp+fN/K4zdE0fDrgq+fjLPTQUgSYw==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "@esri/solution-feature-layer": "^0.19.1",
-        "@esri/solution-file": "^0.19.1",
-        "@esri/solution-form": "^0.19.1",
-        "@esri/solution-group": "^0.19.1",
-        "@esri/solution-hub-types": "^0.19.1",
-        "@esri/solution-simple-types": "^0.19.1",
-        "@esri/solution-storymap": "^0.19.1",
-        "@esri/solution-web-experience": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-feature-layer": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.19.1.tgz",
-      "integrity": "sha512-Xd4ZjsGYWx4aAzquKJcFKwq8TKaJ4N68N75KghLeZkaIj1dNWNN6kNWNDY5h2osOQGEknv6DsG0O5VLFuQaiNA==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-file": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.19.1.tgz",
-      "integrity": "sha512-4bYlOZOyFnTNg3Bz4B2rcqC8+xdQEjNbsHY5bFM/L3LOVeYS2pMQbMTGLu5390f3UzQNnDyqCJlHWCEiyvT3xg==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-form": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.19.1.tgz",
-      "integrity": "sha512-mmylRIzBPDv+5Lb4xUQez2MzGbCv2vpbOweaENdq4bmbsunp9uEfBUPoOgZ0tHdiyb/st8urXlJMw6C8gPDsvg==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "@esri/solution-feature-layer": "^0.19.1",
-        "@esri/solution-file": "^0.19.1",
-        "@esri/solution-group": "^0.19.1",
-        "@esri/solution-simple-types": "^0.19.1",
-        "@esri/solution-storymap": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-group": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.19.1.tgz",
-      "integrity": "sha512-9eiYmXD/3a8Tb0XA8T+bpseZy5iNZ+0ayvgeHGLiyZAJQfPsN5xr74whRIhM/RkOJ1dr/xjSPHjLIbS8NKm7/Q==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-hub-types": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.19.1.tgz",
-      "integrity": "sha512-2+aqGrllH6u54hhrAUonmVH/EvUGqlTHQk1AEXbAZz603c27GCBTDlXtYp37ewqwhfxbwOCm1Ua2RFudVxXpBw==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-simple-types": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.19.1.tgz",
-      "integrity": "sha512-OVrWwL6nL4kM+aRzoX11km0NRUvv9hcQ/Jlp1fgFu1AhMHRXC8V2JOTHYabEZbvA2BI00oG/o+OZImJ9aKY61Q==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "@esri/solution-feature-layer": "^0.19.1",
-        "@esri/solution-file": "^0.19.1",
-        "@esri/solution-group": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-storymap": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.19.1.tgz",
-      "integrity": "sha512-XHvs6NQYemz6XqzzkMQaoW0Nb09JRD6CP3XOjBEdq+sZoVVJGGv3Njf+/w6l1NVgOILjEoeuazbtD1/+cROJuw==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@esri/solution-web-experience": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.19.1.tgz",
-      "integrity": "sha512-leSdbg2lzgwDbg0alcL4B4K/5y4WUOtxLMg5uOOLr2Owp4MJkQJUk25jZZ115xaqNGnawsXkl/sFOABp8n3AVg==",
-      "requires": {
-        "@esri/solution-common": "^0.19.1",
-        "@esri/solution-simple-types": "^0.19.1",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@types/lodash": {
-      "version": "4.14.162",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-      "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
-    },
-    "@types/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "adlib": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.5.tgz",
-      "integrity": "sha512-+9lYo3Hm1UYJn3RxVp+SLBuOCh1pt5RiuW8KXGtgqycALaKvZRWAvxnBIyHDkcfEk4RieZ55svJPl4sHKhKlkQ==",
-      "requires": {
-        "esm": "^3.2.25"
-      }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
-    "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
-      "optional": true
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "jszip": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
-      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "rollup": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.31.0.tgz",
-      "integrity": "sha512-0d8S3XwEZ7aCP910/9SjnelgLvC+ZXziouVolzxPOM1zvKkHioGkWGJIWmlOULlmvB8BZ6S0wrgsT4yMz0eyMg==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.1.2"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "xss": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
-      "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      }
-    }
-  }
+	"name": "demos",
+	"version": "0.19.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@esri/arcgis-html-sanitizer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+			"integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+			"requires": {
+				"lodash.isplainobject": "^4.0.6",
+				"xss": "^1.0.6"
+			}
+		},
+		"@esri/arcgis-rest-auth": {
+			"version": "2.19.2",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-2.19.2.tgz",
+			"integrity": "sha512-74AJOldHCV6kNWzL/hh/VbGRrBNaZj3c080/yNTVagnqAUEoAtCAkhdEhT4M7cWsOEe8+lPGjL6MxAYfrD39PA==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.19.2",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-feature-layer": {
+			"version": "2.19.2",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-2.19.2.tgz",
+			"integrity": "sha512-08kXUibefpwZrDu0EL0oh7yQ0NsGtqLJtJBPIFnX7w6XAPZ1SRYZ39O8BC9RJyUtYyfj2CBNz17r7fL0yxbOwg==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.19.2",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-portal": {
+			"version": "2.19.2",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-2.19.2.tgz",
+			"integrity": "sha512-TQlpFbrIh2SwAcswg++OD0VskQrBpPnA/i2+UgA5lhEL2HxRZr0En3V4LRCP9RQ+B59oFvblhqTZraqo+CQW0w==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.19.2",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-request": {
+			"version": "2.19.2",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-2.19.2.tgz",
+			"integrity": "sha512-zkYMZQBu5WvtSxlealNHOiRldyei6o7MGPCSjZoQ7mMDJ8jLpfBa985kXj9wutbKMrD7zVpMvoeFh7fErHFf8A==",
+			"requires": {
+				"tslib": "^1.10.0"
+			}
+		},
+		"@esri/arcgis-rest-service-admin": {
+			"version": "2.19.2",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-2.19.2.tgz",
+			"integrity": "sha512-4jOVw7IoXHXZ6/TY98Bh2Z7XuR/oexd5JgY+NLVBP7rCPZhW5rfIGnLZNviFJHJiZC6brlurFiWoDbOn7NomWw==",
+			"requires": {
+				"@esri/arcgis-rest-types": "^2.19.2",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/arcgis-rest-types": {
+			"version": "2.19.2",
+			"resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-2.19.2.tgz",
+			"integrity": "sha512-+Bamtdg4GH+Uf6VvIB2A+1G2UsFYmx6pKdjfFS8AAbb7t/7c/lnKpsQSguyw/NCvp4CiJCjfC5x1S91vp+bvuA=="
+		},
+		"@esri/hub-common": {
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
+			"requires": {
+				"adlib": "3.0.5",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/hub-initiatives": {
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
+			"requires": {
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/hub-sites": {
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
+			"requires": {
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/hub-teams": {
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
+			"requires": {
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-common": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.19.1.tgz",
+			"integrity": "sha512-TJfxKkVe6sv5xPMCn51GyNqbo0W+sxDtjtYmf1ux58M2VrBnBzMWKq1zNIjtG13df36AggaYwZt7o/78fTnq5Q==",
+			"requires": {
+				"@esri/arcgis-html-sanitizer": "~2.1.0",
+				"@types/lodash.isplainobject": "^4.0.6",
+				"adlib": "^3.0.4",
+				"jszip": "3.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"tslib": "^1.13.0",
+				"xss": "^1.0.6"
+			}
+		},
+		"@esri/solution-creator": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.19.1.tgz",
+			"integrity": "sha512-PfneciW3EVjblACw+kq7CXjWp9jd60RU1QuMvruGPxM9sjEBJ2PlqudPBeL7/7x0Y3upX8uTCVc/5dyKgxGWBg==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"@esri/solution-feature-layer": "^0.19.1",
+				"@esri/solution-file": "^0.19.1",
+				"@esri/solution-form": "^0.19.1",
+				"@esri/solution-group": "^0.19.1",
+				"@esri/solution-hub-types": "^0.19.1",
+				"@esri/solution-simple-types": "^0.19.1",
+				"@esri/solution-storymap": "^0.19.1",
+				"@esri/solution-web-experience": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-deployer": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.19.1.tgz",
+			"integrity": "sha512-fqGYnqVCzcC3+3jwisKY0c3i9t8MPx6GqD9VIxc2TavWfwd94QnqNj74nPp+fN/K4zdE0fDrgq+fjLPTQUgSYw==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"@esri/solution-feature-layer": "^0.19.1",
+				"@esri/solution-file": "^0.19.1",
+				"@esri/solution-form": "^0.19.1",
+				"@esri/solution-group": "^0.19.1",
+				"@esri/solution-hub-types": "^0.19.1",
+				"@esri/solution-simple-types": "^0.19.1",
+				"@esri/solution-storymap": "^0.19.1",
+				"@esri/solution-web-experience": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-feature-layer": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.19.1.tgz",
+			"integrity": "sha512-Xd4ZjsGYWx4aAzquKJcFKwq8TKaJ4N68N75KghLeZkaIj1dNWNN6kNWNDY5h2osOQGEknv6DsG0O5VLFuQaiNA==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-file": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.19.1.tgz",
+			"integrity": "sha512-4bYlOZOyFnTNg3Bz4B2rcqC8+xdQEjNbsHY5bFM/L3LOVeYS2pMQbMTGLu5390f3UzQNnDyqCJlHWCEiyvT3xg==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-form": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.19.1.tgz",
+			"integrity": "sha512-mmylRIzBPDv+5Lb4xUQez2MzGbCv2vpbOweaENdq4bmbsunp9uEfBUPoOgZ0tHdiyb/st8urXlJMw6C8gPDsvg==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"@esri/solution-feature-layer": "^0.19.1",
+				"@esri/solution-file": "^0.19.1",
+				"@esri/solution-group": "^0.19.1",
+				"@esri/solution-simple-types": "^0.19.1",
+				"@esri/solution-storymap": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-group": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.19.1.tgz",
+			"integrity": "sha512-9eiYmXD/3a8Tb0XA8T+bpseZy5iNZ+0ayvgeHGLiyZAJQfPsN5xr74whRIhM/RkOJ1dr/xjSPHjLIbS8NKm7/Q==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-hub-types": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.19.1.tgz",
+			"integrity": "sha512-2+aqGrllH6u54hhrAUonmVH/EvUGqlTHQk1AEXbAZz603c27GCBTDlXtYp37ewqwhfxbwOCm1Ua2RFudVxXpBw==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-simple-types": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.19.1.tgz",
+			"integrity": "sha512-OVrWwL6nL4kM+aRzoX11km0NRUvv9hcQ/Jlp1fgFu1AhMHRXC8V2JOTHYabEZbvA2BI00oG/o+OZImJ9aKY61Q==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"@esri/solution-feature-layer": "^0.19.1",
+				"@esri/solution-file": "^0.19.1",
+				"@esri/solution-group": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-storymap": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.19.1.tgz",
+			"integrity": "sha512-XHvs6NQYemz6XqzzkMQaoW0Nb09JRD6CP3XOjBEdq+sZoVVJGGv3Njf+/w6l1NVgOILjEoeuazbtD1/+cROJuw==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@esri/solution-web-experience": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.19.1.tgz",
+			"integrity": "sha512-leSdbg2lzgwDbg0alcL4B4K/5y4WUOtxLMg5uOOLr2Owp4MJkQJUk25jZZ115xaqNGnawsXkl/sFOABp8n3AVg==",
+			"requires": {
+				"@esri/solution-common": "^0.19.1",
+				"@esri/solution-simple-types": "^0.19.1",
+				"tslib": "^1.13.0"
+			}
+		},
+		"@types/lodash": {
+			"version": "4.14.162",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
+			"integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
+		},
+		"@types/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+			"requires": {
+				"@types/lodash": "*"
+			}
+		},
+		"adlib": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.5.tgz",
+			"integrity": "sha512-+9lYo3Hm1UYJn3RxVp+SLBuOCh1pt5RiuW8KXGtgqycALaKvZRWAvxnBIyHDkcfEk4RieZ55svJPl4sHKhKlkQ==",
+			"requires": {
+				"esm": "^3.2.25"
+			}
+		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cssfilter": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+			"integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+		},
+		"fsevents": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"dev": true,
+			"optional": true
+		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"jszip": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
+			"integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
+			"requires": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"set-immediate-shim": "~1.0.1"
+			}
+		},
+		"lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"requires": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"rollup": {
+			"version": "2.32.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.32.0.tgz",
+			"integrity": "sha512-0FIG1jY88uhCP2yP4CfvtKEqPDRmsUwfY1kEOOM+DH/KOGATgaIFd/is1+fQOxsvh62ELzcFfKonwKWnHhrqmw==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.1.2"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"xss": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+			"integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+			"requires": {
+				"commander": "^2.20.3",
+				"cssfilter": "0.0.10"
+			}
+		}
+	}
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,13 +1,8 @@
 {
   "lerna": "2.8.0",
   "packages": [
-    "packages/*",
-    "demos/*"
+    "packages/**",
+    "demos/"
   ],
-  "command": {
-    "bootstrap": {
-      "ignore": "demos/*"
-    }
-  },
   "version": "0.19.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.0.tgz",
-      "integrity": "sha512-iV7Gwg0DePKvdDZZWRTkj4MW+6/AbVWd4ZCg+zk8H1RVt5xBpUZS6vLQWwb3pyLg4BFTaGiQCPoJ4Ibmbne4fA==",
+      "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
+      "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.0",
-        "@babel/helper-module-transforms": "^7.12.0",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.12.0",
+        "@babel/generator": "^7.12.1",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.1",
+        "@babel/parser": "^7.12.3",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.0",
-        "@babel/types": "^7.12.0",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -35,23 +35,15 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "@babel/generator": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.0.tgz",
-      "integrity": "sha512-8lnf4QcyiQMf5XQp47BltuMTocsOh6P0z/vueEh8GzhmWWlDbdvOoI5Ziddg0XYhmnx35HyByUW51/9NprF8cA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+      "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.0",
+        "@babel/types": "^7.12.1",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -77,37 +69,37 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
-      "integrity": "sha512-I0d/bgzgzgLsJMk7UZ0TN2KV3OGjC/t/9Saz8PKb9jrcEAXhgjGysOgp4PDKydIKjUv/gj2St4ae+ov8l+T9Xg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+      "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.0"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+      "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
-      "integrity": "sha512-1ZTMoCiLSzTJLbq7mSaTHki4oIrBIf/dUbzdhwTrvtMU3ZNVKwQmGae3gSiqppo7G8HAgnXmc43rfEaD8yYLLQ==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.12.0",
-        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.0",
-        "@babel/types": "^7.12.0",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
       }
     },
@@ -121,25 +113,24 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
-      "integrity": "sha512-9kycFdq2c9e7PXZOr2z/ZqTFF9OzFu287iFwYS+CiDVPuoTCfY8hoTsIqNQNetQjlqoRsRyJFrMG1uhGAR4EEw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+      "integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.0",
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
         "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.12.0",
-        "@babel/types": "^7.12.0"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -158,14 +149,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+      "integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/highlight": {
@@ -180,9 +171,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.0.tgz",
-      "integrity": "sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==",
+      "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+      "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
       "dev": true
     },
     "@babel/template": {
@@ -197,26 +188,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.0.tgz",
-      "integrity": "sha512-ZU9e79xpOukCNPkQ1UzR4gJKCruGckr6edd8v8lmKpSk8iakgUIvb+5ZtaKKV9f7O+x5r+xbMDDIbzVpUoiIuw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+      "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.0",
+        "@babel/generator": "^7.12.1",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
+        "@babel/parser": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.0.tgz",
-      "integrity": "sha512-ggIyFmT2zMaYRheOfPDQ4gz7QqV3B+t2rjqjbttDJxMcb7/LukvWCmlIl1sWcOxrvwpTDd+z0OytzqsbGeb3/g==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+      "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -379,12 +370,6 @@
           "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
           "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -470,12 +455,6 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "yallist": {
@@ -636,12 +615,6 @@
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -824,12 +797,6 @@
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -1368,12 +1335,6 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
         "sort-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -1893,12 +1854,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "slash": {
@@ -2620,23 +2575,6 @@
         "is-reference": "^1.1.2",
         "magic-string": "^0.25.2",
         "resolve": "^1.11.0"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
-        },
-        "magic-string": {
-          "version": "0.25.7",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        }
       }
     },
     "@rollup/plugin-json": {
@@ -2670,14 +2608,6 @@
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
-        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -3189,9 +3119,9 @@
       }
     },
     "@types/node": {
-      "version": "10.17.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.39.tgz",
-      "integrity": "sha512-dJLCxrpQmgyxYGcl0Ae9MTsQgI22qHHcGFj/8VKu7McJA5zQpnuGjoksnxbo1JxSjW/Nahnl13W8MYZf01CZHA==",
+      "version": "10.17.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
+      "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3532,23 +3462,6 @@
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "arg": {
@@ -4478,14 +4391,6 @@
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "babel-register": {
@@ -5009,13 +4914,13 @@
       }
     },
     "browser-sync": {
-      "version": "2.26.12",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.12.tgz",
-      "integrity": "sha512-1GjAe+EpZQJgtKhWsxklEjpaMV0DrRylpHRvZWgOphDQt+bfLZjfynl/j1WjSFIx8ozj9j78g6Yk4TqD3gKaMA==",
+      "version": "2.26.13",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.13.tgz",
+      "integrity": "sha512-JPYLTngIzI+Dzx+StSSlMtF+Q9yjdh58HW6bMFqkFXuzQkJL8FCvp4lozlS6BbECZcsM2Gmlgp0uhEjvl18X4w==",
       "dev": true,
       "requires": {
-        "browser-sync-client": "^2.26.12",
-        "browser-sync-ui": "^2.26.12",
+        "browser-sync-client": "^2.26.13",
+        "browser-sync-ui": "^2.26.13",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
         "chokidar": "^3.4.1",
@@ -5023,7 +4928,7 @@
         "connect-history-api-fallback": "^1",
         "dev-ip": "^1.0.1",
         "easy-extender": "^2.3.4",
-        "eazy-logger": "^3",
+        "eazy-logger": "3.1.0",
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
@@ -5179,9 +5084,9 @@
       }
     },
     "browser-sync-client": {
-      "version": "2.26.12",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.12.tgz",
-      "integrity": "sha512-bEBDRkufKxrIfjOsIB1FN9itUEXr2oLtz1AySgSSr80K2AWzmtoYnxtVASx/i40qFrSdeI31pNvdCjHivihLVA==",
+      "version": "2.26.13",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.13.tgz",
+      "integrity": "sha512-p2VbZoYrpuDhkreq+/Sv1MkToHklh7T1OaIntDwpG6Iy2q/XkBcgwPcWjX+WwRNiZjN8MEehxIjEUh12LweLmQ==",
       "dev": true,
       "requires": {
         "etag": "1.8.1",
@@ -5191,9 +5096,9 @@
       }
     },
     "browser-sync-ui": {
-      "version": "2.26.12",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.12.tgz",
-      "integrity": "sha512-PkAJNf/TfCFTCkQUfXplR2Kp/+/lbCWFO9lrgLZsmxIhvMLx2pYZFBbTBIaem8qjXhld9ZcESUC8EdU5VWFJgQ==",
+      "version": "2.26.13",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.13.tgz",
+      "integrity": "sha512-6NJ/pCnhCnBMzaty1opWo7ipDmFAIk8U71JMQGKJxblCUaGfdsbF2shf6XNZSkXYia1yS0vwKu9LIOzpXqQZCA==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -5816,23 +5721,6 @@
             "graceful-fs": "^4.1.11",
             "micromatch": "^3.1.10",
             "readable-stream": "^2.0.2"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
         },
         "to-regex-range": {
@@ -6006,6 +5894,12 @@
           }
         }
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -6261,23 +6155,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "concurrently": {
@@ -7524,21 +7401,6 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
               }
-            },
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
             }
           }
         },
@@ -7897,14 +7759,6 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
-        }
       }
     },
     "defer-to-connect": {
@@ -7920,14 +7774,6 @@
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "define-property": {
@@ -8118,6 +7964,12 @@
         }
       }
     },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
     "doctrine": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
@@ -8217,23 +8069,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "duplexer3": {
@@ -8277,12 +8112,12 @@
       }
     },
     "eazy-logger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
-      "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
+      "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
       "dev": true,
       "requires": {
-        "tfunk": "^3.0.1"
+        "tfunk": "^4.0.0"
       }
     },
     "ecc-jsbn": {
@@ -8308,9 +8143,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.581",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.581.tgz",
-      "integrity": "sha512-ALORbI23YkYJoVJWusSdmTq8vXH3TLFzniILE47uZkZOim135ZhoTCM7QlIuvmK78As5kLdANfy7kDIQvJ+iPw==",
+      "version": "1.3.582",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.582.tgz",
+      "integrity": "sha512-0nCJ7cSqnkMC+kUuPs0YgklFHraWGl/xHqtZWWtOeVtyi+YqkoAOMGuZQad43DscXCQI/yizcTa3u6B5r+BLww==",
       "dev": true
     },
     "elegant-spinner": {
@@ -8659,14 +8494,6 @@
         "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "es-to-primitive": {
@@ -8742,9 +8569,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {
@@ -9602,23 +9429,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "follow-redirects": {
@@ -9694,23 +9504,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "fs-access": {
@@ -9763,23 +9556,6 @@
         "iferr": "^0.1.5",
         "imurmurhash": "^0.1.4",
         "readable-stream": "1 || 2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "fs.realpath": {
@@ -10013,35 +9789,12 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
         },
         "trim-newlines": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
           "dev": true
         }
       }
@@ -10210,9 +9963,9 @@
           "dev": true
         },
         "cliui": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.2.tgz",
-          "integrity": "sha512-lhpKkuUj67j5JgZIPZxLe7nSa4MQoojzRVWQyzMqBp2hBg6gwRjUDAwC1YDeBaC3APDBKNnjWbv2mlDF4XgOSA==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.3.tgz",
+          "integrity": "sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
@@ -10381,30 +10134,30 @@
           }
         },
         "y18n": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
-          "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==",
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.4.tgz",
+          "integrity": "sha512-deLOfD+RvFgrpAmSZgfGdWYE+OKyHcVHaRQ7NphG/63scpRvTHHeQMAxGGvaLVGJ+HYVcCXlzcTK0ZehFf+eHQ==",
           "dev": true
         },
         "yargs": {
-          "version": "16.0.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
-          "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.0.tgz",
+          "integrity": "sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==",
           "dev": true,
           "requires": {
-            "cliui": "^7.0.0",
-            "escalade": "^3.0.2",
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
             "string-width": "^4.2.0",
-            "y18n": "^5.0.1",
-            "yargs-parser": "^20.0.0"
+            "y18n": "^5.0.2",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
-          "version": "20.2.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.2.tgz",
-          "integrity": "sha512-XmrpXaTl6noDsf1dKpBuUNCOHqjs0g3jRMXf/ztRxdOmb+er8kE5z5b55Lz3p5u2T8KJ59ENBnASS8/iapVJ5g==",
+          "version": "20.2.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
           "dev": true
         }
       }
@@ -10480,30 +10233,7 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-          "dev": true
         }
       }
     },
@@ -10719,35 +10449,12 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
         },
         "trim-newlines": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
           "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
           "dev": true
         }
       }
@@ -12386,6 +12093,15 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -12727,12 +12443,6 @@
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
         }
       }
     },
@@ -12929,12 +12639,12 @@
       }
     },
     "jasmine": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.1.tgz",
-      "integrity": "sha512-Jqp8P6ZWkTVFGmJwBK46p+kJNrZCdqkQ4GL+PGuBXZwK1fM4ST9BizkYgIwCFqYYqnTizAy6+XG2Ej5dFrej9Q==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.2.tgz",
+      "integrity": "sha512-Uc0o2MRnC8TS1MjDrB8jE1umKEo2mflzGvdg0Ncs+yuLtOJ+uz/Wz8VmGsNGtuASr8+E0LDgPkOpvdoC76m5WQ==",
       "dev": true,
       "requires": {
-        "fast-glob": "^2.2.6",
+        "glob": "^7.1.6",
         "jasmine-core": "~3.6.0"
       }
     },
@@ -13118,23 +12828,6 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "just-extend": {
@@ -13849,15 +13542,6 @@
             "flatted": "^2.0.0",
             "rfdc": "^1.1.4",
             "streamroller": "^1.0.6"
-          }
-        },
-        "magic-string": {
-          "version": "0.25.7",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
           }
         },
         "streamroller": {
@@ -15197,23 +14881,6 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0",
             "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
         },
         "pumpify": {
@@ -15247,30 +14914,7 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-          "dev": true
         }
       }
     },
@@ -15505,14 +15149,6 @@
         "semver": "^5.7.1",
         "tar": "^4.4.12",
         "which": "^1.3.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "node-sass": {
@@ -15746,14 +15382,6 @@
         "lodash": "^4.17.3",
         "semver": "^5.3.0",
         "v8flags": "^2.0.11"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "nopt": {
@@ -19368,14 +18996,6 @@
         "osenv": "^0.1.5",
         "semver": "^5.6.0",
         "validate-npm-package-name": "^3.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "npm-packlist": {
@@ -19407,14 +19027,6 @@
         "figgy-pudding": "^3.5.1",
         "npm-package-arg": "^6.0.0",
         "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "npm-run-path": {
@@ -19578,10 +19190,10 @@
         "es-abstract": "^1.18.0-next.1"
       }
     },
-    "object-path": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "object-visit": {
@@ -19603,14 +19215,6 @@
         "es-abstract": "^1.18.0-next.0",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -19641,12 +19245,6 @@
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
         }
       }
     },
@@ -20168,23 +19766,6 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "parent-module": {
@@ -20731,30 +20312,7 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-          "dev": true
         }
       }
     },
@@ -21086,14 +20644,18 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdir-scoped-modules": {
@@ -21339,11 +20901,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -21486,9 +21049,9 @@
       }
     },
     "rollup": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.31.0.tgz",
-      "integrity": "sha512-0d8S3XwEZ7aCP910/9SjnelgLvC+ZXziouVolzxPOM1zvKkHioGkWGJIWmlOULlmvB8BZ6S0wrgsT4yMz0eyMg==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.32.0.tgz",
+      "integrity": "sha512-0FIG1jY88uhCP2yP4CfvtKEqPDRmsUwfY1kEOOM+DH/KOGATgaIFd/is1+fQOxsvh62ELzcFfKonwKWnHhrqmw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
@@ -21526,6 +21089,14 @@
         "estree-walker": "^0.6.1",
         "magic-string": "^0.25.3",
         "rollup-pluginutils": "^2.8.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-node-polyfills": {
@@ -21574,9 +21145,9 @@
           }
         },
         "terser": {
-          "version": "5.3.5",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.5.tgz",
-          "integrity": "sha512-Qw3CZAMmmfU824AoGKalx+riwocSI5Cs0PoGp9RdSLfmxkmJgyBxqLBP/isDNtFyhHnitikvRMZzyVgeq+U+Tg==",
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.7.tgz",
+          "integrity": "sha512-lJbKdfxWvjpV330U4PBZStCT9h3N9A4zZVA5Y4k9sCWXknrpdyxi1oMsRKLmQ/YDMDxSBKIh88v0SkdhdqX06w==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -21617,6 +21188,15 @@
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
           }
         },
         "tslib": {
@@ -21667,6 +21247,14 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
       }
     },
     "run-async": {
@@ -21995,9 +21583,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.6.tgz",
-          "integrity": "sha512-VRvqVD5T6t9HdmNDWTwbi8H/EC722MemAhOSP5QvYAXpDAY0Nhu2I/i+bXsktu4sU5LVHSh/wmXtVU8bDtjedQ==",
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -23076,30 +22664,7 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            }
           }
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-          "dev": true
         }
       }
     },
@@ -23187,23 +22752,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-browserify": {
@@ -23246,23 +22794,6 @@
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-each": {
@@ -23306,12 +22837,6 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-          "dev": true
         }
       }
     },
@@ -23438,12 +22963,6 @@
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
         }
       }
     },
@@ -23475,12 +22994,6 @@
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
         }
       }
     },
@@ -23846,13 +23359,13 @@
       "dev": true
     },
     "tfunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-      "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
+      "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "chalk": "^1.1.3",
+        "dlv": "^1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -24152,12 +23665,6 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -24262,6 +23769,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typedoc": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
@@ -24294,9 +23810,9 @@
           }
         },
         "highlight.js": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.1.tgz",
-          "integrity": "sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g==",
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.1.tgz",
+          "integrity": "sha512-jeW8rdPdhshYKObedYg5XGbpVgb1/DT4AHvDFXhkU7UnGSIjy9kkJ7zHG7qplhFHMitTSzh5/iClKQk3Kb2RFQ==",
           "dev": true
         },
         "jsonfile": {
@@ -24365,9 +23881,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.2.tgz",
-      "integrity": "sha512-G440NU6fewtnQftSgqRV1r2A5ChKbU1gqFCJ7I8S7MPpY/eZZfLGefaY6gUZYiWebMaO+txgiQ1ZyLDuNWJulg==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
+      "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==",
       "dev": true,
       "optional": true
     },
@@ -24831,12 +24347,6 @@
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
         }
       }
     },
@@ -24961,12 +24471,6 @@
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -25049,17 +24553,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      },
-      "dependencies": {
-        "typedarray-to-buffer": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-          "dev": true,
-          "requires": {
-            "is-typedarray": "^1.0.0"
-          }
-        }
       }
     },
     "write-json-file": {
@@ -25195,6 +24688,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -69,9 +69,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -104,9 +104,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,7 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
     "@types/adlib": "^3.0.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
@@ -29,7 +29,7 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1"
+    "@esri/hub-common": "^6.13.1"
   },
   "dependencies": {
     "@esri/arcgis-html-sanitizer": "~2.1.0",

--- a/packages/creator/package-lock.json
+++ b/packages/creator/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/feature-layer/package-lock.json
+++ b/packages/feature-layer/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/feature-layer/package.json
+++ b/packages/feature-layer/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/file/package-lock.json
+++ b/packages/file/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/group/package-lock.json
+++ b/packages/group/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/hub-types/package-lock.json
+++ b/packages/hub-types/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/hub-types/package.json
+++ b/packages/hub-types/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^3.9.7"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/simple-types/package-lock.json
+++ b/packages/simple-types/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,9 +70,9 @@
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -85,9 +85,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/simple-types/package.json
+++ b/packages/simple-types/package.json
@@ -18,8 +18,8 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -29,8 +29,8 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/storymap/package-lock.json
+++ b/packages/storymap/package-lock.json
@@ -40,9 +40,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -56,9 +56,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/storymap/package.json
+++ b/packages/storymap/package.json
@@ -16,7 +16,7 @@
     "@esri/arcgis-rest-auth": "^2.19.1",
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -24,7 +24,7 @@
     "@esri/arcgis-rest-auth": "^2.19.1",
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
-    "@esri/hub-common": "^6.12.1"
+    "@esri/hub-common": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/viewer/package-lock.json
+++ b/packages/viewer/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,27 +70,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.12.1.tgz",
-			"integrity": "sha512-umZYAtnkMV8l5YiSJfK1/FurE9/YHHWy8Ex8mc9o24qqMBKaxdP5RkC+QxdJmiN4EltP+S3P9kCV/vco+2BBkQ==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-6.13.1.tgz",
+			"integrity": "sha512-I3ZoZnDNKljWtQ1iW4q2Wh6CsLkuS5k9bAeK3kObhkAvucSF2JTC1Ipb2+yvnwXG535ZNAPzC9a9Y4ypPKeqKA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.12.1.tgz",
-			"integrity": "sha512-gnK8HgIMnUc5rwmBBHsy8YfQAPyXZm960sgC369OSDuSY+nRxfCqW5+zqnT8tRlh+JDoiON/MlGdblm0lGsQkg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-6.13.1.tgz",
+			"integrity": "sha512-1/zJApytKQyemiP4D5wmCa5CsWzRSOXwmXxGHY9BYFKu0bvZMBtuXt7kU/zZQHmC3hJE0/WqVqfrCpJ0pjRnUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -103,9 +103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^4.0.3"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
-    "@esri/hub-sites": "^6.12.1",
-    "@esri/hub-teams": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
+    "@esri/hub-sites": "^6.13.1",
+    "@esri/hub-teams": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/packages/web-experience/package-lock.json
+++ b/packages/web-experience/package-lock.json
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.12.1.tgz",
-			"integrity": "sha512-LGqoSKF1LBNN6+ISeRCEqn1oeJB4tn6r6uuN+MAAH2+YLqP3BBvA96Gl90NwGjWgJV4ZwHcYhpeMrL2QmOUnqg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-6.13.1.tgz",
+			"integrity": "sha512-PczUR+eExvhVVL6j4OWkq7wY/+iabOYzDP9yivSSU9cM5Zf0yMeFiDFyYsOoEF69aVuzorOFm4ZqUa8eunKKWw==",
 			"dev": true,
 			"requires": {
 				"adlib": "3.0.5",
@@ -70,9 +70,9 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.12.1.tgz",
-			"integrity": "sha512-xF20jwmx+iVdEWFOOpULXgRxEOz81u0utG/kngGN1imsdOiDFOu/SJ/B+XtM0U/xoDB9TLYZf2WJMa0gffM4lw==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-6.13.1.tgz",
+			"integrity": "sha512-B0MMoR8iNhDFEZxRH53pJFQGmZH382tUvGR8C35V77aNi05Ud+v2+CdqQ6k3K9QHJ/28jjPGddgM2eqz8+XZfQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
@@ -85,9 +85,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
 			"dev": true
 		},
 		"acorn": {

--- a/packages/web-experience/package.json
+++ b/packages/web-experience/package.json
@@ -18,8 +18,8 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1",
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1",
     "rollup": "^1.22.0",
     "typescript": "^3.9.7"
   },
@@ -29,8 +29,8 @@
     "@esri/arcgis-rest-portal": "^2.19.1",
     "@esri/arcgis-rest-request": "^2.19.1",
     "@esri/arcgis-rest-service-admin": "^2.19.1",
-    "@esri/hub-common": "^6.12.1",
-    "@esri/hub-initiatives": "^6.12.1"
+    "@esri/hub-common": "^6.13.1",
+    "@esri/hub-initiatives": "^6.13.1"
   },
   "dependencies": {
     "@esri/solution-common": "^0.19.1",

--- a/umd-base-profile.js
+++ b/umd-base-profile.js
@@ -110,6 +110,7 @@ export default {
     format: "umd",
     name: moduleName,
     globals,
+    intro: 'var global = typeof self !== undefined ? self : this;',
     extend: true // causes this module to extend the global specified by `moduleName`
   },
   context: "window",


### PR DESCRIPTION
1. Recent package updates and changes to improve security may have led to a sporadic problem with `global` being defined for modules:
![image](https://user-images.githubusercontent.com/2125181/96512341-35bb1b80-1215-11eb-822d-699012a57a3a.png)
2. Symbolic links are not being set up for the demo apps, and so they are not taking advantage of pre-publication work in the packages.

For the first problem, added the line
```js
intro: 'var global = typeof self !== undefined ? self : this;',
```
to umd-base-profile.js to make sure that `global` is always set up.

For the second problem, removed `command.bootstrap.ignore` from lerna.json.

It also appears that one has to run `npm install` an extra time to get the symlinks to be generated:
```bat
echo ===== install top level =====
call npm install

echo ===== update examples =====
pushd demos
call npm install
call npm run build
popd

echo ===== set up symbolic links =====
call npm install
```