### PR TITLE
Patch thumbnails for deployed hub items

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Some useful commands include:
   * `npm run test:chrome` runs karma in the Chrome browser
   * `npm run test:chrome:ci` runs karma in the ChromeHeadlessCI browser
   * `npm run test:chrome:debug` runs karma in the Chrome browser and leaves the browser open for debugging tests
+  * `npm run test:edge` runs karma in the Edge (Chromium) browser
   * `npm run test:firefox` runs karma in the Firefox browser
   * `npm run test:ci` lints, then runs `test:chrome:ci`, `test:firefox`, and `coveralls` from a bash window
   * `npm run test:ci:win` lints, then runs `test:chrome:ci`, `test:firefox`, and `coveralls:win` from a Windows window

--- a/packages/hub-types/src/hub-page-processor.ts
+++ b/packages/hub-types/src/hub-page-processor.ts
@@ -28,6 +28,7 @@ import {
   UserSession,
   generateEmptyCreationResponse
 } from "@esri/solution-common";
+import { IUpdateItemOptions, updateItem } from "@esri/arcgis-rest-portal";
 import { createHubRequestOptions } from "./helpers/create-hub-request-options";
 import {
   IModel,
@@ -136,6 +137,7 @@ export function createItemFromTemplate(
   let pageModel: IModel;
 
   let hubRo: IHubRequestOptions;
+  const thumbnail: File = template.item.thumbnail; // createPageModelFromTemplate trashes thumbnail
   return createHubRequestOptions(destinationAuthentication, templateDictionary)
     .then(ro => {
       hubRo = ro;
@@ -167,6 +169,20 @@ export function createItemFromTemplate(
         templateDictionary.folderId,
         destinationAuthentication
       );
+    })
+    .then(() => {
+      // Fix the thumbnail
+      const updateOptions: IUpdateItemOptions = {
+        item: {
+          id: pageModel.item.id
+        },
+        params: {
+          // Pass thumbnail in via params because item property is serialized, which discards a blob
+          thumbnail
+        },
+        authentication: destinationAuthentication
+      };
+      return updateItem(updateOptions);
     })
     .then(() => {
       // Update the template dictionary

--- a/packages/hub-types/src/hub-site-processor.ts
+++ b/packages/hub-types/src/hub-site-processor.ts
@@ -29,6 +29,7 @@ import {
   generateEmptyCreationResponse,
   getProp
 } from "@esri/solution-common";
+import { IUpdateItemOptions, updateItem } from "@esri/arcgis-rest-portal";
 import {
   createSiteModelFromTemplate,
   createSite,
@@ -98,6 +99,7 @@ export function createItemFromTemplate(
   // Note: depending on licensing and user privs, will also create the team groups
   // and initiative item.
   let hubRo: IHubRequestOptions;
+  const thumbnail: File = template.item.thumbnail; // createSiteModelFromTemplate trashes thumbnail
   return createHubRequestOptions(destinationAuthentication, templateDictionary)
     .then(ro => {
       hubRo = ro;
@@ -126,6 +128,20 @@ export function createItemFromTemplate(
         templateDictionary.folderId,
         destinationAuthentication
       );
+    })
+    .then(() => {
+      // Fix the thumbnail
+      const updateOptions: IUpdateItemOptions = {
+        item: {
+          id: siteModel.item.id
+        },
+        params: {
+          // Pass thumbnail in via params because item property is serialized, which discards a blob
+          thumbnail
+        },
+        authentication: destinationAuthentication
+      };
+      return updateItem(updateOptions);
     })
     .then(() => {
       // Update the template dictionary

--- a/packages/hub-types/test/hub-page-processor.test.ts
+++ b/packages/hub-types/test/hub-page-processor.test.ts
@@ -15,6 +15,7 @@
  */
 import * as utils from "../../common/test/mocks/utils";
 import * as sitesPackage from "@esri/hub-sites";
+import * as portalPackage from "@esri/arcgis-rest-portal";
 import * as moveHelper from "../src/helpers/move-model-to-folder";
 const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
 
@@ -166,6 +167,10 @@ describe("HubPageProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const td = {
         organization: {
@@ -211,6 +216,10 @@ describe("HubPageProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const td = {
         organization: {
@@ -304,6 +313,10 @@ describe("HubPageProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
       const removePageSpy = spyOn(sitesPackage, "removePage").and.resolveTo({
         success: true,
         itemId: "FAKE3ef"

--- a/packages/hub-types/test/hub-site-processor.test.ts
+++ b/packages/hub-types/test/hub-site-processor.test.ts
@@ -14,6 +14,7 @@
  */
 import * as utils from "@esri/solution-common/test/mocks/utils";
 import * as sitesPackage from "@esri/hub-sites";
+import * as portalPackage from "@esri/arcgis-rest-portal";
 import * as moveHelper from "../src/helpers/move-model-to-folder";
 const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
 
@@ -169,6 +170,10 @@ describe("HubSiteProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const td = {
         organization: {
@@ -215,6 +220,10 @@ describe("HubSiteProcessor: ", () => {
       const moveSiteSpy = spyOn(moveHelper, "moveModelToFolder").and.resolveTo([
         tmplThmb.itemId
       ]);
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const td = {
         organization: {
@@ -263,6 +272,10 @@ describe("HubSiteProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const td = {
         organization: {
@@ -306,6 +319,10 @@ describe("HubSiteProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const td = {
         organization: {
@@ -397,6 +414,10 @@ describe("HubSiteProcessor: ", () => {
         moveHelper,
         "moveModelToFolder"
       ).and.resolveTo();
+      const thumbnailSpy = spyOn(portalPackage, "updateItem").and.resolveTo({
+        success: true,
+        id: "fred"
+      });
 
       const removeSiteSpy = spyOn(sitesPackage, "removeSite").and.resolveTo({
         success: true


### PR DESCRIPTION
A continuation of #604, #605, and #607 for hub pages and hub sites, which do not support supplying a thumbnail file during item creation.