### PR TITLE
Add item to object resolved by createItemFromHubTemplate to prevent d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5326,6 +5326,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
@@ -6371,6 +6381,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -7859,6 +7870,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -10437,6 +10449,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",

--- a/packages/form/src/helpers/create-item-from-hub-template.ts
+++ b/packages/form/src/helpers/create-item-from-hub-template.ts
@@ -24,7 +24,8 @@ import {
   replaceInTemplate,
   updateItemExtended,
   ISurvey123CreateParams,
-  ISurvey123CreateResult
+  ISurvey123CreateResult,
+  getItemBase
 } from "@esri/solution-common";
 import { moveItem } from "@esri/arcgis-rest-portal";
 import { createSurvey } from "./create-survey";
@@ -92,9 +93,12 @@ export function createItemFromHubTemplate(
       return Promise.all(promises)
         .then(() => {
           // then remove the folder that Survey123 created
-          return removeFolder(folderId, destinationAuthentication);
+          return Promise.all([
+            getItemBase(formId, destinationAuthentication),
+            removeFolder(folderId, destinationAuthentication)
+          ]);
         })
-        .then(() => {
+        .then(([item]) => {
           templateDictionary[interpolatedTemplate.itemId] = {
             itemId: formId
           };
@@ -110,7 +114,11 @@ export function createItemFromHubTemplate(
             formId
           );
           return {
-            item: null,
+            item: {
+              ...template,
+              item,
+              itemId: formId
+            },
             id: formId,
             type: "Form",
             postProcess: true

--- a/packages/form/src/helpers/is-hub-form-template.ts
+++ b/packages/form/src/helpers/is-hub-form-template.ts
@@ -25,5 +25,5 @@ import * as common from "@esri/solution-common";
  */
 export function isHubFormTemplate(template: common.IItemTemplate): boolean {
   // relying on basic duck typing vs adding extraneous props during migration
-  return !!common.getProp(template, "properties.services.service");
+  return !!common.getProp(template, "properties.services");
 }

--- a/packages/form/test/helpers/create-item-from-hub-template.test.ts
+++ b/packages/form/test/helpers/create-item-from-hub-template.test.ts
@@ -32,6 +32,7 @@ describe("createItemFromHubTemplate", () => {
   let paramResults: common.ISurvey123CreateParams;
   let createResult: common.ISurvey123CreateResult;
   let MOCK_USER_SESSION: common.UserSession;
+  let getItemBaseResult: common.IItem;
 
   beforeEach(() => {
     MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
@@ -106,6 +107,11 @@ describe("createItemFromHubTemplate", () => {
       featureServiceId: "f7bf45f98d114c3ab85fd63bb44e240d",
       folderId: "g7bf45f98d114c3ab85fd63bb44e240d"
     };
+
+    getItemBaseResult = {
+      ...items.getAGOLItem("form"),
+      id: createResult.formId
+    };
   });
 
   it("should resolve a ISurvey123CreateParams", done => {
@@ -128,6 +134,9 @@ describe("createItemFromHubTemplate", () => {
     const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
     const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
     const itemProgressCallbackSpy = jasmine.createSpy();
+    const getItemBaseSpy = spyOn(common, "getItemBase").and.resolveTo(
+      getItemBaseResult
+    );
     return createItemFromHubTemplate(
       template,
       templateDictionary,
@@ -168,6 +177,11 @@ describe("createItemFromHubTemplate", () => {
         expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
           templateDictionary.folderId
         );
+        expect(getItemBaseSpy.calls.count()).toEqual(1);
+        expect(getItemBaseSpy.calls.first().args).toEqual([
+          createResult.formId,
+          MOCK_USER_SESSION
+        ]);
         expect(removeFolderSpy.calls.count()).toEqual(1);
         expect(removeFolderSpy.calls.first().args).toEqual([
           createResult.folderId,
@@ -187,98 +201,11 @@ describe("createItemFromHubTemplate", () => {
           createResult.formId
         ]);
         expect(results).toEqual({
-          item: null as common.IItemTemplate,
-          id: createResult.formId,
-          type: "Form",
-          postProcess: true
-        });
-        done();
-      })
-      .catch(e => {
-        done.fail(e);
-      });
-  });
-
-  it("should resolve a ISurvey123CreateParams", done => {
-    const replaceInTemplateSpy = spyOn(
-      common,
-      "replaceInTemplate"
-    ).and.returnValue(interpolatedTemplate);
-    const buildCreateParamsSpy = spyOn(
-      buildParamsHelper,
-      "buildCreateParams"
-    ).and.resolveTo(paramResults);
-    const createSurveySpy = spyOn(
-      createSurveyHelper,
-      "createSurvey"
-    ).and.resolveTo(createResult);
-    const updateItemExtendedSpy = spyOn(
-      common,
-      "updateItemExtended"
-    ).and.resolveTo();
-    const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
-    const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
-    const itemProgressCallbackSpy = jasmine.createSpy();
-    return createItemFromHubTemplate(
-      template,
-      templateDictionary,
-      MOCK_USER_SESSION,
-      itemProgressCallbackSpy
-    )
-      .then(results => {
-        expect(replaceInTemplateSpy.calls.count()).toEqual(1);
-        expect(replaceInTemplateSpy.calls.first().args).toEqual([
-          template,
-          templateDictionary
-        ]);
-        expect(buildCreateParamsSpy.calls.count()).toEqual(1);
-        expect(buildCreateParamsSpy.calls.first().args).toEqual([
-          interpolatedTemplate,
-          templateDictionary,
-          MOCK_USER_SESSION
-        ]);
-        expect(createSurveySpy.calls.count()).toEqual(1);
-        expect(createSurveySpy.calls.first().args).toEqual([
-          paramResults,
-          undefined
-        ]);
-        expect(updateItemExtendedSpy.calls.count()).toEqual(1);
-        expect(updateItemExtendedSpy.calls.argsFor(0)[0].id).toBe(
-          createResult.formId
-        );
-        expect(moveItemSpy.calls.count()).toEqual(2);
-        expect(moveItemSpy.calls.argsFor(0)[0].itemId).toBe(
-          createResult.formId
-        );
-        expect(moveItemSpy.calls.argsFor(0)[0].folderId).toBe(
-          templateDictionary.folderId
-        );
-        expect(moveItemSpy.calls.argsFor(1)[0].itemId).toBe(
-          createResult.featureServiceId
-        );
-        expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
-          templateDictionary.folderId
-        );
-        expect(removeFolderSpy.calls.count()).toEqual(1);
-        expect(removeFolderSpy.calls.first().args).toEqual([
-          createResult.folderId,
-          MOCK_USER_SESSION
-        ]);
-        expect(templateDictionary[template.itemId]).toEqual({
-          itemId: createResult.formId
-        });
-        expect(
-          templateDictionary[template.properties.info.serviceInfo.itemId]
-        ).toEqual({ itemId: createResult.featureServiceId });
-        expect(itemProgressCallbackSpy.calls.count()).toEqual(1);
-        expect(itemProgressCallbackSpy.calls.first().args).toEqual([
-          template.itemId,
-          common.EItemProgressStatus.Finished,
-          template.estimatedDeploymentCostFactor,
-          createResult.formId
-        ]);
-        expect(results).toEqual({
-          item: null as common.IItemTemplate,
+          item: {
+            ...template,
+            item: getItemBaseResult,
+            itemId: createResult.formId
+          } as common.IItemTemplate,
           id: createResult.formId,
           type: "Form",
           postProcess: true
@@ -310,6 +237,9 @@ describe("createItemFromHubTemplate", () => {
     const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
     const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
     const itemProgressCallbackSpy = jasmine.createSpy();
+    const getItemBaseSpy = spyOn(common, "getItemBase").and.resolveTo(
+      getItemBaseResult
+    );
     templateDictionary.survey123Url = "https://survey123qa.arcgis.com";
     return createItemFromHubTemplate(
       template,
@@ -351,6 +281,11 @@ describe("createItemFromHubTemplate", () => {
         expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
           templateDictionary.folderId
         );
+        expect(getItemBaseSpy.calls.count()).toEqual(1);
+        expect(getItemBaseSpy.calls.first().args).toEqual([
+          createResult.formId,
+          MOCK_USER_SESSION
+        ]);
         expect(removeFolderSpy.calls.count()).toEqual(1);
         expect(removeFolderSpy.calls.first().args).toEqual([
           createResult.folderId,
@@ -370,7 +305,11 @@ describe("createItemFromHubTemplate", () => {
           createResult.formId
         ]);
         expect(results).toEqual({
-          item: null as common.IItemTemplate,
+          item: {
+            ...template,
+            item: getItemBaseResult,
+            itemId: createResult.formId
+          } as common.IItemTemplate,
           id: createResult.formId,
           type: "Form",
           postProcess: true


### PR DESCRIPTION
…ownstream deployment errors. Also loosen ducktyping logic to identify Solutions.js survey template vs Hub survey template.

Some Hub survey templates are failing to deploy, this PR:

1. Refactoring [createItemFromHubTemplate](https://github.com/Esri/solution.js/blob/develop/packages/form/src/helpers/create-item-from-hub-template.ts#L113) to include the `item` property to prevent downstream NPEs.
2. Loosens the duck-typing logic in [isHubFormTemplate](https://github.com/Esri/solution.js/blob/develop/packages/form/src/helpers/is-hub-form-template.ts#L28) that distinguishes between Solutions.js vs Hub templates.
3. Removes duplicate test in `packages/form/test/helpers/create-item-from-hub-template.test.ts`