### PR TITLE
Changed source of type for compatibility

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,16 +3,22 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
 name: "CodeQL"
 
 on:
   push:
-    branches: [develop, master]
+    branches: [ develop, master, release/0.21 ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [develop]
+    branches: [ develop ]
   schedule:
-    - cron: '0 8 * * 1'
+    - cron: '30 15 * * 1'
 
 jobs:
   analyze:
@@ -22,11 +28,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['javascript']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+        language: [ 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository
@@ -38,7 +43,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/packages/storymap/src/helpers/create-storymap-model-from-template.ts
+++ b/packages/storymap/src/helpers/create-storymap-model-from-template.ts
@@ -19,7 +19,7 @@
  */
 
 import { interpolate, IModelTemplate } from "@esri/hub-common";
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { UserSession } from "@esri/solution-common";
 import { getPortalEnv } from "./get-portal-env";
 import { getStoryMapBaseUrl } from "./get-storymap-base-url";
 import { getStoryMapSubdomain } from "./get-storymap-subdomain";

--- a/packages/storymap/src/helpers/create-storymap.ts
+++ b/packages/storymap/src/helpers/create-storymap.ts
@@ -23,7 +23,7 @@ import {
   stringToBlob
 } from "@esri/hub-common";
 
-import { UserSession } from "@esri/arcgis-rest-auth";
+import { UserSession } from "@esri/solution-common";
 
 import {
   createItem,


### PR DESCRIPTION
Even though two paths lead to same base type, TypeScript generates
```
Types have separate declarations of a private property '_user'.
```