### PR TITLE
dependency issue

### DIFF
--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -27,6 +27,7 @@ import {
   IItemTemplate,
   IItemUpdate,
   ISolutionItemData,
+  isWorkforceProject,
   removeTemplate,
   replaceInTemplate,
   SItemProgressStatus,
@@ -166,10 +167,10 @@ export function addContentToSolution(
         if (solutionTemplates.length > 0) {
           // test for and update group dependencies and other post-processing
           solutionTemplates = _postProcessGroupDependencies(solutionTemplates);
-          solutionTemplates = _postProcessIgnoredItems(solutionTemplates);
           solutionTemplates = postProcessWorkforceTemplates(solutionTemplates);
-          _simplifyUrlsInItemDescriptions(solutionTemplates);
           _templatizeSolutionIds(solutionTemplates);
+          solutionTemplates = _postProcessIgnoredItems(solutionTemplates);
+          _simplifyUrlsInItemDescriptions(solutionTemplates);
           _replaceDictionaryItemsInObject(
             templateDictionary,
             solutionTemplates
@@ -532,6 +533,8 @@ export function _templatizeSolutionIds(templates: IItemTemplate[]): void {
   templates.forEach((template: IItemTemplate) => {
     _replaceRemainingIdsInObject(solutionIds, template.item);
     _replaceRemainingIdsInObject(solutionIds, template.data);
-    template.dependencies = _getDependencies(template);
+    if (template.type !== "Group" && !isWorkforceProject(template)) {
+      template.dependencies = _getDependencies(template);
+    }
   });
 }

--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -533,6 +533,7 @@ export function _templatizeSolutionIds(templates: IItemTemplate[]): void {
   templates.forEach((template: IItemTemplate) => {
     _replaceRemainingIdsInObject(solutionIds, template.item);
     _replaceRemainingIdsInObject(solutionIds, template.data);
+    /* istanbul ignore else */
     if (template.type !== "Group" && !isWorkforceProject(template)) {
       template.dependencies = _getDependencies(template);
     }

--- a/packages/creator/test/helpers/add-content-to-solution.test.ts
+++ b/packages/creator/test/helpers/add-content-to-solution.test.ts
@@ -34,6 +34,7 @@ import * as common from "@esri/solution-common";
 import * as mockItems from "../../../common/test/mocks/agolItems";
 import * as utils from "../../../common/test/mocks/utils";
 import * as templates from "../../../common/test/mocks/templates";
+import * as sinon from "sinon";
 import * as staticRelatedItemsMocks from "../../../common/test/mocks/staticRelatedItemsMocks";
 import { findBy } from "@esri/hub-common";
 // Set up a UserSession to use in all these tests
@@ -1237,5 +1238,26 @@ describe("_simplifyUrlsInItemDescriptions", () => {
 
     _simplifyUrlsInItemDescriptions([notebookTemplate]);
     expect(notebookTemplate.item.description).toBeNull();
+  });
+});
+
+describe("_templatizeSolutionIds", () => {
+  it("skips _getDependencies for workforce", () => {
+    // added for issue #630
+    const template: common.IItemTemplate = templates.getItemTemplate(
+      "Workforce Project"
+    );
+    template.dependencies = [];
+    template.item.typeKeywords.push("Workforce Project");
+    _templatizeSolutionIds([template]);
+    expect(template.dependencies).toEqual([]);
+  });
+
+  it("skips _getDependencies for group", () => {
+    // added for issue #630
+    const getDependenciesSpy = sinon.spy(_getDependencies);
+    const template: common.IItemTemplate = templates.getItemTemplate("Group");
+    _templatizeSolutionIds([template]);
+    expect(getDependenciesSpy.notCalled).toBe(true);
   });
 });


### PR DESCRIPTION
#630

_postProcessGroupDependencies and postProcessWorkforceTemplates both can intentionally remove items from the dependency array.