### PR TITLE
B/156515 handle surveys with zip files named undefined

### DIFF
--- a/packages/common/src/resourceHelpers.ts
+++ b/packages/common/src/resourceHelpers.ts
@@ -774,8 +774,12 @@ export function storeFormItemFiles(
 
     // Store form data
     if (itemData) {
+      const originalFilename =
+        itemTemplate.item.name || (itemData as File).name;
       const filename =
-        itemTemplate.item.name || (itemData as File).name || "formData.zip";
+        originalFilename && originalFilename !== "undefined"
+          ? originalFilename
+          : "formData.zip";
       itemTemplate.item.name = filename;
       const storageName = convertItemResourceToStorageResource(
         itemTemplate.itemId,

--- a/packages/simple-types/test/helpers/convert-item-to-template.test.ts
+++ b/packages/simple-types/test/helpers/convert-item-to-template.test.ts
@@ -135,15 +135,18 @@ describe("simpleTypeConvertItemToTemplate", () => {
     });
 
     describe("form", () => {
-      it("should handle form item type with default filename", done => {
-        const solutionItemId = "sln1234567890";
-        const itemTemplate: common.IItemTemplate = templates.getItemTemplateSkeleton();
+      let solutionItemId: string;
+      let itemTemplate: common.IItemTemplate;
+      let expectedTemplate: any;
+
+      beforeEach(() => {
+        solutionItemId = "sln1234567890";
+        itemTemplate = templates.getItemTemplateSkeleton();
         itemTemplate.itemId = "frm1234567890";
         itemTemplate.item = mockItems.getAGOLItem("Form", null);
         itemTemplate.item.thumbnail = null;
-        itemTemplate.item.name = null;
 
-        const expectedTemplate: any = {
+        expectedTemplate = {
           itemId: "frm1234567890",
           type: "Form",
           item: {
@@ -282,6 +285,18 @@ describe("simpleTypeConvertItemToTemplate", () => {
             ]
           }
         );
+      });
+
+      const verifyFormTemplate = (done: DoneFn) => {
+        return (newItemTemplate: common.IItemTemplate) => {
+          delete newItemTemplate.key; // key is randomly generated, and so is not testable
+          expect(newItemTemplate).toEqual(expectedTemplate);
+          done();
+        };
+      };
+
+      it("should handle form item type with default filename for falsy item name", done => {
+        itemTemplate.item.name = null;
 
         simpleTypes
           .convertItemToTemplate(
@@ -289,11 +304,19 @@ describe("simpleTypeConvertItemToTemplate", () => {
             itemTemplate.item,
             MOCK_USER_SESSION
           )
-          .then(newItemTemplate => {
-            delete newItemTemplate.key; // key is randomly generated, and so is not testable
-            expect(newItemTemplate).toEqual(expectedTemplate);
-            done();
-          }, done.fail);
+          .then(verifyFormTemplate(done), done.fail);
+      });
+
+      it('should handle form item type with default filename for "undefined" string literal item name', done => {
+        itemTemplate.item.name = "undefined";
+
+        simpleTypes
+          .convertItemToTemplate(
+            solutionItemId,
+            itemTemplate.item,
+            MOCK_USER_SESSION
+          )
+          .then(verifyFormTemplate(done), done.fail);
       });
     });
 


### PR DESCRIPTION
[Target Process: 156515](https://esriarlington.tpondemand.com/entity/156515-older-deployed-survey-templates-missing-zip)

Surveys created before Hub switched to using the Survey123 API can have the literal string `"undefined"` as the item name which results in an error when attempting to create a solution template. This PR refactors the resource helpers `storeFormItemFiles` method to account for this.