### PR TITLE
Modified item handling to support Angular

### DIFF
--- a/packages/hub-types/src/hub-page-processor.ts
+++ b/packages/hub-types/src/hub-page-processor.ts
@@ -119,14 +119,11 @@ export function createItemFromTemplate(
     delete template.assets;
   }
 
-  // convert the templateDictionary to a settings hash
-  const settings = cloneObject(templateDictionary);
-
   // solutionItemExtent is in geographic, but it's a string, and we want/need a bbox
   // and Hub templates expect it in organization.defaultExtentBBox
-  if (settings.solutionItemExtent) {
-    const parts = settings.solutionItemExtent.split(",");
-    settings.organization.defaultExtentBBox = [
+  if (templateDictionary.solutionItemExtent) {
+    const parts = templateDictionary.solutionItemExtent.split(",");
+    templateDictionary.organization.defaultExtentBBox = [
       [parts[0], parts[1]],
       [parts[2], parts[3]]
     ];
@@ -143,7 +140,12 @@ export function createItemFromTemplate(
   return createHubRequestOptions(destinationAuthentication, templateDictionary)
     .then(ro => {
       hubRo = ro;
-      return createPageModelFromTemplate(template, settings, transforms, hubRo);
+      return createPageModelFromTemplate(
+        template,
+        templateDictionary,
+        transforms,
+        hubRo
+      );
     })
     .then((interpolated: unknown) => {
       // --------------------------------------------

--- a/packages/hub-types/src/hub-site-processor.ts
+++ b/packages/hub-types/src/hub-site-processor.ts
@@ -81,15 +81,12 @@ export function createItemFromTemplate(
     delete template.assets;
   }
 
-  // convert the templateDictionary to a settings hash
-  const settings = cloneObject(templateDictionary);
-
-  // ensure we have a solution object in the settings hash
-  if (!settings.solution) {
-    settings.solution = {};
+  // ensure we have a solution object in the templateDictionary hash
+  if (!templateDictionary.solution) {
+    templateDictionary.solution = {};
   }
   // .title should always be set on the templateDictionary
-  settings.solution.title = templateDictionary.title;
+  templateDictionary.solution.title = templateDictionary.title;
 
   // TODO: Determine if we need any transforms in this new env
   const transforms = {};
@@ -105,7 +102,12 @@ export function createItemFromTemplate(
   return createHubRequestOptions(destinationAuthentication, templateDictionary)
     .then(ro => {
       hubRo = ro;
-      return createSiteModelFromTemplate(template, settings, transforms, hubRo);
+      return createSiteModelFromTemplate(
+        template,
+        templateDictionary,
+        transforms,
+        hubRo
+      );
     })
     .then(interpolated => {
       const options = {

--- a/packages/storymap/src/storymap-processor.ts
+++ b/packages/storymap/src/storymap-processor.ts
@@ -89,15 +89,12 @@ export function createItemFromTemplate(
     return Promise.resolve(generateEmptyCreationResponse(template.type));
   }
 
-  // convert the templateDictionary to a settings hash
-  const settings = cloneObject(templateDictionary);
-
-  // ensure we have a solution object in the settings hash
-  if (!settings.solution) {
-    settings.solution = {};
+  // ensure we have a solution object in the templateDictionary hash
+  if (!templateDictionary.solution) {
+    templateDictionary.solution = {};
   }
   // .title should always be set on the templateDictionary
-  settings.solution.title = templateDictionary.title;
+  templateDictionary.solution.title = templateDictionary.title;
 
   // TODO: Determine if we need any transforms in this new env
   const transforms = {};
@@ -111,7 +108,7 @@ export function createItemFromTemplate(
   // and initiative item.
   return createStoryMapModelFromTemplate(
     template,
-    settings,
+    templateDictionary,
     transforms,
     destinationAuthentication
   )

--- a/packages/web-experience/src/web-experience-processor.ts
+++ b/packages/web-experience/src/web-experience-processor.ts
@@ -87,13 +87,10 @@ export function createItemFromTemplate(
     return Promise.resolve(generateEmptyCreationResponse(template.type));
   }
 
-  // convert the templateDictionary to a settings hash
-  const settings = cloneObject(templateDictionary);
-
   let exbModel: IModel;
   return createWebExperienceModelFromTemplate(
     template,
-    settings,
+    templateDictionary,
     {},
     destinationAuthentication
   )


### PR DESCRIPTION
The deployment code for four item types--Web Experience, Hub Site Application, Hub Page, and StoryMap--isolated the routines from side effects to make the routines more robust and testable.

This turns out to be a problem when embedding the code into Angular, which has its own definition for a Promise--a definition that contains circular references and thus breaks during certain JavaScript options.

This PR changes the four item types to allow side effects. Not an enhancement, but it does permit Angular to host solution.js.

#598