### PR TITLE
Improved handling of missing Solution item metadata

### DIFF
--- a/packages/common/src/generalHelpers.ts
+++ b/packages/common/src/generalHelpers.ts
@@ -671,7 +671,7 @@ export function getUniqueTitle(
   templateDictionary: any,
   path: string
 ): string {
-  title = title.trim();
+  title = title ? title.trim() : "_";
   const objs: any[] = getProp(templateDictionary, path) || [];
   const titles: string[] = objs.map(obj => {
     return obj.title;

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -629,6 +629,7 @@ export function createItemWithData(
     // Create item
     const createOptions: ICreateItemOptions = {
       item: {
+        title: "_", // provide backup title
         ...itemInfo,
         data: dataInfo
       },

--- a/packages/common/src/restHelpersGet.ts
+++ b/packages/common/src/restHelpersGet.ts
@@ -427,16 +427,22 @@ export function getItemInfoFileUrlPrefix(
  *
  * @param itemId Id of an item whose data information is sought
  * @param authentication Credentials for the request to AGO
- * @return Promise that will resolve with a File containing the metadata or an AGO-style JSON failure response
+ * @return Promise that will resolve with `undefined` or a File containing the metadata
  */
 export function getItemMetadataAsFile(
   itemId: string,
   authentication: UserSession
 ): Promise<File> {
-  return new Promise<File>((resolve, reject) => {
+  return new Promise<File>(resolve => {
     getItemMetadataBlob(itemId, authentication).then(
-      blob => (!blob ? resolve() : resolve(blobToFile(blob, "metadata.xml"))),
-      reject
+      blob => {
+        if (!blob || (blob && blob.type.startsWith("application/json"))) {
+          resolve(); // JSON error
+        } else {
+          resolve(blobToFile(blob, "metadata.xml"));
+        }
+      },
+      () => resolve()
     );
   });
 }
@@ -493,7 +499,7 @@ export function getItemRelatedItems(
   direction: "forward" | "reverse",
   authentication: UserSession
 ): Promise<IGetRelatedItemsResponse> {
-  return new Promise<IGetRelatedItemsResponse>(resolve => {
+  return new Promise<IGetRelatedItemsResponse>((resolve, reject) => {
     const itemRelatedItemsParam: IItemRelationshipOptions = {
       id: itemId,
       relationshipType,

--- a/packages/common/test/restHelpersGet.test.ts
+++ b/packages/common/test/restHelpersGet.test.ts
@@ -664,6 +664,21 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
           }, done.fail);
       });
 
+      it("handles server error", done => {
+        const itemId = "itm1234567890";
+        const url = restHelpersGet.getItemMetadataBlobUrl(
+          itemId,
+          MOCK_USER_SESSION
+        );
+        fetchMock.post(url, mockItems.get500Failure());
+        restHelpersGet
+          .getItemMetadataAsFile(itemId, MOCK_USER_SESSION)
+          .then((json: any) => {
+            expect(json).toBeUndefined();
+            done();
+          }, done.fail);
+      });
+
       it("gets metadata", done => {
         const itemId = "itm1234567890";
         const url = restHelpersGet.getItemMetadataBlobUrl(

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -904,7 +904,7 @@ describe("Module `creator`", () => {
           const options: fetchMock.MockOptions = fetchMock.lastOptions(url);
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
-            "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
+            "f=json&title=xfakeidx&type=Solution&snippet=&description=" +
               "&properties=" +
               encodeURIComponent(
                 JSON.stringify({ schemaVersion: common.CURRENT_SCHEMA_VERSION })
@@ -960,8 +960,9 @@ describe("Module `creator`", () => {
             const fetchBody = (fetchOptions as fetchMock.MockResponseObject)
               .body;
             expect(fetchBody).toEqual(
-              "f=json&type=Solution&title=" +
+              "f=json&title=" +
                 encodeURIComponent(options.title) +
+                "&type=Solution" +
                 "&snippet=" +
                 encodeURIComponent(options.snippet) +
                 "&description=" +
@@ -1141,7 +1142,7 @@ describe("Module `creator`", () => {
           const options: fetchMock.MockOptions = fetchMock.lastOptions(url);
           const fetchBody = (options as fetchMock.MockResponseObject).body;
           expect(fetchBody).toEqual(
-            "f=json&type=Solution&title=xfakeidx&snippet=&description=" +
+            "f=json&title=xfakeidx&type=Solution&snippet=&description=" +
               "&properties=" +
               encodeURIComponent(
                 JSON.stringify({ schemaVersion: common.CURRENT_SCHEMA_VERSION })

--- a/packages/deployer/src/deploySolutionFromTemplate.ts
+++ b/packages/deployer/src/deploySolutionFromTemplate.ts
@@ -292,11 +292,16 @@ export function deploySolutionFromTemplate(
         }
 
         // Pass metadata in via params because item property is serialized, which discards a File
+        const additionalParams: any = {};
+        /* istanbul ignore else */
+        if (solutionTemplateMetadata) {
+          additionalParams.metadata = solutionTemplateMetadata;
+        }
         return common.updateItem(
           solutionTemplateBase,
           authentication,
           deployedFolderId,
-          { metadata: solutionTemplateMetadata }
+          additionalParams
         );
       })
       .then(

--- a/packages/deployer/src/deploySolutionFromTemplate.ts
+++ b/packages/deployer/src/deploySolutionFromTemplate.ts
@@ -182,7 +182,9 @@ export function deploySolutionFromTemplate(
         templateDictionary.solutionItemId = deployedSolutionId;
         solutionTemplateBase.id = deployedSolutionId;
 
-        return common.addTokenToUrl(options.thumbnailurl, authentication);
+        return options.thumbnailurl
+          ? common.addTokenToUrl(options.thumbnailurl, authentication)
+          : Promise.resolve(null);
       })
       .then(updatedThumbnailUrl => {
         /* istanbul ignore else */

--- a/packages/deployer/src/deployer.ts
+++ b/packages/deployer/src/deployer.ts
@@ -28,7 +28,7 @@ import {
   isSolutionTemplateItem,
   updateDeployOptions
 } from "./deployerUtils";
-import { IModel } from "@esri/hub-common";
+import { IModel, isGuid } from "@esri/hub-common";
 
 /**
  * Deploy a Solution
@@ -68,11 +68,13 @@ export function deploySolution(
           common.fail(`${model.item.id} is not a Solution Template`)
         );
       } else {
-        // fetch the metadata and pass the item & data forward
+        // fetch the metadata if the model's id is a GUID and pass the item & data forward
         return Promise.all([
           Promise.resolve(model.item),
           Promise.resolve(model.data),
-          common.getItemMetadataAsFile(model.item.id, storageAuthentication)
+          isGuid(model.item.id)
+            ? common.getItemMetadataAsFile(model.item.id, storageAuthentication)
+            : Promise.resolve()
         ]);
       }
     })

--- a/packages/deployer/src/deployerUtils.ts
+++ b/packages/deployer/src/deployerUtils.ts
@@ -73,12 +73,9 @@ export function updateDeployOptions(
   deployOptions.description = deployOptions.description ?? item.description;
   deployOptions.tags = deployOptions.tags ?? item.tags;
   // add the thumbnail url
-  deployOptions.thumbnailurl = common.getItemThumbnailUrl(
-    item.id,
-    item.thumbnail,
-    false,
-    authentication
-  );
+  deployOptions.thumbnailurl = item.thumbnail
+    ? common.getItemThumbnailUrl(item.id, item.thumbnail, false, authentication)
+    : null;
 
   return deployOptions;
 }

--- a/packages/deployer/test/deploySolutionFromTemplate.test.ts
+++ b/packages/deployer/test/deploySolutionFromTemplate.test.ts
@@ -153,110 +153,118 @@ describe("Module `deploySolutionFromTemplate`", () => {
       fetchMock.restore();
     });
 
-    it("defaults storageAuthentication to authentication", done => {
-      const templates: common.IItemTemplate[] = [
-        mockTemplates.getItemTemplate("Web Map")
-      ];
-      const solution: common.ISolutionItem = mockTemplates.getSolutionTemplateItem(
-        templates
-      );
-      const folderId = "fld1234567890";
-      const templateSolutionId: string = "sln1234567890";
-      const solutionTemplateBase: any = solution.item;
-      const solutionTemplateData: any = solution.data;
-      const solutionTemplateMetadata: File = null;
-      const authentication: common.UserSession = MOCK_USER_SESSION;
-      const options: common.IDeploySolutionOptions = {};
-      const deployedSolutionId = "dpl1234567890";
-      const templateDictionary = {} as any;
-
-      const deployFnStub = sinon
-        .stub(deployItems, "deploySolutionItems")
-        .resolves([
-          {
-            id: deployedSolutionId,
-            type: "Web Map",
-            postProcess: false
-          }
-        ]);
-      const postProcessFnStub = sinon
-        .stub(postProcess, "postProcess")
-        .resolves();
-
-      fetchMock
-        .get(
-          testUtils.PORTAL_SUBSET.restUrl +
-            "/portals/self?f=json&token=fake-token",
-          portalsSelfResponse
-        )
-        .get(
-          testUtils.PORTAL_SUBSET.restUrl +
-            "/community/self?f=json&token=fake-token",
-          communitySelfResponse
-        )
-        .get(
-          testUtils.PORTAL_SUBSET.restUrl +
-            "/content/users/casey?f=json&token=fake-token",
-          testUtils.getSuccessResponse()
-        )
-        .get(
-          testUtils.PORTAL_SUBSET.restUrl +
-            "/community/users/casey?f=json&token=fake-token",
-          testUtils.getSuccessResponse()
-        )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
-          testUtils.getTransformationsResponse()
-        )
-        .post(
-          testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
-          testUtils.getCreateFolderResponse(folderId)
-        )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
-          testUtils.getProjectResponse()
-        )
-        .post(
-          testUtils.PORTAL_SUBSET.restUrl +
-            "/content/users/casey/" +
-            folderId +
-            "/addItem",
-          testUtils.getSuccessResponse({
-            id: deployedSolutionId,
-            folder: folderId
-          })
-        )
-        .post(
-          testUtils.PORTAL_SUBSET.restUrl +
-            "/content/users/casey/fld1234567890/items/dpl1234567890/update",
-          testUtils.getSuccessResponse({ id: deployedSolutionId })
+    // Because metadata file is used in test, shield from Node because it doesn't have Blob
+    if (typeof window !== "undefined") {
+      it("defaults storageAuthentication to authentication", done => {
+        const templates: common.IItemTemplate[] = [
+          mockTemplates.getItemTemplate("Web Map")
+        ];
+        const solution: common.ISolutionItem = mockTemplates.getSolutionTemplateItem(
+          templates
         );
+        const folderId = "fld1234567890";
+        const templateSolutionId: string = "sln1234567890";
+        const solutionTemplateBase: any = solution.item;
+        const solutionTemplateData: any = solution.data;
+        const solutionTemplateMetadata: File = testUtils.getSampleMetadataAsFile();
+        const authentication: common.UserSession = MOCK_USER_SESSION;
+        const options: common.IDeploySolutionOptions = {};
+        const deployedSolutionId = "dpl1234567890";
+        const templateDictionary = {} as any;
 
-      deploySolutionFromTemplate(
-        templateSolutionId,
-        solutionTemplateBase,
-        solutionTemplateData,
-        solutionTemplateMetadata,
-        authentication,
-        options
-      ).then(
-        () => {
-          const deployFnCall = deployFnStub.getCall(0);
-          expect(deployFnCall.args[0]).toEqual(MOCK_USER_SESSION.portal); // portalSharingUrl
-          expect(deployFnCall.args[3].portal).toEqual(MOCK_USER_SESSION.portal); // storageAuthentication
-          expect(deployFnCall.args[5].portal).toEqual(MOCK_USER_SESSION.portal); // destinationAuthentication
+        const deployFnStub = sinon
+          .stub(deployItems, "deploySolutionItems")
+          .resolves([
+            {
+              id: deployedSolutionId,
+              type: "Web Map",
+              postProcess: false
+            }
+          ]);
+        const postProcessFnStub = sinon
+          .stub(postProcess, "postProcess")
+          .resolves();
 
-          deployFnStub.restore();
-          postProcessFnStub.restore();
-          done();
-        },
-        () => {
-          deployFnStub.restore();
-          postProcessFnStub.restore();
-          done.fail();
-        }
-      );
-    });
+        fetchMock
+          .get(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/portals/self?f=json&token=fake-token",
+            portalsSelfResponse
+          )
+          .get(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/community/self?f=json&token=fake-token",
+            communitySelfResponse
+          )
+          .get(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey?f=json&token=fake-token",
+            testUtils.getSuccessResponse()
+          )
+          .get(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/community/users/casey?f=json&token=fake-token",
+            testUtils.getSuccessResponse()
+          )
+          .post(
+            "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
+            testUtils.getTransformationsResponse()
+          )
+          .post(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/createFolder",
+            testUtils.getCreateFolderResponse(folderId)
+          )
+          .post(
+            "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
+            testUtils.getProjectResponse()
+          )
+          .post(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/" +
+              folderId +
+              "/addItem",
+            testUtils.getSuccessResponse({
+              id: deployedSolutionId,
+              folder: folderId
+            })
+          )
+          .post(
+            testUtils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/fld1234567890/items/dpl1234567890/update",
+            testUtils.getSuccessResponse({ id: deployedSolutionId })
+          );
+
+        deploySolutionFromTemplate(
+          templateSolutionId,
+          solutionTemplateBase,
+          solutionTemplateData,
+          solutionTemplateMetadata,
+          authentication,
+          options
+        ).then(
+          () => {
+            const deployFnCall = deployFnStub.getCall(0);
+            expect(deployFnCall.args[0]).toEqual(MOCK_USER_SESSION.portal); // portalSharingUrl
+            expect(deployFnCall.args[3].portal).toEqual(
+              MOCK_USER_SESSION.portal
+            ); // storageAuthentication
+            expect(deployFnCall.args[5].portal).toEqual(
+              MOCK_USER_SESSION.portal
+            ); // destinationAuthentication
+
+            deployFnStub.restore();
+            postProcessFnStub.restore();
+            done();
+          },
+          () => {
+            deployFnStub.restore();
+            postProcessFnStub.restore();
+            done.fail();
+          }
+        );
+      });
+    }
 
     it("allows distinct authentication to the solution template", done => {
       const templates: common.IItemTemplate[] = [

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -114,8 +114,8 @@ describe("Module `deployer`", () => {
                 "getSolutionTemplateItem should be called"
               );
               expect(metaStub.calledOnce).toBe(
-                true,
-                "getItemMetadataAsFile should be called once"
+                false,
+                "getItemMetadataAsFile should not be called because item id is not a GUID"
               );
               expect(deployFnStub.calledOnce).toBe(
                 true,
@@ -170,6 +170,8 @@ describe("Module `deployer`", () => {
 
           // itemInfo that has not been mutated
           const _itemInfo = cloneObject(templates.getSolutionTemplateItem([]));
+          itemInfo.item.id = _itemInfo.item.id =
+            "11181d776d164656836f2fc3c23512b8";
 
           // create stub...
           const pgStub = sinon.stub(opts, "progressCallback");
@@ -182,7 +184,7 @@ describe("Module `deployer`", () => {
               );
               expect(metaStub.calledOnce).toBe(
                 true,
-                "getItemMetadataAsFile should be called once"
+                "getItemMetadataAsFile should be called once because item id is a GUID"
               );
               expect(deployFnStub.calledOnce).toBe(
                 true,


### PR DESCRIPTION
#535 

* Improved handling of missing Solution item metadata
* Don't fetch or upload metadata.xml for the solution item if the Solution's id is not a GUID (for Hub)
* Don't send the thumbnailUrl for the deployed Solution item if its `.thumbnail` property is undefined