### PR TITLE
Remove folders from asset names during 2.3 -> 2.4 schema transform

### DIFF
--- a/packages/common/src/migrations/upgrade-two-dot-four.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-four.ts
@@ -55,7 +55,13 @@ export function _upgradeTwoDotFour(
     clone.data.templates = clone.data.templates.map(tmpl => {
       if (tmpl.assets) {
         tmpl.resources = tmpl.assets.map((a: any) => {
-          return `${tmpl.itemId}-${a.name}`;
+          // thumbnail names can be like thumbnail/filename.ext
+          // so let's generally remove any folder prefixes
+          let name = a.name;
+          if (name.indexOf("/") > -1) {
+            name = name.split("/")[1];
+          }
+          return `${tmpl.itemId}-${name}`;
         });
       }
       // ensure this property is present

--- a/packages/common/src/migrations/upgrade-two-dot-four.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-four.ts
@@ -55,7 +55,7 @@ export function _upgradeTwoDotFour(
     clone.data.templates = clone.data.templates.map(tmpl => {
       if (tmpl.assets) {
         tmpl.resources = tmpl.assets.map((a: any) => {
-          // thumbnail names can be like thumbnail/filename.ext
+          // asset names can be like thumbnail/filename.ext
           // so let's generally remove any folder prefixes
           let name = a.name;
           if (name.indexOf("/") > -1) {

--- a/packages/common/test/migrations/upgrade-two-dot-four.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-four.test.ts
@@ -84,6 +84,25 @@ describe("Upgrade 2.4 ::", () => {
       "should strip the old id out of the filename"
     );
   });
+  it("reworks hub asset names, dropping leading folders", () => {
+    const m = cloneObject(defaultModel);
+    m.data.templates[0].assets = [
+      { name: "thumbnail/somefile.png" },
+      { name: "other/foo.png" }
+    ];
+    const chk = _upgradeTwoDotFour(m, MOCK_USER_SESSION);
+    const tmpl = chk.data.templates[0];
+    expect(Array.isArray(tmpl.resources)).toBe(true, "should add resources");
+    expect(Array.isArray(tmpl.assets)).toBe(true, "should leave assets");
+    expect(tmpl.resources[0]).toBe(
+      "fakeId-somefile.png",
+      "should strip the old id and thumbnail folder out of the filename"
+    );
+    expect(tmpl.resources[1]).toBe(
+      "fakeId-foo.png",
+      "should strip the old id and folder out of the filename"
+    );
+  });
   it("adds estimatedDeploymentCostFactor", () => {
     const m = cloneObject(defaultModel);
     m.data.templates[0].estimatedDeploymentCostFactor = 2;


### PR DESCRIPTION
Got a bug from a customer indicating that some Hub Solutions had asset names w/ folders, but the actual resources did not have that folder structure.

This pr removes the folder from the name during the 2.3 -> 2.4 transform

Verified on Prod in Hub, using the customer's org and live Solution items