### PR TITLE
TypeScript management

### DIFF
--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -377,9 +377,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "util-deprecate": {

--- a/demos/package.json
+++ b/demos/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "rollup": "^2.31.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.3.4"
   },
   "dependencies": {
     "@esri/arcgis-html-sanitizer": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25644,9 +25644,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "sri-toolbox": "0.2.0",
     "ts-node": "^8.3.0",
     "typedoc": "^0.20.36",
-    "typescript": "^4.1.4",
+    "typescript": "^4.3.4",
     "uuid": "^8.0.0"
   },
   "dependencies": {
@@ -202,6 +202,7 @@
   },
   "volta": {
     "node": "14.15.5",
-    "npm": "6.14.11"
+    "npm": "6.14.11",
+    "typescript": "4.3.4"
   }
 }

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -268,9 +268,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		},
 		"util-deprecate": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,8 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "@types/adlib": "^3.0.1",
-    "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "rollup": "^1.22.0"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/common/src/generalHelpers.ts
+++ b/packages/common/src/generalHelpers.ts
@@ -141,6 +141,22 @@ export function createShortId(): string {
 }
 
 /**
+ * Copies an input list removing duplicates.
+ *
+ * @param input List to be deduped
+ * @returns Deduped list; order of items in input is not maintained
+ */
+export function dedupe(input: string[] = []): string[] {
+  if (input.length === 0) {
+    return [];
+  }
+  const dedupedList = new Set(input);
+  const output: string[] = [];
+  dedupedList.forEach((value: string) => output.push(value));
+  return output;
+}
+
+/**
  * Flags a failure to create an item from a template.
  *
  * @param itemType The AGO item type

--- a/packages/common/src/migrations/upgrade-two-dot-zero.ts
+++ b/packages/common/src/migrations/upgrade-two-dot-zero.ts
@@ -71,8 +71,8 @@ export const _convertIndicatorToDefinition = function(ind: any) {
     optional: ind.optional || false,
     definition: {
       description: ind.label || ind.fieldName,
-      supportedTypes: [...ind.layerOptions.supportedTypes],
-      geometryTypes: [...ind.layerOptions.geometryTypes],
+      supportedTypes: [].concat(ind.layerOptions.supportedTypes),
+      geometryTypes: [].concat(ind.layerOptions.geometryTypes),
       fields: ind.fields.map(_convertIndicatorField)
     }
   };
@@ -90,6 +90,6 @@ export const _convertIndicatorField = function(field: any) {
     name: field.label,
     optional: field.optional || false,
     description: field.tooltip,
-    supportedTypes: [...field.supportedTypes]
+    supportedTypes: [].concat(field.supportedTypes)
   };
 };

--- a/packages/common/test/generalHelpers.test.ts
+++ b/packages/common/test/generalHelpers.test.ts
@@ -454,6 +454,33 @@ describe("Module `generalHelpers`: common utility functions shared across packag
     });
   });
 
+  describe("dedupe", () => {
+    it("should handle undefined list", () => {
+      expect(generalHelpers.dedupe()).toEqual([]);
+    });
+
+    it("should handle empty list", () => {
+      expect(generalHelpers.dedupe([])).toEqual([]);
+    });
+
+    it("should handle list with no duplicates", () => {
+      expect(generalHelpers.dedupe(["a", "b", "c", "d"])).toEqual([
+        "a",
+        "b",
+        "c",
+        "d"
+      ]);
+    });
+
+    it("should handle list with duplicates", () => {
+      expect(generalHelpers.dedupe(["a", "d", "c", "d"])).toEqual([
+        "a",
+        "d",
+        "c"
+      ]);
+    });
+  });
+
   describe("deleteProp", () => {
     it("should handle missing prop", () => {
       const testObject: any = {};

--- a/packages/common/test/resources/store-item-resources.test.ts
+++ b/packages/common/test/resources/store-item-resources.test.ts
@@ -630,6 +630,10 @@ describe("storeItemResources :: ", () => {
         MOCK_USER_SESSION,
         1
       ).then(actual => {
+        // Sort before comparing because Chrome and Firefox tests sometimes have different results on Linux test machine
+        actual.sort();
+        expected.sort();
+
         expect(actual).toEqual(expected);
         done();
       }, done.fail);

--- a/packages/creator/package-lock.json
+++ b/packages/creator/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/deployer/src/helpers/post-process.ts
+++ b/packages/deployer/src/helpers/post-process.ts
@@ -85,9 +85,7 @@ export function postProcess(
     return acc;
   }, []);
 
-  return Promise.all([
-    ...postProcessPromises,
-    sharePromises,
-    ...relationshipPromises
-  ]);
+  return Promise.all(
+    [sharePromises].concat(postProcessPromises, relationshipPromises)
+  );
 }

--- a/packages/feature-layer/package-lock.json
+++ b/packages/feature-layer/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/feature-layer/package.json
+++ b/packages/feature-layer/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/file/package-lock.json
+++ b/packages/file/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/form/src/helpers/post-process-survey.ts
+++ b/packages/form/src/helpers/post-process-survey.ts
@@ -72,10 +72,9 @@ export function postProcessHubSurvey(
         {
           id: featureServiceResultId,
           extent: interpolated.item.extent,
-          typeKeywords: [
-            ...featureServiceResultBase.typeKeywords,
-            `source-${featureServiceSourceId}`
-          ]
+          typeKeywords: [`source-${featureServiceSourceId}`].concat(
+            featureServiceResultBase.typeKeywords
+          )
         }
       ];
       const toUpdatePromise = (updatedItem: IItemUpdate) =>

--- a/packages/form/test/helpers/post-process-survey.test.ts
+++ b/packages/form/test/helpers/post-process-survey.test.ts
@@ -137,10 +137,9 @@ describe("postProcessHubSurvey", () => {
           {
             id: featureServiceResultBase.id,
             extent: interpolatedTemplate.item.extent,
-            typeKeywords: [
-              ...featureServiceResultBase.typeKeywords,
-              `source-${featureServiceSourceBase.id}`
-            ]
+            typeKeywords: [`source-${featureServiceSourceBase.id}`].concat(
+              featureServiceResultBase.typeKeywords
+            )
           },
           MOCK_USER_SESSION
         ]);

--- a/packages/group/package-lock.json
+++ b/packages/group/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/hub-types/package-lock.json
+++ b/packages/hub-types/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/hub-types/package.json
+++ b/packages/hub-types/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/hub-types/src/hub-site-processor.ts
+++ b/packages/hub-types/src/hub-site-processor.ts
@@ -27,6 +27,7 @@ import {
   EItemProgressStatus,
   UserSession,
   createHubRequestOptions,
+  dedupe,
   generateEmptyCreationResponse,
   getProp
 } from "@esri/solution-common";
@@ -218,7 +219,7 @@ export function convertItemToTemplate(
       }
       // swap out dependency id's to {{<depid>.itemId}}
       // so it will be re-interpolated
-      tmpl.dependencies = [...new Set(tmpl.dependencies || [])]; // dedupe
+      tmpl.dependencies = dedupe(tmpl.dependencies);
       tmpl = replaceItemIds(tmpl);
 
       // and return it

--- a/packages/simple-types/package-lock.json
+++ b/packages/simple-types/package-lock.json
@@ -128,9 +128,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/simple-types/package.json
+++ b/packages/simple-types/package.json
@@ -21,7 +21,7 @@
     "@esri/hub-common": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/storymap/package-lock.json
+++ b/packages/storymap/package-lock.json
@@ -99,9 +99,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/storymap/package.json
+++ b/packages/storymap/package.json
@@ -18,7 +18,7 @@
     "@esri/arcgis-rest-request": "^3.1.1",
     "@esri/hub-common": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/storymap/src/helpers/convert-storymap-to-template.ts
+++ b/packages/storymap/src/helpers/convert-storymap-to-template.ts
@@ -67,12 +67,11 @@ export function convertStoryMapToTemplate(
   // Note: Hub team decided to discard unpublished drafts when creating a template
   const typeKeywords = tmpl.item.typeKeywords;
   if (typeKeywords.indexOf(unPublishedChangesKW) !== -1) {
-    tmpl.item.typeKeywords = [
-      publishedChangesKW,
-      ...tmpl.item.typeKeywords.filter(
+    tmpl.item.typeKeywords = [publishedChangesKW].concat(
+      tmpl.item.typeKeywords.filter(
         (word: string) => word !== unPublishedChangesKW
       )
-    ];
+    );
   }
 
   tmpl.properties = {};

--- a/packages/viewer/package-lock.json
+++ b/packages/viewer/package-lock.json
@@ -146,9 +146,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -23,7 +23,7 @@
     "@esri/hub-sites": "^8.5.1",
     "@esri/hub-teams": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",

--- a/packages/web-experience/package-lock.json
+++ b/packages/web-experience/package-lock.json
@@ -128,9 +128,9 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
 			"dev": true
 		}
 	}

--- a/packages/web-experience/package.json
+++ b/packages/web-experience/package.json
@@ -21,7 +21,7 @@
     "@esri/hub-common": "^8.5.1",
     "@esri/hub-initiatives": "^8.5.1",
     "rollup": "^1.22.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.4"
   },
   "peerDependencies": {
     "@esri/arcgis-rest-auth": "^3.1.1",


### PR DESCRIPTION
The current versions of TypeScript are failing builds because of the use of spread arrays in the code. Planned to leave the updates in the `develop` branch, but it now appears necessary in the `release/agol-9.2` branch.

This PR updates TypeScript and replaces spread arrays.