### PR TITLE
fix: add migration to address very old hub templates

### DIFF
--- a/packages/common/src/migrations/upgrade-two-dot-seven.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-seven.ts
@@ -1,0 +1,51 @@
+/** @license
+ * Copyright 2020 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getProp, createId } from "@esri/hub-common";
+
+export function _upgradeTwoDotSeven(model: any): any {
+  if (getProp(model, "item.properties.schemaVersion") >= 2.7) {
+    return model;
+  }
+  // These templates predate the use of the dependency array to create
+  // the deployment order. Thus the templates are listed in the order
+  // they should be created. We need to construct the dependency graph
+  // based on the order
+  model.data.templates = model.data.templates.map(
+    (t: any, idx: number, arr: any[]) => {
+      // Not all templates will even have `.itemId` as a real value
+      // so if it's empty, we should set it to a random string
+      // Downside is that if there are tokens in the rest of the
+      // json, there is no way to ever interpolate them
+      if (!t.itemId) {
+        t.itemId = createId();
+      }
+      // if the dependencies array does not exist, add an empty one
+      if (!t.dependencies) {
+        t.dependencies = [];
+      }
+      // We want the dependency to be the pervious entry in
+      // the array's itemId
+      if (idx > 0 && t.dependencies.length === 0) {
+        t.dependencies = [arr[idx - 1].itemId];
+      }
+      return t;
+    }
+  );
+
+  model.item.properties.schemaVersion = 2.7;
+  return model;
+}

--- a/packages/common/src/migrator.ts
+++ b/packages/common/src/migrator.ts
@@ -24,6 +24,7 @@ import { _upgradeTwoDotThree } from "./migrations/upgrade-two-dot-three";
 import { _upgradeTwoDotFour } from "./migrations/upgrade-two-dot-four";
 import { _upgradeTwoDotFive } from "./migrations/upgrade-two-dot-five";
 import { _upgradeTwoDotSix } from "./migrations/upgrade-two-dot-six";
+import { _upgradeTwoDotSeven } from "./migrations/upgrade-two-dot-seven";
 import { _upgradeThreeDotZero } from "./migrations/upgrade-three-dot-zero";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { _upgradeThreeDotOne } from "./migrations/upgrade-three-dot-one";
@@ -72,7 +73,8 @@ export function migrateSchema(model: ISolutionItem): Promise<ISolutionItem> {
         _upgradeTwoDotThree,
         _upgradeTwoDotFour,
         _upgradeTwoDotFive,
-        _upgradeTwoDotSix
+        _upgradeTwoDotSix,
+        _upgradeTwoDotSeven
       );
       // Apply the 3.x upgrades
       schemaUpgrades.push(

--- a/packages/common/test/migrations/upgrade-two-dot-seven.test.ts
+++ b/packages/common/test/migrations/upgrade-two-dot-seven.test.ts
@@ -1,0 +1,85 @@
+/** @license
+ * Copyright 2018 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cloneObject, IItemTemplate } from "@esri/hub-common";
+import { ISolutionItem } from "../../src/interfaces";
+import { _upgradeTwoDotSeven } from "../../src/migrations/upgrade-two-dot-seven";
+describe("Upgrade 2.7 ::", () => {
+  it("returns same model if on or above 2.7", () => {
+    const m = cloneObject(defaultModel);
+    m.item.properties.schemaVersion = 2.7;
+    const chk = _upgradeTwoDotSeven(m);
+    expect(chk).toBe(m, "should return the exact same object");
+  });
+  it("adds missing ids, dependencies", () => {
+    const m = cloneObject(defaultModel);
+    const chk = _upgradeTwoDotSeven(m);
+    const tmpls = chk.data.templates;
+    expect(tmpls[0].itemId).toBeDefined("add itemId to first template");
+    expect(tmpls[0].dependencies).toBeDefined(
+      "add dependencies to first template"
+    );
+    expect(Array.isArray(tmpls[0].dependencies)).toBe(
+      true,
+      "add dependencies array to first template"
+    );
+    expect(tmpls[0].dependencies.length).toBe(
+      0,
+      "should not add entries to dependencies on first template"
+    );
+    expect(tmpls[1].dependencies).toBeDefined(
+      "add dependencies to second template"
+    );
+    expect(Array.isArray(tmpls[1].dependencies)).toBe(
+      true,
+      "add dependencies array to second template"
+    );
+    expect(tmpls[1].dependencies.length).toBe(
+      1,
+      "should add entries to dependencies on second template"
+    );
+    expect(tmpls[2].dependencies.length).toBe(
+      1,
+      "should add entries to dependencies on third template"
+    );
+  });
+});
+
+const defaultModel = {
+  item: {
+    type: "Solution",
+    typeKeywords: ["Solution", "Template"],
+    properties: {
+      schemaVersion: 2.6
+    }
+  },
+  data: {
+    metadata: {},
+    templates: [
+      {
+        item: {}
+      },
+      {
+        item: {},
+        itemId: "two"
+      },
+      {
+        item: {},
+        itemId: "three",
+        dependencies: []
+      }
+    ] as IItemTemplate[]
+  }
+} as ISolutionItem;

--- a/packages/common/test/migrator.test.ts
+++ b/packages/common/test/migrator.test.ts
@@ -25,6 +25,7 @@ import * as twoDotThree from "../src/migrations/upgrade-two-dot-three";
 import * as twoDotFour from "../src/migrations/upgrade-two-dot-four";
 import * as twoDotFive from "../src/migrations/upgrade-two-dot-five";
 import * as twoDotSix from "../src/migrations/upgrade-two-dot-six";
+import * as twoDotSeven from "../src/migrations/upgrade-two-dot-seven";
 import * as threeDotZero from "../src/migrations/upgrade-three-dot-zero";
 import * as threeDotOne from "../src/migrations/upgrade-three-dot-one";
 import * as utils from "../../common/test/mocks/utils";
@@ -102,6 +103,11 @@ describe("Schema Migrator", () => {
     const sp5 = spyOn(twoDotSix, "_upgradeTwoDotSix").and.callFake(model => {
       return cloneObject(model);
     });
+    const sp6 = spyOn(twoDotSeven, "_upgradeTwoDotSeven").and.callFake(
+      model => {
+        return cloneObject(model);
+      }
+    );
     const threeZeroUpgradeSpy = spyOn(
       threeDotZero,
       "_upgradeThreeDotZero"
@@ -124,6 +130,7 @@ describe("Schema Migrator", () => {
         expect(sp3.calls.count()).toBe(1, "should call third upgrade");
         expect(sp4.calls.count()).toBe(1, "should call fourth upgrade");
         expect(sp5.calls.count()).toBe(1, "should call fifth upgrade");
+        expect(sp6.calls.count()).toBe(1, "should call sixth upgrade");
         expect(threeZeroUpgradeSpy.calls.count()).toBe(
           1,
           "should call 3.0 upgrade"


### PR DESCRIPTION
We ran into some issues w/ very old Hub templates, and needed to add another 2.x migration to address the problem.