### PR TITLE
166968 - Fix intermittent Hub survey template deployment failures.

### DIFF
--- a/packages/form/src/helpers/create-item-from-hub-template.ts
+++ b/packages/form/src/helpers/create-item-from-hub-template.ts
@@ -20,14 +20,12 @@ import {
   IItemProgressCallback,
   ICreateItemFromTemplateResponse,
   EItemProgressStatus,
-  removeFolder,
   replaceInTemplate,
   updateItemExtended,
   ISurvey123CreateParams,
   ISurvey123CreateResult,
   getItemBase
 } from "@esri/solution-common";
-import { moveItem } from "@esri/arcgis-rest-portal";
 import { createSurvey } from "./create-survey";
 import { buildCreateParams } from "./build-create-params";
 
@@ -65,7 +63,7 @@ export function createItemFromHubTemplate(
       return createSurvey(params, survey123Url);
     })
     .then((createSurveyResponse: ISurvey123CreateResult) => {
-      const { formId, folderId, featureServiceId } = createSurveyResponse;
+      const { formId, featureServiceId } = createSurveyResponse;
 
       // Update the item with its thumbnail
       let thumbDef: Promise<any> = Promise.resolve(null);
@@ -79,26 +77,9 @@ export function createItemFromHubTemplate(
         );
       }
 
-      // Survey123 API creates Form & Feature Service in a different directory,
-      // so move those items to the deployed solution folder
-      const promises = [thumbDef].concat(
-        [formId, featureServiceId].map((id: string) => {
-          return moveItem({
-            itemId: id,
-            folderId: templateDictionary.folderId as string,
-            authentication: destinationAuthentication
-          });
-        })
-      );
-      return Promise.all(promises)
-        .then(() => {
-          // then remove the folder that Survey123 created
-          return Promise.all([
-            getItemBase(formId, destinationAuthentication),
-            removeFolder(folderId, destinationAuthentication)
-          ]);
-        })
-        .then(([item]) => {
+      return thumbDef
+        .then(() => getItemBase(formId, destinationAuthentication))
+        .then(item => {
           templateDictionary[interpolatedTemplate.itemId] = {
             itemId: formId
           };

--- a/packages/form/test/helpers/create-item-from-hub-template.test.ts
+++ b/packages/form/test/helpers/create-item-from-hub-template.test.ts
@@ -131,8 +131,6 @@ describe("createItemFromHubTemplate", () => {
       common,
       "updateItemExtended"
     ).and.resolveTo();
-    // const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
-    // const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
     const itemProgressCallbackSpy = jasmine.createSpy();
     const getItemBaseSpy = spyOn(common, "getItemBase").and.resolveTo(
       getItemBaseResult
@@ -216,8 +214,6 @@ describe("createItemFromHubTemplate", () => {
       common,
       "updateItemExtended"
     ).and.resolveTo();
-    // const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
-    // const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
     const itemProgressCallbackSpy = jasmine.createSpy();
     const getItemBaseSpy = spyOn(common, "getItemBase").and.resolveTo(
       getItemBaseResult

--- a/packages/form/test/helpers/create-item-from-hub-template.test.ts
+++ b/packages/form/test/helpers/create-item-from-hub-template.test.ts
@@ -131,8 +131,8 @@ describe("createItemFromHubTemplate", () => {
       common,
       "updateItemExtended"
     ).and.resolveTo();
-    const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
-    const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
+    // const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
+    // const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
     const itemProgressCallbackSpy = jasmine.createSpy();
     const getItemBaseSpy = spyOn(common, "getItemBase").and.resolveTo(
       getItemBaseResult
@@ -164,27 +164,9 @@ describe("createItemFromHubTemplate", () => {
         expect(updateItemExtendedSpy.calls.argsFor(0)[0].id).toBe(
           createResult.formId
         );
-        expect(moveItemSpy.calls.count()).toEqual(2);
-        expect(moveItemSpy.calls.argsFor(0)[0].itemId).toBe(
-          createResult.formId
-        );
-        expect(moveItemSpy.calls.argsFor(0)[0].folderId).toBe(
-          templateDictionary.folderId
-        );
-        expect(moveItemSpy.calls.argsFor(1)[0].itemId).toBe(
-          createResult.featureServiceId
-        );
-        expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
-          templateDictionary.folderId
-        );
         expect(getItemBaseSpy.calls.count()).toEqual(1);
         expect(getItemBaseSpy.calls.first().args).toEqual([
           createResult.formId,
-          MOCK_USER_SESSION
-        ]);
-        expect(removeFolderSpy.calls.count()).toEqual(1);
-        expect(removeFolderSpy.calls.first().args).toEqual([
-          createResult.folderId,
           MOCK_USER_SESSION
         ]);
         expect(templateDictionary[template.itemId]).toEqual({
@@ -234,8 +216,8 @@ describe("createItemFromHubTemplate", () => {
       common,
       "updateItemExtended"
     ).and.resolveTo();
-    const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
-    const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
+    // const moveItemSpy = spyOn(restPortal, "moveItem").and.resolveTo();
+    // const removeFolderSpy = spyOn(common, "removeFolder").and.resolveTo();
     const itemProgressCallbackSpy = jasmine.createSpy();
     const getItemBaseSpy = spyOn(common, "getItemBase").and.resolveTo(
       getItemBaseResult
@@ -268,27 +250,9 @@ describe("createItemFromHubTemplate", () => {
         expect(updateItemExtendedSpy.calls.argsFor(0)[0].id).toBe(
           createResult.formId
         );
-        expect(moveItemSpy.calls.count()).toEqual(2);
-        expect(moveItemSpy.calls.argsFor(0)[0].itemId).toBe(
-          createResult.formId
-        );
-        expect(moveItemSpy.calls.argsFor(0)[0].folderId).toBe(
-          templateDictionary.folderId
-        );
-        expect(moveItemSpy.calls.argsFor(1)[0].itemId).toBe(
-          createResult.featureServiceId
-        );
-        expect(moveItemSpy.calls.argsFor(1)[0].folderId).toBe(
-          templateDictionary.folderId
-        );
         expect(getItemBaseSpy.calls.count()).toEqual(1);
         expect(getItemBaseSpy.calls.first().args).toEqual([
           createResult.formId,
-          MOCK_USER_SESSION
-        ]);
-        expect(removeFolderSpy.calls.count()).toEqual(1);
-        expect(removeFolderSpy.calls.first().args).toEqual([
-          createResult.folderId,
           MOCK_USER_SESSION
         ]);
         expect(templateDictionary[template.itemId]).toEqual({


### PR DESCRIPTION
[166968](https://esriarlington.tpondemand.com/entity/166968-regression-survey-solution-templates-fail-to).

We're experiencing intermittent deployment failures for Hub survey templates. When the error occurs, the message is `Item does not exist or is inaccessible` and is related to the logic that moves the `Form` & `Feature Service` items and deletes their original folder created by the S123 API. Despite the  REST `move` API returning a success response for both items, the `Form` remains in the S123 folder and gets deleted when the original S123 folder gets deleted. The actual error is thrown from a downstream `update` call for the `Form` in the post processing logic.

This PR resolves in the intermittent failures by moving the calls that move the items & delete the original S123 folder from `create-item-from-template` to the end of the `post-processing` logic.