### PR TITLE
Delete deployment folder when deleting a solution

### DIFF
--- a/packages/common/src/deleteSolution.ts
+++ b/packages/common/src/deleteSolution.ts
@@ -60,6 +60,7 @@ export function deleteSolution(
   let progressPercentStep = 0;
   let percentDone = 0;
   let solutionFolderId: string;
+  let deletedItemIds = [] as string[];
 
   return Promise.all([
     restHelpersGet.getItemBase(solutionItemId, authentication),
@@ -96,6 +97,7 @@ export function deleteSolution(
           (template: any) => template.itemId
         );
       }
+      deletedItemIds = buildOrderIds.concat([solutionItemId]);
 
       let hubSiteItemIds = [] as string[];
       hubSiteItemIds = itemData.templates
@@ -156,7 +158,11 @@ export function deleteSolution(
     .then(allItemsSuccessfullyDeleted => {
       if (allItemsSuccessfullyDeleted) {
         // If all deletes succeeded, see if we can delete the folder that contained them
-        return _deleteSolutionFolder(solutionFolderId, authentication);
+        return _deleteSolutionFolder(
+          solutionFolderId,
+          deletedItemIds,
+          authentication
+        );
       } else {
         return Promise.resolve(false);
       }
@@ -170,12 +176,14 @@ export function deleteSolution(
  * Deletes a deployed Solution's folder if the folder is empty.
  *
  * @param solutionFolderId Id of the folder of a deployed Solution
+ * @param deletedItemIds Ids in the Solution, including the Solution item; used to deal with lagging folder deletion
  * @param authentication Credentials for the request
  * @return Promise that will resolve if deletion was successful and fail if any part of it failed;
  * if the folder has a non-Solution item, it will not be deleted, but the function will return true
  */
 export function _deleteSolutionFolder(
   solutionFolderId: string,
+  deletedItemIds: string[],
   authentication: UserSession
 ): Promise<boolean> {
   // See if the deployment folder is empty and can be deleted; first, we need info about user
@@ -199,7 +207,15 @@ export function _deleteSolutionFolder(
       });
     })
     .then((searchResult: portal.ISearchResult<portal.IItem>) => {
-      if (searchResult.total === 0) {
+      // If the search results are all in the deletedItemIds list, then we're dealing with AGO lagging:
+      // successfully reporting a deletion and yet still returning the item in search results.
+      // Filter the Solution items out of the search results.
+      const nonSolutionItems = searchResult.results
+        .map(foundItem => foundItem.id)
+        .filter(foundItemId => !deletedItemIds.includes(foundItemId)); // only save non-solution items
+
+      // If the list is empty, then there are no non-solution items
+      if (nonSolutionItems.length === 0) {
         // OK to delete the folder
         return portal.removeFolder({
           folderId: solutionFolderId,

--- a/packages/common/src/deleteSolution.ts
+++ b/packages/common/src/deleteSolution.ts
@@ -59,6 +59,7 @@ export function deleteSolution(
   const deleteOptions: IDeleteSolutionOptions = options || {};
   let progressPercentStep = 0;
   let percentDone = 0;
+  let solutionFolderId: string;
 
   return Promise.all([
     restHelpersGet.getItemBase(solutionItemId, authentication),
@@ -67,6 +68,7 @@ export function deleteSolution(
     .then((response: any) => {
       const itemBase: IItemGeneralized = response[0];
       const itemData: ISolutionItemData = response[1];
+      solutionFolderId = itemBase.ownerFolder;
 
       // Make sure that the item is a deployed Solution
       if (
@@ -151,8 +153,70 @@ export function deleteSolution(
         }
       });
     })
+    .then(allItemsSuccessfullyDeleted => {
+      if (allItemsSuccessfullyDeleted) {
+        // If all deletes succeeded, see if we can delete the folder that contained them
+        return _deleteSolutionFolder(solutionFolderId, authentication);
+      } else {
+        return Promise.resolve(false);
+      }
+    })
     .catch(error => {
       throw error.message;
+    });
+}
+
+/**
+ * Deletes a deployed Solution's folder if the folder is empty.
+ *
+ * @param solutionFolderId Id of the folder of a deployed Solution
+ * @param authentication Credentials for the request
+ * @return Promise that will resolve if deletion was successful and fail if any part of it failed;
+ * if the folder has a non-Solution item, it will not be deleted, but the function will return true
+ */
+export function _deleteSolutionFolder(
+  solutionFolderId: string,
+  authentication: UserSession
+): Promise<boolean> {
+  // See if the deployment folder is empty and can be deleted; first, we need info about user
+  return authentication
+    .getUser({ authentication })
+    .then(user => {
+      // And then we need to be sure that the folder is empty
+      const query = new portal.SearchQueryBuilder()
+        .match(authentication.username)
+        .in("owner")
+        .and()
+        .match(user.orgId)
+        .in("orgid")
+        .and()
+        .match(solutionFolderId)
+        .in("ownerfolder");
+
+      return portal.searchItems({
+        q: query,
+        authentication
+      });
+    })
+    .then((searchResult: portal.ISearchResult<portal.IItem>) => {
+      if (searchResult.total === 0) {
+        // OK to delete the folder
+        return portal.removeFolder({
+          folderId: solutionFolderId,
+          owner: authentication.username,
+          authentication
+        });
+      } else {
+        // A non-deployment item is in the folder, so leave it alone
+        return Promise.resolve({ success: true });
+      }
+    })
+    .then(deleteFolderResponse => {
+      // Extract the success property
+      return deleteFolderResponse.success;
+    })
+    .catch(() => {
+      return Promise.resolve(false);
     });
 }
 

--- a/packages/common/test/deleteSolution.test.ts
+++ b/packages/common/test/deleteSolution.test.ts
@@ -100,6 +100,18 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
         Promise.resolve(utils.getSuccessResponse({ id: solutionItem.base.id }))
       );
 
+      const getUserSpy = spyOn(MOCK_USER_SESSION, "getUser").and.resolveTo({
+        orgId: "orgABC"
+      });
+
+      const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
+        total: 0
+      } as any);
+
+      const removeFolderSpy = spyOn(portal, "removeFolder").and.resolveTo({
+        success: true
+      } as any);
+
       deleteSolution
         .deleteSolution(solutionItem.base.id, MOCK_USER_SESSION)
         .then(ok => {
@@ -139,10 +151,112 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
         Promise.resolve(utils.getSuccessResponse({ id: solutionItem.base.id }))
       );
 
+      const getUserSpy = spyOn(MOCK_USER_SESSION, "getUser").and.resolveTo({
+        orgId: "orgABC"
+      });
+
+      const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
+        total: 0
+      } as any);
+
+      const removeFolderSpy = spyOn(portal, "removeFolder").and.resolveTo({
+        success: true
+      } as any);
+
       deleteSolution
         .deleteSolution(solutionItem.base.id, MOCK_USER_SESSION)
         .then(ok => {
           expect(ok).toBeTruthy();
+          done();
+        }, done.fail);
+    });
+
+    it("deletes a version 1 Solution, but its folder contains a non-Solution item", done => {
+      const solutionItem = mockItems.getCompleteDeployedSolutionItemVersioned(
+        "1"
+      );
+
+      const getItemBaseSpy = spyOn(restHelpersGet, "getItemBase").and.resolveTo(
+        solutionItem.base
+      );
+      const getItemDataAsJsonSpy = spyOn(
+        restHelpersGet,
+        "getItemDataAsJson"
+      ).and.resolveTo(solutionItem.data);
+
+      const unprotectItemSpy = spyOn(portal, "unprotectItem").and.resolveTo(
+        utils.getSuccessResponse()
+      );
+
+      const removeItemSpy = spyOn(restHelpers, "removeItem").and.returnValues(
+        Promise.resolve(
+          utils.getSuccessResponse({
+            id: solutionItem.data.templates[0].itemId
+          })
+        ),
+        Promise.resolve(
+          utils.getSuccessResponse({
+            id: solutionItem.data.templates[1].itemId
+          })
+        ),
+        Promise.resolve(utils.getSuccessResponse({ id: solutionItem.base.id }))
+      );
+
+      const getUserSpy = spyOn(MOCK_USER_SESSION, "getUser").and.resolveTo({
+        orgId: "orgABC"
+      });
+
+      const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
+        total: 1
+      } as any);
+
+      deleteSolution
+        .deleteSolution(solutionItem.base.id, MOCK_USER_SESSION)
+        .then(ok => {
+          expect(ok).toBeTruthy();
+          done();
+        }, done.fail);
+    });
+
+    it("deletes a version 1 Solution, but deleting its folder fails", done => {
+      const solutionItem = mockItems.getCompleteDeployedSolutionItemVersioned(
+        "1"
+      );
+
+      const getItemBaseSpy = spyOn(restHelpersGet, "getItemBase").and.resolveTo(
+        solutionItem.base
+      );
+      const getItemDataAsJsonSpy = spyOn(
+        restHelpersGet,
+        "getItemDataAsJson"
+      ).and.resolveTo(solutionItem.data);
+
+      const unprotectItemSpy = spyOn(portal, "unprotectItem").and.resolveTo(
+        utils.getSuccessResponse()
+      );
+
+      const removeItemSpy = spyOn(restHelpers, "removeItem").and.returnValues(
+        Promise.resolve(
+          utils.getSuccessResponse({
+            id: solutionItem.data.templates[0].itemId
+          })
+        ),
+        Promise.resolve(
+          utils.getSuccessResponse({
+            id: solutionItem.data.templates[1].itemId
+          })
+        ),
+        Promise.resolve(utils.getSuccessResponse({ id: solutionItem.base.id }))
+      );
+
+      const getUserSpy = spyOn(MOCK_USER_SESSION, "getUser").and.resolveTo(
+        utils.getFailureResponse()
+      );
+
+      deleteSolution
+        .deleteSolution(solutionItem.base.id, MOCK_USER_SESSION)
+        .then(ok => {
+          expect(ok).toBeFalsy();
           done();
         }, done.fail);
     });
@@ -270,6 +384,18 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       const removeSolnItemSpy = spyOn(restHelpers, "removeItem").and.resolveTo(
         utils.getSuccessResponse({ id: solutionItem.base.id })
       );
+
+      const getUserSpy = spyOn(MOCK_USER_SESSION, "getUser").and.resolveTo({
+        orgId: "orgABC"
+      });
+
+      const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
+        total: 0
+      } as any);
+
+      const removeFolderSpy = spyOn(portal, "removeFolder").and.resolveTo({
+        success: true
+      } as any);
 
       deleteSolution
         .deleteSolution(solutionItem.base.id, MOCK_USER_SESSION)

--- a/packages/common/test/deleteSolution.test.ts
+++ b/packages/common/test/deleteSolution.test.ts
@@ -105,7 +105,8 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       });
 
       const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
-        total: 0
+        total: 0,
+        results: []
       } as any);
 
       const removeFolderSpy = spyOn(portal, "removeFolder").and.resolveTo({
@@ -156,7 +157,8 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       });
 
       const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
-        total: 0
+        total: 0,
+        results: []
       } as any);
 
       const removeFolderSpy = spyOn(portal, "removeFolder").and.resolveTo({
@@ -207,7 +209,8 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       });
 
       const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
-        total: 1
+        total: 1,
+        results: [{ id: "itm1234567890" }]
       } as any);
 
       deleteSolution
@@ -390,7 +393,8 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       });
 
       const searchSpy = spyOn(portal, "searchItems").and.resolveTo({
-        total: 0
+        total: 0,
+        results: []
       } as any);
 
       const removeFolderSpy = spyOn(portal, "removeFolder").and.resolveTo({


### PR DESCRIPTION
See https://github.com/Esri/solution.js/issues/624#issuecomment-845987971

Does not delete folder if it contains a non-Solution item.

After all deletions, the code queries the folder for its contents. Because sometimes AGO will report an item successfully deleted, yet will still later return that item during a query, the code checks the successful deletions against the list of items in the Solution. If all items returned from a query are in the list of successfully deleted items, then the code goes ahead with deleting the folder even though it nominally contains items.