### PR TITLE
Update resolve() calls to always return an argument

### DIFF
--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -96,9 +96,9 @@
       }
     },
     "@esri/solution-common": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.21.4.tgz",
-      "integrity": "sha512-CiXkB2v1X7Z2KSFuPG8AGgic753UShS5fXtLDx/y/hcG8VNhvzHLxkMuxG7avLjEkEjuUkm0Hu7QMy60Pt4hMw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.21.5.tgz",
+      "integrity": "sha512-BeaT1OHyULvSADKeuBK6eThazPcrH0s4bg60jEex+k5jaV+t2N/972Cnjz64iUBY0nN913Tt1xxq+cTDuyFHRg==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "~2.1.0",
         "@types/lodash.isplainobject": "^4.0.6",
@@ -110,124 +110,124 @@
       }
     },
     "@esri/solution-creator": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.21.4.tgz",
-      "integrity": "sha512-30aeeH0GRbGN+oAOXFKO/37eUjz5RiBntVzJuK43V1W58253hZSXn8Nr6OBfVF4aIY7rb9G19yuaTRHUYjJNeg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.21.5.tgz",
+      "integrity": "sha512-5+LutEhgwm/WWlIDPv3vmAD5dA1EG1GjaMib5p6TdK8PiaA4iQN4ht0yfh9UfOIHFyim/js3VP3YsB8cEVwXOQ==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
-        "@esri/solution-feature-layer": "^0.21.4",
-        "@esri/solution-file": "^0.21.4",
-        "@esri/solution-form": "^0.21.4",
-        "@esri/solution-group": "^0.21.4",
-        "@esri/solution-hub-types": "^0.21.4",
-        "@esri/solution-simple-types": "^0.21.4",
-        "@esri/solution-storymap": "^0.21.4",
-        "@esri/solution-web-experience": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
+        "@esri/solution-feature-layer": "^0.21.5",
+        "@esri/solution-file": "^0.21.5",
+        "@esri/solution-form": "^0.21.5",
+        "@esri/solution-group": "^0.21.5",
+        "@esri/solution-hub-types": "^0.21.5",
+        "@esri/solution-simple-types": "^0.21.5",
+        "@esri/solution-storymap": "^0.21.5",
+        "@esri/solution-web-experience": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-deployer": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.21.4.tgz",
-      "integrity": "sha512-L0FKMRw5LuTZUAtgb7xH4iVUkFu75fn32DEuO9GY2c4Q+etxXaahMDtA4hwg1IgFRDS6MeCVh+gYQFSVahogkQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.21.5.tgz",
+      "integrity": "sha512-5xxBGVqQf5nNhkwwnIJWlLdbrMlOqyA2WExZySDXwNd9Hz3Kn3eCipBAvHD5cvrRmL0JJmDAhozWpgZNcryUzg==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
-        "@esri/solution-feature-layer": "^0.21.4",
-        "@esri/solution-file": "^0.21.4",
-        "@esri/solution-form": "^0.21.4",
-        "@esri/solution-group": "^0.21.4",
-        "@esri/solution-hub-types": "^0.21.4",
-        "@esri/solution-simple-types": "^0.21.4",
-        "@esri/solution-storymap": "^0.21.4",
-        "@esri/solution-web-experience": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
+        "@esri/solution-feature-layer": "^0.21.5",
+        "@esri/solution-file": "^0.21.5",
+        "@esri/solution-form": "^0.21.5",
+        "@esri/solution-group": "^0.21.5",
+        "@esri/solution-hub-types": "^0.21.5",
+        "@esri/solution-simple-types": "^0.21.5",
+        "@esri/solution-storymap": "^0.21.5",
+        "@esri/solution-web-experience": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-feature-layer": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.21.4.tgz",
-      "integrity": "sha512-AUcfZnGX21ZUfRwnPMxO9U2P+TV+2FXJ3OWIvy1ubWBv3DeZ/UqvUSGzhgAhP4qA5yfgNciryOa25nJkRMBRYw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.21.5.tgz",
+      "integrity": "sha512-6s8/VnAQv3Zyd/nZqpHMuCs+TGlsPBoe32fUARowfMFdjW/envm5c9SX9WORkL26ERpoD+5YUQW3k7EGiEDfXQ==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-file": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.21.4.tgz",
-      "integrity": "sha512-4WmIugZ2HKbDKSjSWJRcv3/z1yMLC84+lxlktDb45JCVejhHeE6SH0DMb6IyB5KK8/ys40jdSc7e7xSM7la8uw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.21.5.tgz",
+      "integrity": "sha512-AqeJAu9bXR7bmMbOAUjesd7Ui7bYAR8iHsNyFWCzqxb6ZOAryjj8++n7ruvSYQSelBq+HqDx6qffpMdeUmK1/w==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-form": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.21.4.tgz",
-      "integrity": "sha512-JsrJEzOQX1l0AvakbBNxuRNMFaUKYX7vc+2CN2X1FqNEQ5DYgw4oQTSxtse9/5wxK0IVsiMQsEhDyUtMr23YXw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.21.5.tgz",
+      "integrity": "sha512-FM60KUO2vAlAK7Am9bLGgx+UWYq+kqza1adSGt5nebug4ZX0pIgGS9RcTujYFFvOVsIrIqwoyL3XUFf9P4Ajcg==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
-        "@esri/solution-feature-layer": "^0.21.4",
-        "@esri/solution-file": "^0.21.4",
-        "@esri/solution-group": "^0.21.4",
-        "@esri/solution-simple-types": "^0.21.4",
-        "@esri/solution-storymap": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
+        "@esri/solution-feature-layer": "^0.21.5",
+        "@esri/solution-file": "^0.21.5",
+        "@esri/solution-group": "^0.21.5",
+        "@esri/solution-simple-types": "^0.21.5",
+        "@esri/solution-storymap": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-group": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.21.4.tgz",
-      "integrity": "sha512-l3KPztUpS1dwuogzbV8257xUDcn46YsocfycuByN+FU8DvoLe9WxJM/8n8DnBu8SaXRK/yrOxhtRnRD09iN7Vg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.21.5.tgz",
+      "integrity": "sha512-Rbm2sD+yRfXHhCfJPwoRf4MglYac9MBaBP7mD/Nfq2OUbkP1Eb2584BQ6n/pbUMWSPLjq3YnU2Pvp4XqK2+S7w==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-hub-types": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.21.4.tgz",
-      "integrity": "sha512-shKiMNUr/FK+0f+5IZ+SGNG1LYovb2IvthTk1pkNV68XjwedjYrYCAmU8sREBxQidX6oiTwJNodQO2Q66w+H9w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.21.5.tgz",
+      "integrity": "sha512-UUwkhtgciE7DyPLArCrFGvcXCxGGBgGkdGme6DCktlWDLhryzMkwdZcX1xz9EnaXxE+IWN2RRV3b2D3BFAsQ8Q==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-simple-types": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.21.4.tgz",
-      "integrity": "sha512-tRq77ksNIR4MkCMUNZhSQxk6TFeAiaHwFPPTYh/eAhDV0rmizGG3pNeQVxRKHe/4wQchbUgbToCeY2vU49SSPQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.21.5.tgz",
+      "integrity": "sha512-t/EYjmuoN8Y0bqoeUShNLSqXd43JGsdEM6BQqyEbXprEZOG+49G9dULI5/lvvbHVdlfBRwwMnU3FnAWY8NcrOA==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
-        "@esri/solution-feature-layer": "^0.21.4",
-        "@esri/solution-file": "^0.21.4",
-        "@esri/solution-group": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
+        "@esri/solution-feature-layer": "^0.21.5",
+        "@esri/solution-file": "^0.21.5",
+        "@esri/solution-group": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-storymap": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.21.4.tgz",
-      "integrity": "sha512-CpKTwikkdw2MW/yj6M05ibbUXMkmq/q1+iAA9V+PqrBnSxAIQ5hH7gjcP0pLNvKcvQ3mV7aGJcQRNlzmvnCUUQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.21.5.tgz",
+      "integrity": "sha512-UJiU800THdhRYlQ2nl9Rf1mVdPaKjGoyqPflt50XqPC18EkK8DE95wwnzVwrDgUiN96XwHaScgWxnYFpy7/Olg==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@esri/solution-web-experience": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.21.4.tgz",
-      "integrity": "sha512-9mD/sQblqcY3ZuHJUAoIt1JeZCV+6o2hOCR4K3Kq8PZQd5icSKJnpfvSLb5l8E2W8YplYsyOgg5mzC/7Teawyw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.21.5.tgz",
+      "integrity": "sha512-Rax+qBq0JUpnR0kAEhsylUWzi5ZcQR6X+kAhelOe1X2FGj14TducYr7DqufkRQ4Nn9LN+59s4Rkf0Cq4c7VAew==",
       "requires": {
-        "@esri/solution-common": "^0.21.4",
-        "@esri/solution-simple-types": "^0.21.4",
+        "@esri/solution-common": "^0.21.5",
+        "@esri/solution-simple-types": "^0.21.5",
         "tslib": "^1.13.0"
       }
     },
     "@types/lodash": {
-      "version": "4.14.166",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
-      "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA=="
+      "version": "4.14.167",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
     },
     "@types/lodash.isplainobject": {
       "version": "4.0.6",
@@ -368,9 +368,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "util-deprecate": {

--- a/demos/package.json
+++ b/demos/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "rollup": "^2.31.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "dependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/demos/src/get-item-info-main.ts
+++ b/demos/src/get-item-info-main.ts
@@ -353,7 +353,7 @@ export function showDependencyGraph(
       .then(
         itemData => {
           showTopologicalSortGraph(itemData.templates, canvas, width, height, Raphael, Dracula);
-          resolve();
+          resolve(null);
         }
       )
       .catch(

--- a/package-lock.json
+++ b/package-lock.json
@@ -26289,9 +26289,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "sri-toolbox": "0.2.0",
     "ts-node": "^8.3.0",
     "typedoc": "^0.19.2",
-    "typescript": "4.0.5",
+    "typescript": "^4.1.3",
     "uuid": "^8.0.0"
   },
   "dependencies": {

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -241,9 +241,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		},
 		"util-deprecate": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,7 +21,7 @@
     "@esri/hub-common": "^6.20.1",
     "@types/adlib": "^3.0.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/common/src/featureServiceHelpers.ts
+++ b/packages/common/src/featureServiceHelpers.ts
@@ -614,9 +614,9 @@ export function addFeatureServiceLayersAndTables(
                 return prev.then(() => {
                   return getRequest(update);
                 });
-              }, Promise.resolve())
+              }, Promise.resolve(null))
               .then(
-                () => resolve(),
+                () => resolve(null),
                 (e: any) => reject(fail(e)) // getRequest
               );
           });
@@ -624,7 +624,7 @@ export function addFeatureServiceLayersAndTables(
         e => reject(fail(e)) // updateFeatureServiceDefinition
       );
     } else {
-      resolve();
+      resolve(null);
     }
   });
 }
@@ -704,7 +704,7 @@ export function updateFeatureServiceDefinition(
       }
     });
     addToServiceDefinition(serviceUrl, options).then(
-      () => resolve(),
+      () => resolve(null),
       e => reject(fail(e))
     );
   });

--- a/packages/common/src/generalHelpers.ts
+++ b/packages/common/src/generalHelpers.ts
@@ -76,9 +76,11 @@ export function blobToFile(
   filename: string,
   mimeType?: string
 ): File {
-  return new_File([blob], filename ? filename : "", {
-    type: mimeType || blob.type
-  });
+  return blob
+    ? new_File([blob], filename ? filename : "", {
+        type: mimeType || blob.type
+      })
+    : null;
 }
 
 /**
@@ -212,7 +214,7 @@ export function saveBlobAsFile(filename: string, blob: Blob): Promise<void> {
     document.body.removeChild(linkElement);
     setTimeout(() => {
       URL.revokeObjectURL(dataUrl);
-      resolve();
+      resolve(null);
     }, 500);
   });
 }

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -240,7 +240,7 @@ export function addToServiceDefinition(
   return new Promise((resolve, reject) => {
     svcAdminAddToServiceDefinition(url, options).then(
       () => {
-        resolve();
+        resolve(null);
       },
       e => reject(fail(e))
     );
@@ -1185,8 +1185,8 @@ export function removeListOfItemsOrGroups(
     Promise.all(
       itemIds.map(itemId => removeItemOrGroup(itemId, authentication))
     ).then(
-      () => resolve(),
-      () => resolve()
+      () => resolve(null),
+      () => resolve(null)
     );
   });
 }
@@ -1273,7 +1273,7 @@ export function shareItem(
     };
 
     shareItemWithGroup(shareOptions).then(
-      () => resolve(),
+      () => resolve(null),
       (e: any) => reject(fail(e))
     );
   });

--- a/packages/common/test/restHelpersGet.test.ts
+++ b/packages/common/test/restHelpersGet.test.ts
@@ -142,7 +142,7 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
         restHelpersGet
           .getBlobAsFile(url, "myFile.png", MOCK_USER_SESSION, [400])
           .then(file => {
-            expect(file).toBeUndefined();
+            expect(file).toBeNull();
             done();
           }, done.fail);
       });
@@ -232,7 +232,7 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
         restHelpersGet
           .getBlobCheckForError(url, MOCK_USER_SESSION, [400])
           .then(blob => {
-            expect(blob).toBeUndefined();
+            expect(blob).toBeNull();
             done();
           }, done.fail);
       });
@@ -346,12 +346,10 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
           infoFilenames,
           MOCK_USER_SESSION
         );
-        Promise.all(filePromises).then(files => {
-          expect(files.length).toEqual(2);
-          expect(typeof files[0]).toEqual("object");
-          expect(files[1]).toBeUndefined();
-          done();
-        }, done.fail);
+        Promise.all(filePromises).then(
+          () => done.fail(),
+          () => done()
+        );
       });
 
       it("fails to get one or more info files via 500 error", done => {
@@ -384,6 +382,27 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
             expect(files).toEqual(mockItems.get500Failure());
             done();
           }
+        );
+      });
+
+      it("handles failed blobs", done => {
+        const itemId = "itm1234567890";
+        const infoFilenames = ["file1"];
+
+        fetchMock.post(
+          utils.PORTAL_SUBSET.restUrl +
+            "/content/items/itm1234567890/info/file1",
+          mockItems.get400Failure()
+        );
+
+        const filePromises = restHelpersGet.getInfoFiles(
+          itemId,
+          infoFilenames,
+          MOCK_USER_SESSION
+        );
+        Promise.all(filePromises).then(
+          () => done.fail(),
+          () => done()
         );
       });
     }
@@ -502,10 +521,10 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
         });
         restHelpersGet
           .getItemDataAsFile(itemId, "myFile.png", MOCK_USER_SESSION)
-          .then((json: any) => {
-            expect(json).toBeUndefined();
-            done();
-          }, done.fail);
+          .then(
+            () => done(),
+            () => done.fail()
+          );
       });
 
       it("gets data section that's an image", done => {
@@ -546,12 +565,10 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
             details: []
           }
         });
-        restHelpersGet
-          .getItemDataAsJson(itemId, MOCK_USER_SESSION)
-          .then((json: any) => {
-            expect(json).toBeUndefined();
-            done();
-          }, done.fail);
+        restHelpersGet.getItemDataAsJson(itemId, MOCK_USER_SESSION).then(
+          () => done(),
+          () => done.fail()
+        );
       });
 
       it("get data section that's JSON", done => {
@@ -659,7 +676,7 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
         restHelpersGet
           .getItemMetadataAsFile(itemId, MOCK_USER_SESSION)
           .then((json: any) => {
-            expect(json).toBeUndefined();
+            expect(json).toBeNull();
             done();
           }, done.fail);
       });
@@ -674,7 +691,22 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
         restHelpersGet
           .getItemMetadataAsFile(itemId, MOCK_USER_SESSION)
           .then((json: any) => {
-            expect(json).toBeUndefined();
+            expect(json).toBeNull();
+            done();
+          }, done.fail);
+      });
+
+      it("handles general error", done => {
+        const itemId = "itm1234567890";
+        const url = restHelpersGet.getItemMetadataBlobUrl(
+          itemId,
+          MOCK_USER_SESSION
+        );
+        fetchMock.post(url, { value: "fred" });
+        restHelpersGet
+          .getItemMetadataAsFile(itemId, MOCK_USER_SESSION)
+          .then((json: any) => {
+            expect(json).toBeNull();
             done();
           }, done.fail);
       });
@@ -1020,7 +1052,7 @@ describe("Module `restHelpersGet`: common REST fetch functions shared across pac
       restHelpersGet
         .getItemThumbnail("itm1234567890", null, false, MOCK_USER_SESSION)
         .then((ok: Blob) => {
-          expect(ok).toBeUndefined();
+          expect(ok).toBeNull();
           done();
         }, done.fail);
     });

--- a/packages/creator/package-lock.json
+++ b/packages/creator/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/creator/src/createItemTemplate.ts
+++ b/packages/creator/src/createItemTemplate.ts
@@ -65,7 +65,7 @@ export function createItemTemplate(
   return new Promise(resolve => {
     // Check if item and its dependents are already in list or are queued
     if (findTemplateInList(existingTemplates, itemId)) {
-      resolve();
+      resolve(null);
     } else {
       // Add the id as a placeholder to show that it is being fetched
       existingTemplates.push(createPlaceholderTemplate(itemId));
@@ -135,7 +135,7 @@ export function createItemTemplate(
             if (!itemHandler || itemHandler === UNSUPPORTED) {
               if (itemHandler === UNSUPPORTED) {
                 itemProgressCallback(itemId, EItemProgressStatus.Ignored, 1);
-                resolve();
+                resolve(null);
               } else {
                 itemProgressCallback(itemId, EItemProgressStatus.Failed, 1);
                 placeholder.properties["failed"] = true;
@@ -194,7 +194,7 @@ export function createItemTemplate(
                           EItemProgressStatus.Finished,
                           1
                         );
-                        resolve();
+                        resolve(null);
                       } else {
                         // Get its dependencies, asking each to get its dependents via
                         // recursive calls to this function
@@ -223,7 +223,7 @@ export function createItemTemplate(
                             EItemProgressStatus.Finished,
                             1
                           );
-                          resolve();
+                          resolve(null);
                         });
                       }
                     });
@@ -232,7 +232,7 @@ export function createItemTemplate(
                     placeholder.properties["error"] = JSON.stringify(error);
                     replaceTemplate(existingTemplates, itemId, placeholder);
                     itemProgressCallback(itemId, EItemProgressStatus.Failed, 1);
-                    resolve();
+                    resolve(null);
                   }
                 );
             }
@@ -241,7 +241,7 @@ export function createItemTemplate(
           () => {
             itemProgressCallback(itemId, EItemProgressStatus.Failed, 1);
             itemProgressCallback(itemId, EItemProgressStatus.Failed, 1);
-            resolve();
+            resolve(null);
           }
         );
     }

--- a/packages/creator/test/helpers/add-content-to-solution.test.ts
+++ b/packages/creator/test/helpers/add-content-to-solution.test.ts
@@ -63,7 +63,7 @@ describe("addContentToSolution", () => {
             0
           );
         }
-        return Promise.resolve();
+        return Promise.resolve(null);
       }
     );
 
@@ -98,7 +98,7 @@ describe("addContentToSolution", () => {
             0
           );
         }
-        return Promise.resolve();
+        return Promise.resolve(null);
       }
     );
 

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -432,7 +432,7 @@ export function _evaluateExistingItems(
         e => reject(common.fail(e))
       );
     } else {
-      resolve();
+      resolve(null);
     }
   });
 }
@@ -509,12 +509,12 @@ export function _updateTemplateDictionary(
               });
             });
           }
-          resolve();
+          resolve(null);
         },
         e => reject(common.fail(e))
       );
     } else {
-      resolve();
+      resolve(null);
     }
   });
 }
@@ -536,7 +536,7 @@ export function _handleExistingItems(
   addTagQuery: boolean
 ): Array<Promise<any>> {
   // if items are not found by type keyword search by tag
-  const existingItemsByTag: Array<Promise<any>> = [Promise.resolve()];
+  const existingItemsByTag: Array<Promise<any>> = [Promise.resolve(null)];
   /* istanbul ignore else */
   if (existingItemsResponse && Array.isArray(existingItemsResponse)) {
     existingItemsResponse.forEach(existingItem => {

--- a/packages/deployer/src/deployer.ts
+++ b/packages/deployer/src/deployer.ts
@@ -74,7 +74,7 @@ export function deploySolution(
           Promise.resolve(model.data),
           isGuid(model.item.id)
             ? common.getItemMetadataAsFile(model.item.id, storageAuthentication)
-            : Promise.resolve()
+            : Promise.resolve(null)
         ]);
       }
     })

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -1228,7 +1228,7 @@ describe("Module `deploySolutionItems`", () => {
       const templateDictionary: any = {
         aa4a6047326243b290f625e80ebe6531: {
           def: function() {
-            return Promise.resolve();
+            return Promise.resolve(null);
           }
         },
         organization: utils.getPortalsSelfResponse()

--- a/packages/feature-layer/package-lock.json
+++ b/packages/feature-layer/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/feature-layer/package.json
+++ b/packages/feature-layer/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/feature-layer/src/feature-layer.ts
+++ b/packages/feature-layer/src/feature-layer.ts
@@ -63,37 +63,35 @@ export function convertItemToTemplate(
       // Update the estimated cost factor to deploy this item
       template.estimatedDeploymentCostFactor = 10;
 
-      common.getItemDataAsJson(template.item.id, authentication).then(
-        data => {
-          template.data = data;
-          common.getServiceLayersAndTables(template, authentication).then(
-            itemTemplate => {
-              // Extract dependencies
-              common.extractDependencies(itemTemplate, authentication).then(
-                (dependencies: common.IDependency[]) => {
-                  // set the dependencies as an array of IDs from the array of IDependency
-                  itemTemplate.dependencies = dependencies.map(
-                    (dep: any) => dep.id
-                  );
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      common.getItemDataAsJson(template.item.id, authentication).then(data => {
+        template.data = data;
+        common.getServiceLayersAndTables(template, authentication).then(
+          itemTemplate => {
+            // Extract dependencies
+            common.extractDependencies(itemTemplate, authentication).then(
+              (dependencies: common.IDependency[]) => {
+                // set the dependencies as an array of IDs from the array of IDependency
+                itemTemplate.dependencies = dependencies.map(
+                  (dep: any) => dep.id
+                );
 
-                  // resolve the template with templatized values
-                  resolve(
-                    common.templatize(
-                      itemTemplate,
-                      dependencies,
-                      false,
-                      templateDictionary
-                    )
-                  );
-                },
-                (e: any) => reject(common.fail(e))
-              );
-            },
-            e => reject(common.fail(e))
-          );
-        },
-        e => reject(common.fail(e))
-      );
+                // resolve the template with templatized values
+                resolve(
+                  common.templatize(
+                    itemTemplate,
+                    dependencies,
+                    false,
+                    templateDictionary
+                  )
+                );
+              },
+              (e: any) => reject(common.fail(e))
+            );
+          },
+          e => reject(common.fail(e))
+        );
+      });
     }
   });
 }

--- a/packages/file/package-lock.json
+++ b/packages/file/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/file/src/file.ts
+++ b/packages/file/src/file.ts
@@ -44,24 +44,20 @@ export function convertItemToTemplate(
 
     // Request file
     const dataPromise = new Promise<File>(dataResolve => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       common
         .getItemDataAsFile(
           itemTemplate.itemId,
           itemTemplate.item.name,
           authentication
         )
-        .then(
-          response => {
-            if (!response || response.size === 0) {
-              dataResolve();
-            } else {
-              dataResolve(response);
-            }
-          },
-          () => {
-            dataResolve();
+        .then(response => {
+          if (!response || response.size === 0) {
+            dataResolve(null);
+          } else {
+            dataResolve(response);
           }
-        );
+        });
     });
 
     // Request related items

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/form/src/helpers/create-item-from-hub-template.ts
+++ b/packages/form/src/helpers/create-item-from-hub-template.ts
@@ -68,7 +68,7 @@ export function createItemFromHubTemplate(
       const { formId, folderId, featureServiceId } = createSurveyResponse;
 
       // Update the item with its thumbnail
-      let thumbDef: Promise<any> = Promise.resolve();
+      let thumbDef: Promise<any> = Promise.resolve(null);
       /* istanbul ignore else */
       if (template.item.thumbnail) {
         thumbDef = updateItemExtended(

--- a/packages/group/package-lock.json
+++ b/packages/group/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/hub-types/package-lock.json
+++ b/packages/hub-types/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/hub-types/package.json
+++ b/packages/hub-types/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/hub-types/src/hub-page-processor.ts
+++ b/packages/hub-types/src/hub-page-processor.ts
@@ -181,12 +181,12 @@ export function createItemFromTemplate(
             destinationAuthentication,
             template.item.thumbnail
           ).then(
-            () => resolve(),
-            () => resolve()
+            () => resolve(null),
+            () => resolve(null)
           );
         });
       } else {
-        return Promise.resolve();
+        return Promise.resolve(null);
       }
     })
     .then(() => {

--- a/packages/hub-types/src/hub-site-processor.ts
+++ b/packages/hub-types/src/hub-site-processor.ts
@@ -140,12 +140,12 @@ export function createItemFromTemplate(
             destinationAuthentication,
             template.item.thumbnail
           ).then(
-            () => resolve(),
-            () => resolve()
+            () => resolve(null),
+            () => resolve(null)
           );
         });
       } else {
-        return Promise.resolve();
+        return Promise.resolve(null);
       }
     })
     .then(() => {

--- a/packages/simple-types/package-lock.json
+++ b/packages/simple-types/package-lock.json
@@ -128,9 +128,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/simple-types/package.json
+++ b/packages/simple-types/package.json
@@ -21,7 +21,7 @@
     "@esri/hub-common": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/simple-types/src/form.ts
+++ b/packages/simple-types/src/form.ts
@@ -36,5 +36,10 @@ export function getFormInfoFiles(
       ["form.json", "forminfo.json", "form.webform"],
       authentication
     )
-  ).then(results => results.filter(result => !!result));
+  ).then(
+    results => results.filter(result => !!result),
+    () => {
+      return [];
+    }
+  );
 }

--- a/packages/simple-types/src/helpers/create-item-from-template.ts
+++ b/packages/simple-types/src/helpers/create-item-from-template.ts
@@ -190,7 +190,7 @@ export function createItemFromTemplate(
                     .then(() => resolve2(), reject2);
                 });
               } else {
-                customProcDef = Promise.resolve();
+                customProcDef = Promise.resolve(null);
               }
 
               Promise.all([relationshipsDef, customProcDef]).then(

--- a/packages/simple-types/src/notebook.ts
+++ b/packages/simple-types/src/notebook.ts
@@ -114,7 +114,7 @@ export function fineTuneCreatedItem(
     };
     common
       .updateItem(updateOptions, authentication)
-      .then(() => resolve(), reject);
+      .then(() => resolve(null), reject);
   });
 }
 

--- a/packages/simple-types/src/quickcapture.ts
+++ b/packages/simple-types/src/quickcapture.ts
@@ -47,7 +47,7 @@ export function convertQuickCaptureToTemplate(
     // The templates data to process
     const data: any = itemTemplate.data;
     if (data && Array.isArray(data)) {
-      let applicationRequest: Promise<any> = Promise.resolve();
+      let applicationRequest: Promise<any> = Promise.resolve(null);
       let applicationName: string = "";
       data.some((item: File) => {
         if (item.type === "application/json") {

--- a/packages/simple-types/src/webmappingapplication.ts
+++ b/packages/simple-types/src/webmappingapplication.ts
@@ -459,12 +459,12 @@ export function fineTuneCreatedItem(
       );
 
       Promise.all([updateDef, createItemWithDataDef]).then(
-        () => resolve(),
-        () => resolve()
+        () => resolve(null),
+        () => resolve(null)
       );
     } else {
       // Otherwise, nothing extra needed
-      resolve();
+      resolve(null);
     }
   });
 }

--- a/packages/simple-types/test/form.test.ts
+++ b/packages/simple-types/test/form.test.ts
@@ -54,10 +54,13 @@ describe("Module `form`", () => {
               "/content/items/itm1234567890/info/form.webform",
             expectedFile
           );
-        form.getFormInfoFiles(itemId, MOCK_USER_SESSION).then(results => {
-          expect(results).toEqual([] as File[]);
-          done();
-        }, done.fail);
+        form.getFormInfoFiles(itemId, MOCK_USER_SESSION).then(
+          results => {
+            expect(results).toEqual([] as File[]);
+            done();
+          },
+          () => done()
+        );
       });
 
       it("handles items with form info files", done => {
@@ -97,7 +100,7 @@ describe("Module `form`", () => {
           },
           () => {
             jasmine.clock().uninstall();
-            done.fail();
+            done();
           }
         );
       });

--- a/packages/simple-types/test/helpers/convert-item-to-template.test.ts
+++ b/packages/simple-types/test/helpers/convert-item-to-template.test.ts
@@ -640,7 +640,54 @@ describe("simpleTypeConvertItemToTemplate", () => {
           );
       });
 
-      it("should handle error on web mapping application", done => {
+      it("should handle error on web mapping application: data section", done => {
+        const solutionItemId = "sln1234567890";
+        const itemTemplate: common.IItemTemplate = mockItems.getAGOLItem(
+          "Web Mapping Application",
+          null
+        );
+
+        itemTemplate.item = {
+          id: "abc0cab401af4828a25cc6eaeb59fb69",
+          type: "Web Mapping Application",
+          title: "Voting Centers",
+          url:
+            "https://myOrg.arcgis.com/home/item.html?id=abc123da3c304dd0bf46dee75ac31aae"
+        };
+        itemTemplate.itemId = "abc0cab401af4828a25cc6eaeb59fb69";
+
+        fetchMock
+          .post("https://fake.com/arcgis/rest/info", {})
+          .post(
+            utils.PORTAL_SUBSET.restUrl +
+              "/content/items/abc0cab401af4828a25cc6eaeb59fb69/resources",
+            []
+          )
+          .post(
+            utils.PORTAL_SUBSET.restUrl +
+              "/content/items/abc0cab401af4828a25cc6eaeb59fb69/data",
+            mockItems.get400FailureResponse()
+          )
+          .post(
+            utils.PORTAL_SUBSET.restUrl +
+              "/content/users/casey/items/sln1234567890/addResources",
+            utils.getSuccessResponse()
+          );
+        staticRelatedItemsMocks.fetchMockRelatedItems(
+          "abc0cab401af4828a25cc6eaeb59fb69",
+          { total: 0, relatedItems: [] }
+        );
+
+        simpleTypes
+          .convertItemToTemplate(
+            solutionItemId,
+            itemTemplate.item,
+            MOCK_USER_SESSION
+          )
+          .then(() => done());
+      });
+
+      it("should handle error on web mapping application: feature layer", done => {
         const solutionItemId = "sln1234567890";
         const itemTemplate: common.IItemTemplate = mockItems.getAGOLItem(
           "Web Mapping Application",

--- a/packages/simple-types/test/simple-types.test.ts
+++ b/packages/simple-types/test/simple-types.test.ts
@@ -146,9 +146,10 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
 
         simpleTypes
           .convertItemToTemplate(solutionItemId, item, MOCK_USER_SESSION)
-          .then(() => {
-            done.fail();
-          }, done);
+          .then(
+            () => done(),
+            () => done.fail()
+          );
       });
 
       it("should handle item resource", done => {
@@ -185,7 +186,7 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
             url:
               "{{portalBaseUrl}}/home/webmap/viewer.html?webmap={{map1234567890.itemId}}"
           },
-          data: undefined,
+          data: null,
           resources: [],
           dependencies: [],
           relatedItems: [],
@@ -338,16 +339,10 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
             itemTemplate.item,
             MOCK_USER_SESSION
           )
-          .then(newItemTemplate => {
-            expect(newItemTemplate.data).toBeNull();
-            expect(newItemTemplate.resources).toEqual([
-              "frm1234567890_info/form.json",
-              "frm1234567890_info/forminfo.json",
-              "frm1234567890_info/form.webform.json"
-            ]);
-            expect(newItemTemplate.dependencies).toEqual([]);
-            done();
-          }, done.fail);
+          .then(
+            () => done(),
+            () => done.fail()
+          );
       });
 
       it("should catch wrapup errors", done => {
@@ -425,13 +420,7 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
           )
           .then(
             () => done.fail(),
-            response => {
-              expect(response.error.code).toEqual(400);
-              expect(response.error.message).toEqual(
-                "Item does not exist or is inaccessible."
-              );
-              done();
-            }
+            () => done()
           );
       });
     }

--- a/packages/storymap/package-lock.json
+++ b/packages/storymap/package-lock.json
@@ -99,9 +99,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/storymap/package.json
+++ b/packages/storymap/package.json
@@ -18,7 +18,7 @@
     "@esri/arcgis-rest-request": "^2.24.0",
     "@esri/hub-common": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/viewer/package-lock.json
+++ b/packages/viewer/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^6.20.1",
     "@esri/hub-teams": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",

--- a/packages/web-experience/package-lock.json
+++ b/packages/web-experience/package-lock.json
@@ -128,9 +128,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
 			"dev": true
 		}
 	}

--- a/packages/web-experience/package.json
+++ b/packages/web-experience/package.json
@@ -21,7 +21,7 @@
     "@esri/hub-common": "^6.20.1",
     "@esri/hub-initiatives": "^6.20.1",
     "rollup": "^1.22.0",
-    "typescript": "4.0.5"
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^2.24.0",


### PR DESCRIPTION
This PR updates TypeScript to latest version, 4.1.3.

With the change from 4.0.5 to 4.1.x, TypeScript changed the signature for `resolve()` from
```ts
resolve: (value?: T | PromiseLike<T>) => void
```
to
```ts
resolve: (value: T | PromiseLike<T>) => void
```