### PR TITLE
Fetch user when creating IHubRequestOptions

### DIFF
--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -95,16 +95,13 @@
         "tslib": "^1.13.0"
       }
     },
-<<<<<<< HEAD
     "@esri/solution-common": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.22.5.tgz",
-      "integrity": "sha512-ufu+EUWo5AbT/vkVf8y+Kb36yIMiayw2waR15/ZJMWeStmB+kQwsiyadRmdbWbyby3FhGkaK6bCX7CfKYwa+BQ==",
+      "version": "0.22.6",
       "requires": {
         "@esri/arcgis-html-sanitizer": "~2.1.0",
         "@types/lodash.isplainobject": "^4.0.6",
         "adlib": "3.0.7",
-        "jszip": "3.4.0",
+        "jszip": "3.6.0",
         "lodash.isplainobject": "^4.0.6",
         "tslib": "^1.13.0",
         "xss": "^1.0.6"
@@ -118,139 +115,7960 @@
             "lodash.isplainobject": "^4.0.6",
             "xss": "^1.0.6"
           }
+        },
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@types/adlib": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+          "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/lodash": {
+          "version": "4.14.168",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+          "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+        },
+        "@types/lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+          "requires": {
+            "@types/lodash": "*"
+          }
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cssfilter": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+          "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "immediate": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "jszip": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+          "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+          "requires": {
+            "lie": "~3.3.0",
+            "pako": "~1.0.2",
+            "readable-stream": "~2.3.6",
+            "set-immediate-shim": "~1.0.1"
+          }
+        },
+        "lie": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+          "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+          "requires": {
+            "immediate": "~3.0.5"
+          }
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+          "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "xss": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+          "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+          "requires": {
+            "commander": "^2.20.3",
+            "cssfilter": "0.0.10"
+          }
         }
       }
     },
     "@esri/solution-creator": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-creator/-/solution-creator-0.22.5.tgz",
-      "integrity": "sha512-I0DkifnZ87xof5KT0PsmYvJ6UJ7LPjBHc9UbMwFxJm3lyTQz/vSjZJHQ7Q4ffh+O3UFETgYaboK9CqhKFVM1Lg==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
-        "@esri/solution-feature-layer": "^0.22.5",
-        "@esri/solution-file": "^0.22.5",
-        "@esri/solution-form": "^0.22.5",
-        "@esri/solution-group": "^0.22.5",
-        "@esri/solution-hub-types": "^0.22.5",
-        "@esri/solution-simple-types": "^0.22.5",
-        "@esri/solution-storymap": "^0.22.5",
-        "@esri/solution-web-experience": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
+        "@esri/solution-feature-layer": "^0.22.6",
+        "@esri/solution-file": "^0.22.6",
+        "@esri/solution-form": "^0.22.6",
+        "@esri/solution-group": "^0.22.6",
+        "@esri/solution-hub-types": "^0.22.6",
+        "@esri/solution-simple-types": "^0.22.6",
+        "@esri/solution-storymap": "^0.22.6",
+        "@esri/solution-web-experience": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {
+            "@esri/arcgis-html-sanitizer": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+              "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+              "requires": {
+                "lodash.isplainobject": "^4.0.6",
+                "xss": "^1.0.6"
+              }
+            },
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@types/adlib": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+              "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/lodash": {
+              "version": "4.14.168",
+              "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+              "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+            },
+            "@types/lodash.isplainobject": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+              "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+              "requires": {
+                "@types/lodash": "*"
+              }
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            },
+            "cssfilter": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+              "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "immediate": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+              "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            },
+            "jszip": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+              "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+              "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
+              }
+            },
+            "lie": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+              "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+              "requires": {
+                "immediate": "~3.0.5"
+              }
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+              "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+            },
+            "pako": {
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+              "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+              "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            },
+            "xss": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+              "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+              "requires": {
+                "commander": "^2.20.3",
+                "cssfilter": "0.0.10"
+              }
+            }
+          }
+        },
+        "@esri/solution-feature-layer": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {
+                "@esri/arcgis-html-sanitizer": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                  "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                  "requires": {
+                    "lodash.isplainobject": "^4.0.6",
+                    "xss": "^1.0.6"
+                  }
+                },
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@types/adlib": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                  "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/lodash": {
+                  "version": "4.14.168",
+                  "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                  "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                },
+                "@types/lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                  "requires": {
+                    "@types/lodash": "*"
+                  }
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "cssfilter": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                  "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "immediate": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                  "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                },
+                "inherits": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                  "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "jszip": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                  "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                  "requires": {
+                    "lie": "~3.3.0",
+                    "pako": "~1.0.2",
+                    "readable-stream": "~2.3.6",
+                    "set-immediate-shim": "~1.0.1"
+                  }
+                },
+                "lie": {
+                  "version": "3.3.0",
+                  "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                  "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                  "requires": {
+                    "immediate": "~3.0.5"
+                  }
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                },
+                "pako": {
+                  "version": "1.0.11",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                  "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                },
+                "process-nextick-args": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                  "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "xss": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                  "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                  "requires": {
+                    "commander": "^2.20.3",
+                    "cssfilter": "0.0.10"
+                  }
+                }
+              }
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-file": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {
+                "@esri/arcgis-html-sanitizer": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                  "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                  "requires": {
+                    "lodash.isplainobject": "^4.0.6",
+                    "xss": "^1.0.6"
+                  }
+                },
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@types/adlib": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                  "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/lodash": {
+                  "version": "4.14.168",
+                  "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                  "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                },
+                "@types/lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                  "requires": {
+                    "@types/lodash": "*"
+                  }
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "cssfilter": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                  "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "immediate": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                  "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                },
+                "inherits": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                  "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "jszip": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                  "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                  "requires": {
+                    "lie": "~3.3.0",
+                    "pako": "~1.0.2",
+                    "readable-stream": "~2.3.6",
+                    "set-immediate-shim": "~1.0.1"
+                  }
+                },
+                "lie": {
+                  "version": "3.3.0",
+                  "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                  "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                  "requires": {
+                    "immediate": "~3.0.5"
+                  }
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                },
+                "pako": {
+                  "version": "1.0.11",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                  "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                },
+                "process-nextick-args": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                  "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "xss": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                  "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                  "requires": {
+                    "commander": "^2.20.3",
+                    "cssfilter": "0.0.10"
+                  }
+                }
+              }
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-form": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-feature-layer": "^0.22.6",
+            "@esri/solution-file": "^0.22.6",
+            "@esri/solution-group": "^0.22.6",
+            "@esri/solution-simple-types": "^0.22.6",
+            "@esri/solution-storymap": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {
+                "@esri/arcgis-html-sanitizer": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                  "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                  "requires": {
+                    "lodash.isplainobject": "^4.0.6",
+                    "xss": "^1.0.6"
+                  }
+                },
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@types/adlib": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                  "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/lodash": {
+                  "version": "4.14.168",
+                  "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                  "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                },
+                "@types/lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                  "requires": {
+                    "@types/lodash": "*"
+                  }
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "cssfilter": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                  "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "immediate": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                  "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                },
+                "inherits": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                  "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "jszip": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                  "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                  "requires": {
+                    "lie": "~3.3.0",
+                    "pako": "~1.0.2",
+                    "readable-stream": "~2.3.6",
+                    "set-immediate-shim": "~1.0.1"
+                  }
+                },
+                "lie": {
+                  "version": "3.3.0",
+                  "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                  "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                  "requires": {
+                    "immediate": "~3.0.5"
+                  }
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                },
+                "pako": {
+                  "version": "1.0.11",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                  "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                },
+                "process-nextick-args": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                  "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "xss": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                  "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                  "requires": {
+                    "commander": "^2.20.3",
+                    "cssfilter": "0.0.10"
+                  }
+                }
+              }
+            },
+            "@esri/solution-feature-layer": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-initiatives": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+                  "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-sites": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+                  "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-teams": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                  "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/solution-common": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/arcgis-html-sanitizer": "~2.1.0",
+                    "@types/lodash.isplainobject": "^4.0.6",
+                    "adlib": "3.0.7",
+                    "jszip": "3.6.0",
+                    "lodash.isplainobject": "^4.0.6",
+                    "tslib": "^1.13.0",
+                    "xss": "^1.0.6"
+                  },
+                  "dependencies": {}
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                }
+              }
+            },
+            "@esri/solution-file": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-initiatives": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+                  "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-sites": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+                  "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-teams": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                  "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/solution-common": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/arcgis-html-sanitizer": "~2.1.0",
+                    "@types/lodash.isplainobject": "^4.0.6",
+                    "adlib": "3.0.7",
+                    "jszip": "3.6.0",
+                    "lodash.isplainobject": "^4.0.6",
+                    "tslib": "^1.13.0",
+                    "xss": "^1.0.6"
+                  },
+                  "dependencies": {}
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                }
+              }
+            },
+            "@esri/solution-group": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-initiatives": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+                  "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-sites": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+                  "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-teams": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                  "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/solution-common": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/arcgis-html-sanitizer": "~2.1.0",
+                    "@types/lodash.isplainobject": "^4.0.6",
+                    "adlib": "3.0.7",
+                    "jszip": "3.6.0",
+                    "lodash.isplainobject": "^4.0.6",
+                    "tslib": "^1.13.0",
+                    "xss": "^1.0.6"
+                  },
+                  "dependencies": {
+                    "@esri/arcgis-html-sanitizer": {
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                      "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                      "requires": {
+                        "lodash.isplainobject": "^4.0.6",
+                        "xss": "^1.0.6"
+                      }
+                    },
+                    "@esri/arcgis-rest-auth": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                      "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-feature-layer": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                      "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-portal": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                      "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-request": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                      "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                      "requires": {
+                        "tslib": "^1.10.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-service-admin": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                      "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-types": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                      "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                    },
+                    "@esri/hub-common": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                      "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                      "requires": {
+                        "adlib": "^3.0.7",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@types/adlib": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                      "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                    },
+                    "@types/estree": {
+                      "version": "0.0.46",
+                      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                    },
+                    "@types/lodash": {
+                      "version": "4.14.168",
+                      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                    },
+                    "@types/lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                      "requires": {
+                        "@types/lodash": "*"
+                      }
+                    },
+                    "@types/node": {
+                      "version": "14.14.31",
+                      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                    },
+                    "acorn": {
+                      "version": "7.4.1",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                    },
+                    "adlib": {
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                      "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                      "requires": {
+                        "esm": "^3.2.25"
+                      }
+                    },
+                    "commander": {
+                      "version": "2.20.3",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                    },
+                    "cssfilter": {
+                      "version": "0.0.10",
+                      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                    },
+                    "esm": {
+                      "version": "3.2.25",
+                      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                    },
+                    "immediate": {
+                      "version": "3.0.6",
+                      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                    },
+                    "inherits": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    },
+                    "jszip": {
+                      "version": "3.6.0",
+                      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                      "requires": {
+                        "lie": "~3.3.0",
+                        "pako": "~1.0.2",
+                        "readable-stream": "~2.3.6",
+                        "set-immediate-shim": "~1.0.1"
+                      }
+                    },
+                    "lie": {
+                      "version": "3.3.0",
+                      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                      "requires": {
+                        "immediate": "~3.0.5"
+                      }
+                    },
+                    "lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                    },
+                    "pako": {
+                      "version": "1.0.11",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                    },
+                    "process-nextick-args": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                    },
+                    "readable-stream": {
+                      "version": "2.3.7",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                      "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                      }
+                    },
+                    "rollup": {
+                      "version": "1.32.1",
+                      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                      "requires": {
+                        "@types/estree": "*",
+                        "@types/node": "*",
+                        "acorn": "^7.1.0"
+                      }
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                    },
+                    "string_decoder": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                      "requires": {
+                        "safe-buffer": "~5.1.0"
+                      }
+                    },
+                    "tslib": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    },
+                    "typescript": {
+                      "version": "4.1.5",
+                      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                    },
+                    "xss": {
+                      "version": "1.0.8",
+                      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                      "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                      "requires": {
+                        "commander": "^2.20.3",
+                        "cssfilter": "0.0.10"
+                      }
+                    }
+                  }
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                }
+              }
+            },
+            "@esri/solution-simple-types": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "@esri/solution-feature-layer": "^0.22.6",
+                "@esri/solution-file": "^0.22.6",
+                "@esri/solution-group": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-teams": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                  "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/solution-common": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/arcgis-html-sanitizer": "~2.1.0",
+                    "@types/lodash.isplainobject": "^4.0.6",
+                    "adlib": "3.0.7",
+                    "jszip": "3.6.0",
+                    "lodash.isplainobject": "^4.0.6",
+                    "tslib": "^1.13.0",
+                    "xss": "^1.0.6"
+                  },
+                  "dependencies": {
+                    "@esri/arcgis-html-sanitizer": {
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                      "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                      "requires": {
+                        "lodash.isplainobject": "^4.0.6",
+                        "xss": "^1.0.6"
+                      }
+                    },
+                    "@esri/arcgis-rest-auth": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                      "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-feature-layer": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                      "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-portal": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                      "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-request": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                      "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                      "requires": {
+                        "tslib": "^1.10.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-service-admin": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                      "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-types": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                      "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                    },
+                    "@esri/hub-common": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                      "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                      "requires": {
+                        "adlib": "^3.0.7",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@types/adlib": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                      "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                    },
+                    "@types/estree": {
+                      "version": "0.0.46",
+                      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                    },
+                    "@types/lodash": {
+                      "version": "4.14.168",
+                      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                    },
+                    "@types/lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                      "requires": {
+                        "@types/lodash": "*"
+                      }
+                    },
+                    "@types/node": {
+                      "version": "14.14.31",
+                      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                    },
+                    "acorn": {
+                      "version": "7.4.1",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                    },
+                    "adlib": {
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                      "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                      "requires": {
+                        "esm": "^3.2.25"
+                      }
+                    },
+                    "commander": {
+                      "version": "2.20.3",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                    },
+                    "cssfilter": {
+                      "version": "0.0.10",
+                      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                    },
+                    "esm": {
+                      "version": "3.2.25",
+                      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                    },
+                    "immediate": {
+                      "version": "3.0.6",
+                      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                    },
+                    "inherits": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    },
+                    "jszip": {
+                      "version": "3.6.0",
+                      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                      "requires": {
+                        "lie": "~3.3.0",
+                        "pako": "~1.0.2",
+                        "readable-stream": "~2.3.6",
+                        "set-immediate-shim": "~1.0.1"
+                      }
+                    },
+                    "lie": {
+                      "version": "3.3.0",
+                      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                      "requires": {
+                        "immediate": "~3.0.5"
+                      }
+                    },
+                    "lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                    },
+                    "pako": {
+                      "version": "1.0.11",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                    },
+                    "process-nextick-args": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                    },
+                    "readable-stream": {
+                      "version": "2.3.7",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                      "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                      }
+                    },
+                    "rollup": {
+                      "version": "1.32.1",
+                      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                      "requires": {
+                        "@types/estree": "*",
+                        "@types/node": "*",
+                        "acorn": "^7.1.0"
+                      }
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                    },
+                    "string_decoder": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                      "requires": {
+                        "safe-buffer": "~5.1.0"
+                      }
+                    },
+                    "tslib": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    },
+                    "typescript": {
+                      "version": "4.1.5",
+                      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                    },
+                    "xss": {
+                      "version": "1.0.8",
+                      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                      "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                      "requires": {
+                        "commander": "^2.20.3",
+                        "cssfilter": "0.0.10"
+                      }
+                    }
+                  }
+                },
+                "@esri/solution-feature-layer": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/solution-common": "^0.22.6",
+                    "tslib": "^1.13.0"
+                  },
+                  "dependencies": {
+                    "@esri/arcgis-rest-auth": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                      "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-feature-layer": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                      "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-portal": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                      "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-request": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                      "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                      "requires": {
+                        "tslib": "^1.10.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-service-admin": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                      "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-types": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                      "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                    },
+                    "@esri/hub-common": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                      "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                      "requires": {
+                        "adlib": "^3.0.7",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-initiatives": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+                      "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-sites": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+                      "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-teams": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                      "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/solution-common": {
+                      "version": "0.22.6",
+                      "requires": {
+                        "@esri/arcgis-html-sanitizer": "~2.1.0",
+                        "@types/lodash.isplainobject": "^4.0.6",
+                        "adlib": "3.0.7",
+                        "jszip": "3.6.0",
+                        "lodash.isplainobject": "^4.0.6",
+                        "tslib": "^1.13.0",
+                        "xss": "^1.0.6"
+                      },
+                      "dependencies": {}
+                    },
+                    "@types/estree": {
+                      "version": "0.0.46",
+                      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                    },
+                    "@types/node": {
+                      "version": "14.14.31",
+                      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                    },
+                    "acorn": {
+                      "version": "7.4.1",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                    },
+                    "adlib": {
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                      "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                      "requires": {
+                        "esm": "^3.2.25"
+                      }
+                    },
+                    "esm": {
+                      "version": "3.2.25",
+                      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                    },
+                    "rollup": {
+                      "version": "1.32.1",
+                      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                      "requires": {
+                        "@types/estree": "*",
+                        "@types/node": "*",
+                        "acorn": "^7.1.0"
+                      }
+                    },
+                    "tslib": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    },
+                    "typescript": {
+                      "version": "4.1.5",
+                      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                    }
+                  }
+                },
+                "@esri/solution-file": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/solution-common": "^0.22.6",
+                    "tslib": "^1.13.0"
+                  },
+                  "dependencies": {
+                    "@esri/arcgis-rest-auth": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                      "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-feature-layer": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                      "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-portal": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                      "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-request": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                      "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                      "requires": {
+                        "tslib": "^1.10.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-service-admin": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                      "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-types": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                      "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                    },
+                    "@esri/hub-common": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                      "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                      "requires": {
+                        "adlib": "^3.0.7",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-initiatives": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+                      "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-sites": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+                      "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-teams": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                      "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/solution-common": {
+                      "version": "0.22.6",
+                      "requires": {
+                        "@esri/arcgis-html-sanitizer": "~2.1.0",
+                        "@types/lodash.isplainobject": "^4.0.6",
+                        "adlib": "3.0.7",
+                        "jszip": "3.6.0",
+                        "lodash.isplainobject": "^4.0.6",
+                        "tslib": "^1.13.0",
+                        "xss": "^1.0.6"
+                      },
+                      "dependencies": {}
+                    },
+                    "@types/estree": {
+                      "version": "0.0.46",
+                      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                    },
+                    "@types/node": {
+                      "version": "14.14.31",
+                      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                    },
+                    "acorn": {
+                      "version": "7.4.1",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                    },
+                    "adlib": {
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                      "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                      "requires": {
+                        "esm": "^3.2.25"
+                      }
+                    },
+                    "esm": {
+                      "version": "3.2.25",
+                      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                    },
+                    "rollup": {
+                      "version": "1.32.1",
+                      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                      "requires": {
+                        "@types/estree": "*",
+                        "@types/node": "*",
+                        "acorn": "^7.1.0"
+                      }
+                    },
+                    "tslib": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    },
+                    "typescript": {
+                      "version": "4.1.5",
+                      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                    }
+                  }
+                },
+                "@esri/solution-group": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/solution-common": "^0.22.6",
+                    "tslib": "^1.13.0"
+                  },
+                  "dependencies": {
+                    "@esri/arcgis-rest-auth": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                      "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-feature-layer": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                      "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-portal": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                      "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-request": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                      "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                      "requires": {
+                        "tslib": "^1.10.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-service-admin": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                      "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-types": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                      "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                    },
+                    "@esri/hub-common": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                      "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                      "requires": {
+                        "adlib": "^3.0.7",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-initiatives": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+                      "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-sites": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+                      "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/hub-teams": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                      "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                      "requires": {
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/solution-common": {
+                      "version": "0.22.6",
+                      "requires": {
+                        "@esri/arcgis-html-sanitizer": "~2.1.0",
+                        "@types/lodash.isplainobject": "^4.0.6",
+                        "adlib": "3.0.7",
+                        "jszip": "3.6.0",
+                        "lodash.isplainobject": "^4.0.6",
+                        "tslib": "^1.13.0",
+                        "xss": "^1.0.6"
+                      },
+                      "dependencies": {}
+                    },
+                    "@types/estree": {
+                      "version": "0.0.46",
+                      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                    },
+                    "@types/node": {
+                      "version": "14.14.31",
+                      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                    },
+                    "acorn": {
+                      "version": "7.4.1",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                    },
+                    "adlib": {
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                      "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                      "requires": {
+                        "esm": "^3.2.25"
+                      }
+                    },
+                    "esm": {
+                      "version": "3.2.25",
+                      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                    },
+                    "rollup": {
+                      "version": "1.32.1",
+                      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                      "requires": {
+                        "@types/estree": "*",
+                        "@types/node": "*",
+                        "acorn": "^7.1.0"
+                      }
+                    },
+                    "tslib": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    },
+                    "typescript": {
+                      "version": "4.1.5",
+                      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                    }
+                  }
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                }
+              }
+            },
+            "@esri/solution-storymap": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/solution-common": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/arcgis-html-sanitizer": "~2.1.0",
+                    "@types/lodash.isplainobject": "^4.0.6",
+                    "adlib": "3.0.7",
+                    "jszip": "3.6.0",
+                    "lodash.isplainobject": "^4.0.6",
+                    "tslib": "^1.13.0",
+                    "xss": "^1.0.6"
+                  },
+                  "dependencies": {
+                    "@esri/arcgis-html-sanitizer": {
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                      "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                      "requires": {
+                        "lodash.isplainobject": "^4.0.6",
+                        "xss": "^1.0.6"
+                      }
+                    },
+                    "@esri/arcgis-rest-auth": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                      "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-feature-layer": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                      "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-portal": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                      "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-request": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                      "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                      "requires": {
+                        "tslib": "^1.10.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-service-admin": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                      "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                      "requires": {
+                        "@esri/arcgis-rest-types": "^3.0.3",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@esri/arcgis-rest-types": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                      "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                    },
+                    "@esri/hub-common": {
+                      "version": "7.3.0",
+                      "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                      "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                      "requires": {
+                        "adlib": "^3.0.7",
+                        "tslib": "^1.13.0"
+                      }
+                    },
+                    "@types/adlib": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                      "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                    },
+                    "@types/estree": {
+                      "version": "0.0.46",
+                      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                    },
+                    "@types/lodash": {
+                      "version": "4.14.168",
+                      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                    },
+                    "@types/lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                      "requires": {
+                        "@types/lodash": "*"
+                      }
+                    },
+                    "@types/node": {
+                      "version": "14.14.31",
+                      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                    },
+                    "acorn": {
+                      "version": "7.4.1",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                    },
+                    "adlib": {
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                      "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                      "requires": {
+                        "esm": "^3.2.25"
+                      }
+                    },
+                    "commander": {
+                      "version": "2.20.3",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                    },
+                    "cssfilter": {
+                      "version": "0.0.10",
+                      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                    },
+                    "esm": {
+                      "version": "3.2.25",
+                      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                    },
+                    "immediate": {
+                      "version": "3.0.6",
+                      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                    },
+                    "inherits": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    },
+                    "jszip": {
+                      "version": "3.6.0",
+                      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                      "requires": {
+                        "lie": "~3.3.0",
+                        "pako": "~1.0.2",
+                        "readable-stream": "~2.3.6",
+                        "set-immediate-shim": "~1.0.1"
+                      }
+                    },
+                    "lie": {
+                      "version": "3.3.0",
+                      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                      "requires": {
+                        "immediate": "~3.0.5"
+                      }
+                    },
+                    "lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                    },
+                    "pako": {
+                      "version": "1.0.11",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                    },
+                    "process-nextick-args": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                    },
+                    "readable-stream": {
+                      "version": "2.3.7",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                      "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                      }
+                    },
+                    "rollup": {
+                      "version": "1.32.1",
+                      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                      "requires": {
+                        "@types/estree": "*",
+                        "@types/node": "*",
+                        "acorn": "^7.1.0"
+                      }
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.2",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                    },
+                    "string_decoder": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                      "requires": {
+                        "safe-buffer": "~5.1.0"
+                      }
+                    },
+                    "tslib": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    },
+                    "typescript": {
+                      "version": "4.1.5",
+                      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                    },
+                    "xss": {
+                      "version": "1.0.8",
+                      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                      "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                      "requires": {
+                        "commander": "^2.20.3",
+                        "cssfilter": "0.0.10"
+                      }
+                    }
+                  }
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                }
+              }
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-group": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-hub-types": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {
+                "@esri/arcgis-html-sanitizer": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                  "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                  "requires": {
+                    "lodash.isplainobject": "^4.0.6",
+                    "xss": "^1.0.6"
+                  }
+                },
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@types/adlib": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                  "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/lodash": {
+                  "version": "4.14.168",
+                  "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                  "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                },
+                "@types/lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                  "requires": {
+                    "@types/lodash": "*"
+                  }
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "cssfilter": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                  "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "immediate": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                  "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                },
+                "inherits": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                  "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "jszip": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                  "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                  "requires": {
+                    "lie": "~3.3.0",
+                    "pako": "~1.0.2",
+                    "readable-stream": "~2.3.6",
+                    "set-immediate-shim": "~1.0.1"
+                  }
+                },
+                "lie": {
+                  "version": "3.3.0",
+                  "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                  "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                  "requires": {
+                    "immediate": "~3.0.5"
+                  }
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                },
+                "pako": {
+                  "version": "1.0.11",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                  "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                },
+                "process-nextick-args": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                  "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "xss": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                  "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                  "requires": {
+                    "commander": "^2.20.3",
+                    "cssfilter": "0.0.10"
+                  }
+                }
+              }
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-simple-types": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-feature-layer": "^0.22.6",
+            "@esri/solution-file": "^0.22.6",
+            "@esri/solution-group": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-feature-layer": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-file": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-group": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-storymap": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-web-experience": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-simple-types": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {
+                "@esri/arcgis-html-sanitizer": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+                  "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+                  "requires": {
+                    "lodash.isplainobject": "^4.0.6",
+                    "xss": "^1.0.6"
+                  }
+                },
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@types/adlib": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+                  "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/lodash": {
+                  "version": "4.14.168",
+                  "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+                  "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+                },
+                "@types/lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+                  "requires": {
+                    "@types/lodash": "*"
+                  }
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "cssfilter": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+                  "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "immediate": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                  "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+                },
+                "inherits": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                  "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "jszip": {
+                  "version": "3.6.0",
+                  "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                  "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                  "requires": {
+                    "lie": "~3.3.0",
+                    "pako": "~1.0.2",
+                    "readable-stream": "~2.3.6",
+                    "set-immediate-shim": "~1.0.1"
+                  }
+                },
+                "lie": {
+                  "version": "3.3.0",
+                  "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+                  "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+                  "requires": {
+                    "immediate": "~3.0.5"
+                  }
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                },
+                "pako": {
+                  "version": "1.0.11",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+                  "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+                },
+                "process-nextick-args": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                  "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "xss": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+                  "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+                  "requires": {
+                    "commander": "^2.20.3",
+                    "cssfilter": "0.0.10"
+                  }
+                }
+              }
+            },
+            "@esri/solution-simple-types": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "@esri/solution-feature-layer": "^0.22.6",
+                "@esri/solution-file": "^0.22.6",
+                "@esri/solution-group": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {
+                "@esri/arcgis-rest-auth": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+                  "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-feature-layer": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+                  "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-portal": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+                  "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-request": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+                  "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+                  "requires": {
+                    "tslib": "^1.10.0"
+                  }
+                },
+                "@esri/arcgis-rest-service-admin": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+                  "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+                  "requires": {
+                    "@esri/arcgis-rest-types": "^3.0.3",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/arcgis-rest-types": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+                  "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+                },
+                "@esri/hub-common": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+                  "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+                  "requires": {
+                    "adlib": "^3.0.7",
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/hub-teams": {
+                  "version": "7.3.0",
+                  "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+                  "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+                  "requires": {
+                    "tslib": "^1.13.0"
+                  }
+                },
+                "@esri/solution-common": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/arcgis-html-sanitizer": "~2.1.0",
+                    "@types/lodash.isplainobject": "^4.0.6",
+                    "adlib": "3.0.7",
+                    "jszip": "3.6.0",
+                    "lodash.isplainobject": "^4.0.6",
+                    "tslib": "^1.13.0",
+                    "xss": "^1.0.6"
+                  },
+                  "dependencies": {}
+                },
+                "@esri/solution-feature-layer": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/solution-common": "^0.22.6",
+                    "tslib": "^1.13.0"
+                  },
+                  "dependencies": {}
+                },
+                "@esri/solution-file": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/solution-common": "^0.22.6",
+                    "tslib": "^1.13.0"
+                  },
+                  "dependencies": {}
+                },
+                "@esri/solution-group": {
+                  "version": "0.22.6",
+                  "requires": {
+                    "@esri/solution-common": "^0.22.6",
+                    "tslib": "^1.13.0"
+                  },
+                  "dependencies": {}
+                },
+                "@types/estree": {
+                  "version": "0.0.46",
+                  "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+                  "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+                },
+                "@types/node": {
+                  "version": "14.14.31",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                  "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                },
+                "acorn": {
+                  "version": "7.4.1",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                  "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+                },
+                "adlib": {
+                  "version": "3.0.7",
+                  "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+                  "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+                  "requires": {
+                    "esm": "^3.2.25"
+                  }
+                },
+                "esm": {
+                  "version": "3.2.25",
+                  "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+                  "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+                },
+                "rollup": {
+                  "version": "1.32.1",
+                  "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+                  "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+                  "requires": {
+                    "@types/estree": "*",
+                    "@types/node": "*",
+                    "acorn": "^7.1.0"
+                  }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "typescript": {
+                  "version": "4.1.5",
+                  "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+                  "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+                }
+              }
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-deployer": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-deployer/-/solution-deployer-0.22.5.tgz",
-      "integrity": "sha512-26TGs5dDmveHL+Yv1DVC0xHCIfG1GRzOJEwG2BmIY85/2H8dP8xyw4RK0b5O0WjNLDHKt9JhkDkO6b/Xmp9piw==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
-        "@esri/solution-feature-layer": "^0.22.5",
-        "@esri/solution-file": "^0.22.5",
-        "@esri/solution-form": "^0.22.5",
-        "@esri/solution-group": "^0.22.5",
-        "@esri/solution-hub-types": "^0.22.5",
-        "@esri/solution-simple-types": "^0.22.5",
-        "@esri/solution-storymap": "^0.22.5",
-        "@esri/solution-web-experience": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
+        "@esri/solution-feature-layer": "^0.22.6",
+        "@esri/solution-file": "^0.22.6",
+        "@esri/solution-form": "^0.22.6",
+        "@esri/solution-group": "^0.22.6",
+        "@esri/solution-hub-types": "^0.22.6",
+        "@esri/solution-simple-types": "^0.22.6",
+        "@esri/solution-storymap": "^0.22.6",
+        "@esri/solution-web-experience": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {
+            "@esri/arcgis-html-sanitizer": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.1.1.tgz",
+              "integrity": "sha512-289SCEEBCNZ5Y2D6KHaNoNjIERXlXGsoEZqppQheS8oNUKnNc8NVGH6rWWqfSjLljDyK6kagERuxFsuCfV3esA==",
+              "requires": {
+                "lodash.isplainobject": "^4.0.6",
+                "xss": "^1.0.6"
+              }
+            },
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@types/adlib": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/@types/adlib/-/adlib-3.0.1.tgz",
+              "integrity": "sha512-7vRDaOFejVMdjzKagD45fK+mFs8pb0h9zmvsGrYsaQY9z+X3xUqf71uNMv8+OiVa8u/w1A7DS29LSUFzOnstRw=="
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/lodash": {
+              "version": "4.14.168",
+              "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+              "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+            },
+            "@types/lodash.isplainobject": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+              "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
+              "requires": {
+                "@types/lodash": "*"
+              }
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            },
+            "cssfilter": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+              "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "immediate": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+              "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            },
+            "jszip": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+              "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+              "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
+              }
+            },
+            "lie": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+              "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+              "requires": {
+                "immediate": "~3.0.5"
+              }
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+              "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+            },
+            "pako": {
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+              "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+              "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            },
+            "xss": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
+              "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+              "requires": {
+                "commander": "^2.20.3",
+                "cssfilter": "0.0.10"
+              }
+            }
+          }
+        },
+        "@esri/solution-feature-layer": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-file": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-form": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-feature-layer": "^0.22.6",
+            "@esri/solution-file": "^0.22.6",
+            "@esri/solution-group": "^0.22.6",
+            "@esri/solution-simple-types": "^0.22.6",
+            "@esri/solution-storymap": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-feature-layer": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-file": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-group": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-simple-types": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "@esri/solution-feature-layer": "^0.22.6",
+                "@esri/solution-file": "^0.22.6",
+                "@esri/solution-group": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-storymap": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-group": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-hub-types": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-sites": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+              "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-simple-types": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-feature-layer": "^0.22.6",
+            "@esri/solution-file": "^0.22.6",
+            "@esri/solution-group": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-teams": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+              "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-feature-layer": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-file": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-group": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-storymap": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@esri/solution-web-experience": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-simple-types": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "@esri/arcgis-rest-auth": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+              "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-feature-layer": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+              "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-portal": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+              "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-request": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+              "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+              "requires": {
+                "tslib": "^1.10.0"
+              }
+            },
+            "@esri/arcgis-rest-service-admin": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+              "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+              "requires": {
+                "@esri/arcgis-rest-types": "^3.0.3",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/arcgis-rest-types": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+              "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+            },
+            "@esri/hub-common": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+              "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+              "requires": {
+                "adlib": "^3.0.7",
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/hub-initiatives": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+              "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+              "requires": {
+                "tslib": "^1.13.0"
+              }
+            },
+            "@esri/solution-common": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/arcgis-html-sanitizer": "~2.1.0",
+                "@types/lodash.isplainobject": "^4.0.6",
+                "adlib": "3.0.7",
+                "jszip": "3.6.0",
+                "lodash.isplainobject": "^4.0.6",
+                "tslib": "^1.13.0",
+                "xss": "^1.0.6"
+              },
+              "dependencies": {}
+            },
+            "@esri/solution-simple-types": {
+              "version": "0.22.6",
+              "requires": {
+                "@esri/solution-common": "^0.22.6",
+                "@esri/solution-feature-layer": "^0.22.6",
+                "@esri/solution-file": "^0.22.6",
+                "@esri/solution-group": "^0.22.6",
+                "tslib": "^1.13.0"
+              },
+              "dependencies": {}
+            },
+            "@types/estree": {
+              "version": "0.0.46",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+              "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+            },
+            "@types/node": {
+              "version": "14.14.31",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+              "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+            },
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "adlib": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+              "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+              "requires": {
+                "esm": "^3.2.25"
+              }
+            },
+            "esm": {
+              "version": "3.2.25",
+              "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+              "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            },
+            "rollup": {
+              "version": "1.32.1",
+              "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+              "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+              "requires": {
+                "@types/estree": "*",
+                "@types/node": "*",
+                "acorn": "^7.1.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            },
+            "typescript": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+              "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+            }
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-feature-layer": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-feature-layer/-/solution-feature-layer-0.22.5.tgz",
-      "integrity": "sha512-p+YenBSMi+QyLVB0YCyYV/7K8G8GT/4M7JAkhaaPVnbEJe6sFod5gWH4BsBqhp8OfITVT/OovoC1HRcOF6lxdg==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-file": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-file/-/solution-file-0.22.5.tgz",
-      "integrity": "sha512-8dB4/+1BFe45A4ERa3LIq/9cnvJW5hd0X5XBxHfhvOqtpyfKN/jORcgMCXzmwietdUs3jYXgL7vfp6iGsY1WKg==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-form": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-form/-/solution-form-0.22.5.tgz",
-      "integrity": "sha512-7fI+uf2pjHRzx0ijPrbO81aLWVN4BvZuvMAK4VZPzo/NWGo1qhX2gk5eCJXMwz0wvL95IoFgSU7I7IQ6QX62mw==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
-        "@esri/solution-feature-layer": "^0.22.5",
-        "@esri/solution-file": "^0.22.5",
-        "@esri/solution-group": "^0.22.5",
-        "@esri/solution-simple-types": "^0.22.5",
-        "@esri/solution-storymap": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
+        "@esri/solution-feature-layer": "^0.22.6",
+        "@esri/solution-file": "^0.22.6",
+        "@esri/solution-group": "^0.22.6",
+        "@esri/solution-simple-types": "^0.22.6",
+        "@esri/solution-storymap": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-feature-layer": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-file": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-group": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-simple-types": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-feature-layer": "^0.22.6",
+            "@esri/solution-file": "^0.22.6",
+            "@esri/solution-group": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-storymap": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-group": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-group/-/solution-group-0.22.5.tgz",
-      "integrity": "sha512-ZJWectDzDY9MASFUCKI4FfmWdbrsCQQ13dOrMa6xqg4a3NBuhBYli+D2UN6g9xtnbqL/jwo4jsbKLZBrQL8PLw==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-hub-types": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-hub-types/-/solution-hub-types-0.22.5.tgz",
-      "integrity": "sha512-dlsYbHRGWXbTtdxw+YDPSS6c5QnjLCG0lj9ckcNJ41LnFhwVqpPf/NBHC20cfoVdtJ74OGjD5p43w5VZOJ9P6Q==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-sites": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
+          "integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-simple-types": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-simple-types/-/solution-simple-types-0.22.5.tgz",
-      "integrity": "sha512-c3OIXYazpK3uyvt0nwXhoD3WIk9umpWKOp2BawMLRlXnyLc4yWvhV9JWhGotFPkOajDhFyjtKaRwFupyhECrbw==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
-        "@esri/solution-feature-layer": "^0.22.5",
-        "@esri/solution-file": "^0.22.5",
-        "@esri/solution-group": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
+        "@esri/solution-feature-layer": "^0.22.6",
+        "@esri/solution-file": "^0.22.6",
+        "@esri/solution-group": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-teams": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
+          "integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-feature-layer": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-file": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-group": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-storymap": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-storymap/-/solution-storymap-0.22.5.tgz",
-      "integrity": "sha512-nezLRgbB2qablAXMOnkE/4K/TTTXOa5vlS5cGmf00Nn6iIctI9wbis198YNjKkgZZUwIuJ0xj2RUYeBR4D0WPQ==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
     "@esri/solution-web-experience": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/@esri/solution-web-experience/-/solution-web-experience-0.22.5.tgz",
-      "integrity": "sha512-EEQIznb9+yTWwITD1nqQAXFaRwhPzyc6Ak9qn9nl2fRvZPTaDaadMMZWuSReXjIB5Niq1vzLlqCVbVKOvzrJxw==",
+      "version": "0.22.6",
       "requires": {
-        "@esri/solution-common": "^0.22.5",
-        "@esri/solution-simple-types": "^0.22.5",
+        "@esri/solution-common": "^0.22.6",
+        "@esri/solution-simple-types": "^0.22.6",
         "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "@esri/arcgis-rest-auth": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-auth/-/arcgis-rest-auth-3.0.3.tgz",
+          "integrity": "sha512-Eiu6EqRj2rViLk1z3xAvTiwaJiOZm8GWs7Ffx0mMNSD/JaLQ7S2yisq5zJ2vW/uo+tPGMAhTS8mP/riidJlm6w==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-feature-layer": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-layer/-/arcgis-rest-feature-layer-3.0.3.tgz",
+          "integrity": "sha512-+QmyB3KLxyvLH6VjTNdGJB3agy99IcD/GDi44MZhYSoc7fI1XmEUhqhZWWJku7LZt0OJ/Vczi+AD7EUPNGG5Hw==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-portal": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-3.0.3.tgz",
+          "integrity": "sha512-Vzl27/FxlX729KsB8L9gmjD6sUJZQjtnVIKqmK1n7DYJj7p16w4ys4GeDsTUfTej9SH3OSSKit3dSu3BSUsxOA==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-request": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-3.0.3.tgz",
+          "integrity": "sha512-gUI7xi5fqxRWLSCUzuvgStlGlT2rdKYTPo2TTkQpcBsPdxw5fGt1VkCNl23UI2FfxjJC8PSDXsqqOcBa205SvA==",
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "@esri/arcgis-rest-service-admin": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-service-admin/-/arcgis-rest-service-admin-3.0.3.tgz",
+          "integrity": "sha512-ZRbCBh/A0RvJkzZKR5QIwpmYOn8Qq97mTd41JVTRcgrT1THcuZIYmCqT6qsDgOMZaihPG3uXfrYGuM383qExDQ==",
+          "requires": {
+            "@esri/arcgis-rest-types": "^3.0.3",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/arcgis-rest-types": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-types/-/arcgis-rest-types-3.0.3.tgz",
+          "integrity": "sha512-hsJn98WoM5i9Y/xmv0Sp87wd0aaokBpJ/2Z9p9VfCDjCEC9CW0YdVdjsID+HDZ1LE4PY9rgY17QhyQ4R90KzAw=="
+        },
+        "@esri/hub-common": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-7.3.0.tgz",
+          "integrity": "sha512-fCUt0K6AQ6L21Tvg3AcZZXXUlj1bx+UfYmFFzqPXjOPXu89f6mru4qat/PB26przH9pVsWVt2naiR3RbkPB0sQ==",
+          "requires": {
+            "adlib": "^3.0.7",
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/hub-initiatives": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-7.3.0.tgz",
+          "integrity": "sha512-YhkJrZJEe2g3wP7dSz+tkLlx17GpjFlrP10hwVEt6mLkWEMmnb+Ci5WYU9mnELOBXk1SeUfuUukFdSPV+YAupg==",
+          "requires": {
+            "tslib": "^1.13.0"
+          }
+        },
+        "@esri/solution-common": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/arcgis-html-sanitizer": "~2.1.0",
+            "@types/lodash.isplainobject": "^4.0.6",
+            "adlib": "3.0.7",
+            "jszip": "3.6.0",
+            "lodash.isplainobject": "^4.0.6",
+            "tslib": "^1.13.0",
+            "xss": "^1.0.6"
+          },
+          "dependencies": {}
+        },
+        "@esri/solution-simple-types": {
+          "version": "0.22.6",
+          "requires": {
+            "@esri/solution-common": "^0.22.6",
+            "@esri/solution-feature-layer": "^0.22.6",
+            "@esri/solution-file": "^0.22.6",
+            "@esri/solution-group": "^0.22.6",
+            "tslib": "^1.13.0"
+          },
+          "dependencies": {}
+        },
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+        },
+        "@types/node": {
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
+        "adlib": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
+          "integrity": "sha512-74ylfcwB7+fu+jqN6e3mBJrAWhWHI5l8icUKh8IhNhmezetLRaMBrxQKJZ+GgyrNxyW+0M12eUirY1RJ5HhWKg==",
+          "requires": {
+            "esm": "^3.2.25"
+          }
+        },
+        "esm": {
+          "version": "3.2.25",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+          "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "typescript": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
+        }
       }
     },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
-    },
-    "@types/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-=======
->>>>>>> 3601f87f (fix: createHubRequestOptions always fetches user)
     "adlib": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",

--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -95,6 +95,7 @@
         "tslib": "^1.13.0"
       }
     },
+<<<<<<< HEAD
     "@esri/solution-common": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/@esri/solution-common/-/solution-common-0.22.5.tgz",
@@ -248,6 +249,8 @@
         "@types/lodash": "*"
       }
     },
+=======
+>>>>>>> 3601f87f (fix: createHubRequestOptions always fetches user)
     "adlib": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/adlib/-/adlib-3.0.7.tgz",
@@ -260,11 +263,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cssfilter": {
       "version": "0.0.10",
@@ -283,68 +281,10 @@
       "dev": true,
       "optional": true
     },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "jszip": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
-      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
     },
     "rollup": {
       "version": "2.33.3",
@@ -353,24 +293,6 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "tslib": {
@@ -383,11 +305,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "xss": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5392,6 +5392,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
@@ -6413,6 +6423,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -7997,6 +8008,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -10562,6 +10574,13 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",

--- a/packages/hub-types/package-lock.json
+++ b/packages/hub-types/package-lock.json
@@ -79,18 +79,18 @@
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.0.tgz",
-			"integrity": "sha512-e+IC9d4lvmbaisvkJZkGhqG8+/06WVPAjMo9O5PjQBS7Ul1Rfdxwa7GEv+9eDzH9jbwAdAqLzGscJUEp9IPHHw==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-7.3.2.tgz",
+			"integrity": "sha512-xIM4eCdSQYCdi/BunE3YDLAWATXFplLQJS1F9wYiZYuoQtl8wAjkBuCiimxqNjNYCqazh1/bkRoTKs2wfVKztw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.0.tgz",
-			"integrity": "sha512-+TMOrCm5e7DvRwHiHvviFzjveKrGQW23JasL6YIrg92I1ukzwUyi9rQwabxBOoiqxpSINgKHEb7Naj1mRuJCYw==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-7.3.2.tgz",
+			"integrity": "sha512-G6tj8nzbJSTEPuhGcYVxrOPob98443QipesbBTwr766o8pilIFZYGb2gY6tPOZ507nEqs/GJLOmMDPtaVW3tGg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/hub-types/package.json
+++ b/packages/hub-types/package.json
@@ -20,8 +20,8 @@
     "@esri/arcgis-rest-service-admin": "^3.0.3",
     "@esri/hub-common": "^7.3.0",
     "@esri/hub-initiatives": "^7.3.0",
-    "@esri/hub-sites": "^7.3.0",
-    "@esri/hub-teams": "^7.3.0",
+    "@esri/hub-sites": "^7.3.2",
+    "@esri/hub-teams": "^7.3.2",
     "rollup": "^1.22.0",
     "typescript": "^4.1.3"
   },
@@ -33,8 +33,8 @@
     "@esri/arcgis-rest-service-admin": "^3.0.3",
     "@esri/hub-common": "^7.3.0",
     "@esri/hub-initiatives": "^7.3.0",
-    "@esri/hub-sites": "^7.3.0",
-    "@esri/hub-teams": "^7.3.0"
+    "@esri/hub-sites": "^7.3.2",
+    "@esri/hub-teams": "^7.3.2"
   },
   "dependencies": {
     "@esri/solution-common": "^0.22.6",

--- a/packages/hub-types/src/helpers/create-hub-request-options.ts
+++ b/packages/hub-types/src/helpers/create-hub-request-options.ts
@@ -23,7 +23,7 @@ import {
   getProp
 } from "@esri/hub-common";
 
-import { getSelf } from "@esri/arcgis-rest-portal";
+import { getSelf, getUser } from "@esri/arcgis-rest-portal";
 
 /**
  * Create a IHubRequestOptions object from
@@ -40,28 +40,26 @@ export function createHubRequestOptions(
   authentication: UserSession,
   templateDictionary: any = {}
 ): Promise<IHubRequestOptions> {
-  let orgUserPrms;
-  // try to get info from templateDict
-  const portalSelf = getProp(templateDictionary, "organization");
-  const currentUser = getProp(templateDictionary, "user");
+  // We used to pull the user
+  // the template dictionary, but ran into issues
+  // with the user.groups being filtered to groups
+  // the user owns, vs all groups the user belongs to
+  // this was problematic as we need to check if the user
+  // can add more groups, based on how close they are to
+  // the max 512 group limit.
 
-  // if we've been passed the templateDictionary, use it
-  if (portalSelf && currentUser) {
-    orgUserPrms = Promise.all([
-      Promise.resolve(cloneObject(portalSelf)),
-      Promise.resolve(cloneObject(currentUser))
-    ]);
+  // At this time we are simply fetching the user directly
+  const promises = [];
+  if (templateDictionary.organization) {
+    promises.push(Promise.resolve(templateDictionary.organization));
   } else {
-    // need to use the auth to get the user and the org
-    orgUserPrms = Promise.all([
-      getSelf({ authentication }),
-      authentication.getUser()
-    ]);
+    promises.push(getSelf({ authentication }));
   }
+  // always get the user
+  promises.push(getUser({ authentication }));
 
-  return orgUserPrms.then(([pSelf, user]) => {
+  return Promise.all(promises).then(([pSelf, user]) => {
     pSelf.user = user;
-
     const ro = {
       authentication,
       portalSelf: pSelf,

--- a/packages/hub-types/test/helpers/create-hub-request-options.test.ts
+++ b/packages/hub-types/test/helpers/create-hub-request-options.test.ts
@@ -19,16 +19,20 @@ import * as portalModule from "@esri/arcgis-rest-portal";
 const MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
 
 describe("createHubRequestOptions", () => {
-  it("creates hubRequestOptions from the templateDictionary and session", () => {
+  it("returns portal from templateDict", () => {
     const td = {
       organization: {
         id: "somePortalId",
         portalHostname: "www.arcgis.com"
       },
       user: {
-        username: "vader"
+        username: "rando"
       }
     };
+
+    const getUserSpy = spyOn(portalModule, "getUser").and.resolveTo({
+      username: MOCK_USER_SESSION.username
+    });
 
     return createHubRequestOptions(MOCK_USER_SESSION, td).then(hubRo => {
       expect(hubRo.portalSelf.id).toBe(
@@ -36,8 +40,8 @@ describe("createHubRequestOptions", () => {
         "should copy organization to portalSelf"
       );
       expect(hubRo.portalSelf.user.username).toBe(
-        "vader",
-        "should copy user to portalSelf.user"
+        MOCK_USER_SESSION.username,
+        "use return user from getUser not templateDict"
       );
       expect(hubRo.authentication).toBe(
         MOCK_USER_SESSION,
@@ -53,7 +57,7 @@ describe("createHubRequestOptions", () => {
       isPortal: false
     } as portalModule.IPortal;
     const getSelfSpy = spyOn(portalModule, "getSelf").and.resolveTo(portal);
-    const getUserSpy = spyOn(MOCK_USER_SESSION, "getUser").and.resolveTo({
+    const getUserSpy = spyOn(portalModule, "getUser").and.resolveTo({
       username: MOCK_USER_SESSION.username
     });
 
@@ -68,34 +72,25 @@ describe("createHubRequestOptions", () => {
     });
   });
 
-  it("does not sent hubApiUrl if portal", () => {
-    const td = {
-      organization: {
-        id: "somePortalId",
-        portalHostname: "www.arcgis.com",
-        isPortal: true
-      },
-      user: {
-        username: "vader"
-      }
-    };
+  it("does not set hubApiUrl if portal", done => {
+    const portal = {
+      id: "bc23",
+      portalHostname: "www.arcgis.com",
+      name: "somePortal",
+      isPortal: true
+    } as portalModule.IPortal;
+    const getSelfSpy = spyOn(portalModule, "getSelf").and.resolveTo(portal);
+    const getUserSpy = spyOn(portalModule, "getUser").and.resolveTo({
+      username: MOCK_USER_SESSION.username
+    });
 
-    return createHubRequestOptions(MOCK_USER_SESSION, td).then(hubRo => {
-      expect(hubRo.hubApiUrl).not.toBeDefined(
+    return createHubRequestOptions(MOCK_USER_SESSION).then(ro => {
+      expect(ro.hubApiUrl).not.toBeDefined(
         "should not return hubApiUrl for portal"
       );
-      expect(hubRo.portalSelf.id).toBe(
-        "somePortalId",
-        "should copy organization to portalSelf"
-      );
-      expect(hubRo.portalSelf.user.username).toBe(
-        "vader",
-        "should copy user to portalSelf.user"
-      );
-      expect(hubRo.authentication).toBe(
-        MOCK_USER_SESSION,
-        "should pass thru the auth"
-      );
+      expect(getSelfSpy.calls.count()).toBe(1, "should get self");
+      expect(getUserSpy.calls.count()).toBe(1, "should get user");
+      done();
     });
   });
 });

--- a/packages/hub-types/test/hub-page-processor.test.ts
+++ b/packages/hub-types/test/hub-page-processor.test.ts
@@ -171,7 +171,10 @@ describe("HubPageProcessor: ", () => {
         success: true,
         id: "fred"
       });
-
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const td = {
         organization: {
           id: "somePortalId",
@@ -205,6 +208,10 @@ describe("HubPageProcessor: ", () => {
     });
 
     it("asset and resource juggling", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const createFromTmplSpy = spyOn(
         sitesPackage,
         "createPageModelFromTemplate"
@@ -260,7 +267,10 @@ describe("HubPageProcessor: ", () => {
       spyOn(sitesPackage, "createPageModelFromTemplate").and.rejectWith(
         "Whoa thats bad"
       );
-
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const td = {
         organization: {
           id: "somePortalId",
@@ -286,6 +296,10 @@ describe("HubPageProcessor: ", () => {
         });
     });
     it("it early-exits correctly", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const td = {};
       const cb = () => false;
       return HubPageProcessor.createItemFromTemplate(
@@ -302,6 +316,10 @@ describe("HubPageProcessor: ", () => {
       });
     });
     it("cleans up if job is cancelled late", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const createFromTmplSpy = spyOn(
         sitesPackage,
         "createPageModelFromTemplate"

--- a/packages/hub-types/test/hub-site-processor.test.ts
+++ b/packages/hub-types/test/hub-site-processor.test.ts
@@ -174,6 +174,10 @@ describe("HubSiteProcessor: ", () => {
         success: true,
         id: "fred"
       });
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
 
       const td = {
         organization: {
@@ -210,6 +214,10 @@ describe("HubSiteProcessor: ", () => {
       });
     });
     it("happy-path with thumbnail", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const createFromTmplSpy = spyOn(
         sitesPackage,
         "createSiteModelFromTemplate"
@@ -261,6 +269,10 @@ describe("HubSiteProcessor: ", () => {
     });
 
     it("other branches:: delegates to hub.js", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const createFromTmplSpy = spyOn(
         sitesPackage,
         "createSiteModelFromTemplate"
@@ -308,6 +320,10 @@ describe("HubSiteProcessor: ", () => {
       });
     });
     it("asset and resource juggling", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const createFromTmplSpy = spyOn(
         sitesPackage,
         "createSiteModelFromTemplate"
@@ -358,6 +374,10 @@ describe("HubSiteProcessor: ", () => {
       });
     });
     it("callsback on exception", done => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       spyOn(sitesPackage, "createSiteModelFromTemplate").and.rejectWith(
         "Whoa thats bad"
       );
@@ -387,6 +407,10 @@ describe("HubSiteProcessor: ", () => {
         });
     });
     it("it early-exits correctly", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const td = {};
       const cb = () => false;
       return HubSiteProcessor.createItemFromTemplate(
@@ -403,6 +427,10 @@ describe("HubSiteProcessor: ", () => {
       });
     });
     it("it cleans up if job is cancelled late", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const createFromTmplSpy = spyOn(
         sitesPackage,
         "createSiteModelFromTemplate"
@@ -473,6 +501,10 @@ describe("HubSiteProcessor: ", () => {
   });
   describe("postProcess ::", () => {
     it("delegates to _postProcessSite", () => {
+      const hubRoSpy = spyOn(
+        hubRoModule,
+        "createHubRequestOptions"
+      ).and.resolveTo({} as hubCommon.IHubRequestOptions);
       const getSiteByIdSpy = spyOn(sitesPackage, "getSiteById").and.resolveTo({
         item: {},
         data: {}


### PR DESCRIPTION
The hub-types package had been pulling the user from `templateDictionary.user` and using that to construct the `IHubRequestOptions` hash that's needed by the hub-js functions that create sites etc.
However, the groups attached to that user are currently filtered to only the groups the user owns. This decreses the count of groups, which is a problem when a user is a member of 512 groups... the Hub code checks how many groups they belong to (via user.groups), and since it's filtered, it returns a number that's lower and then it tries to create more groups... and the api calls fail... and things go badly.

In this change, we always fetch the user from the platform, and use that instead.