### PR TITLE
Improve handling of postprocessing dependencies

### DIFF
--- a/demos/src/getFormattedItemInfo.ts
+++ b/demos/src/getFormattedItemInfo.ts
@@ -39,10 +39,10 @@ export function getFormattedItemInfo(
         await formatItemInfo(portalUrl, item, Raphael, Dracula)
         .then(
           html => resolve(html),
-          (error: any) => reject(JSON.stringify(error))
+          reject
         );
       },
-      (error: any) => reject(JSON.stringify(error))
+      reject
     );
   });
 }

--- a/packages/common/src/completeItem.ts
+++ b/packages/common/src/completeItem.ts
@@ -117,8 +117,5 @@ export function getCompleteItem(
         completeItem.featureServiceProperties = properties;
       }
       return Promise.resolve(completeItem);
-    })
-    .catch(() => {
-      return null;
     });
 }

--- a/packages/common/src/completeItem.ts
+++ b/packages/common/src/completeItem.ts
@@ -47,9 +47,6 @@ export function getCompleteItem(
   return restHelpersGet
     .getItemBase(itemId, authentication)
     .then((response: any) => {
-      if (restHelpersGet.checkJsonForError(response)) {
-        throw new Error();
-      }
       itemBase = response;
 
       return Promise.all([

--- a/packages/common/test/completeItem.test.ts
+++ b/packages/common/test/completeItem.test.ts
@@ -143,10 +143,10 @@ describe("Module `completeItem`: functions for accessing a complete item", () =>
     it("should handle failure to get an item", done => {
       const itemId = "abc";
 
-      const baseSpy = spyOn(restHelpersGet, "getItemBase").and.resolveTo(
+      const baseSpy = spyOn(restHelpersGet, "getItemBase").and.rejectWith(
         mockItems.get400Failure()
       );
-      const dataSpy = spyOn(restHelpersGet, "getItemDataAsFile").and.resolveTo(
+      const dataSpy = spyOn(restHelpersGet, "getItemDataAsFile").and.rejectWith(
         mockItems.get400Failure()
       );
       const thumbnailSpy = spyOn(
@@ -170,12 +170,13 @@ describe("Module `completeItem`: functions for accessing a complete item", () =>
         "getFeatureServiceProperties"
       ).and.resolveTo({} as interfaces.IFeatureServiceProperties);
 
-      completeItem
-        .getCompleteItem(itemId, MOCK_USER_SESSION)
-        .then((item: interfaces.ICompleteItem) => {
-          expect(item).toBeNull();
+      completeItem.getCompleteItem(itemId, MOCK_USER_SESSION).then(
+        () => done.fail(),
+        error => {
+          expect(error.error.code).toEqual(400);
           done();
-        });
+        }
+      );
     });
   });
 });

--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -533,5 +533,9 @@ export function _templatizeSolutionIds(templates: IItemTemplate[]): void {
   templates.forEach((template: IItemTemplate) => {
     _replaceRemainingIdsInObject(solutionIds, template.item);
     _replaceRemainingIdsInObject(solutionIds, template.data);
+    /* istanbul ignore else */
+    if (template.type !== "Group" && !isWorkforceProject(template)) {
+      template.dependencies = _getDependencies(template);
+    }
   });
 }

--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -215,9 +215,6 @@ export function _getDependencies(template: IItemTemplate): string[] {
   // Get all dependencies
   let deps = template.dependencies.concat(
     _getIdsOutOfTemplateVariables(
-      _getTemplateVariables(JSON.stringify(template.item))
-    ),
-    _getIdsOutOfTemplateVariables(
       _getTemplateVariables(JSON.stringify(template.data))
     )
   );

--- a/packages/creator/test/helpers/add-content-to-solution.test.ts
+++ b/packages/creator/test/helpers/add-content-to-solution.test.ts
@@ -160,11 +160,12 @@ describe("_getDependencies", () => {
       "https://experience.arcgis.com/experience/{{fcb2bf2837a6404ebb418a1f805f976a.itemId}}<div>{{portalBaseUrl}}/apps/webappviewer/index.html?id={{cefb7d787b8b4edb971efba758ee0c1e.itemId}}</div>{{" +
       template.itemId +
       "}}";
+    template.data.operationalLayers[0].title =
+      "ROW {{5f8c7627614a4c179ea5b243509d5b7c}} {{124f66175750431096575c449b42bd65}} {{854f1128cb784cf692e848390452d100}} Permits";
     template.dependencies = ["124f66175750431096575c449b42bd65"];
     expect(_getDependencies(template)).toEqual([
       "124f66175750431096575c449b42bd65",
-      "cefb7d787b8b4edb971efba758ee0c1e",
-      "fcb2bf2837a6404ebb418a1f805f976a"
+      "5f8c7627614a4c179ea5b243509d5b7c"
     ]);
   });
 });


### PR DESCRIPTION
1. fixed error handling when copySolutions has problems fetching the Solution that it just created
2. only look in an item's data section when seeking additional dependencies

See https://github.com/Esri/solution.js/issues/652#issuecomment-866964432