### PR TITLE
Add item references to an item's dependencies

### DIFF
--- a/packages/common/test/mocks/agolItems.ts
+++ b/packages/common/test/mocks/agolItems.ts
@@ -1270,7 +1270,7 @@ export function getItemTypeAbbrev(type: string): string {
       Solution: "sol",
       StoryMap: "xxx",
       "Urban Model": "xxx",
-      "Web Experience Template": "xxx",
+      "Web Experience Template": "wex",
       "Web Experience": "xxx",
       "Web Mapping Application": "wma",
       "Workforce Project": "wrk",

--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -41,7 +41,7 @@ import {
 } from "@esri/solution-common";
 import { UserSession } from "@esri/arcgis-rest-auth";
 import { failSafe, IModel } from "@esri/hub-common";
-import { _addContentToSolution } from "./helpers/add-content-to-solution";
+import { addContentToSolution } from "./helpers/add-content-to-solution";
 
 // Simple no-op to clean up progressCallback management
 const noOp = () => {};
@@ -231,7 +231,7 @@ export function _createSolutionFromItemIds(
     .then(id => {
       solutionId = id;
       // Add list of items to the new solution
-      return _addContentToSolution(solutionId, options, authentication);
+      return addContentToSolution(solutionId, options, authentication);
     })
     .catch(addError => {
       // If the solution item got created, delete it

--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -201,6 +201,13 @@ export function addContentToSolution(
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
+/**
+ * Gets the dependencies of an item by merging its dependencies list with item references in template variables.
+ *
+ * @param template Template to examine
+ * @return List of dependency ids
+ * @private
+ */
 export function _getDependencies(template: IItemTemplate): string[] {
   // Get all dependencies
   let deps = template.dependencies.concat(
@@ -227,6 +234,13 @@ export function _getDependencies(template: IItemTemplate): string[] {
   return deps;
 }
 
+/**
+ * Extracts AGO ids out of template variables.
+ *
+ * @param variables List of template variables to examine
+ * @return List of AGO ids referenced in `variables`
+ * @private
+ */
 export function _getIdsOutOfTemplateVariables(variables: string[]): string[] {
   return variables
     .map(variable => {
@@ -240,6 +254,13 @@ export function _getIdsOutOfTemplateVariables(variables: string[]): string[] {
     .filter(variable => !!variable);
 }
 
+/**
+ * Extracts template variables out of a string.
+ *
+ * @param text String to examine
+ * @return List of template variables found in string
+ * @private
+ */
 export function _getTemplateVariables(text: string): string[] {
   return (text.match(/{{[a-z0-9.]*}}/gi) || []) // find variable
     .map(variable => variable.substring(2, variable.length - 2)); // remove "{{" & "}}"
@@ -304,7 +325,7 @@ export function _postProcessGroupDependencies(
  *
  * @param templates The array of templates to evaluate
  * @return Updated version of the templates
- * @protected
+ * @private
  */
 export function _postProcessIgnoredItems(
   templates: IItemTemplate[]

--- a/packages/simple-types/test/helpers/create-item-from-template.test.ts
+++ b/packages/simple-types/test/helpers/create-item-from-template.test.ts
@@ -203,12 +203,6 @@ describe("simpleTypeCreateItemFromTemplate", () => {
     });
   });
 
-  /*fdescribe("oic", () => {
-    it("should handle OIC (Oriented Imagery Catalog)", done => {
-      done.fail();
-    });
-  });*/
-
   describe("quick capture", () => {
     it("should create quick capture project", done => {
       const newItemId: string = "xxx79c91fc7642ebb4c0bbacfbacd510";


### PR DESCRIPTION
Look for item references in places such as an item's description and add those references to the item's dependencies list.

#534

Also added three-letter code for Web Experience Template and renamed `_addContentToSolution` because it's an external function.