### PR TITLE
Fixed thumbnail sent during group creation

### DIFF
--- a/packages/group/test/group.test.ts
+++ b/packages/group/test/group.test.ts
@@ -663,6 +663,7 @@ describe("Module `group`: manages the creation and deployment of groups", () => 
         itemTemplate
       );
       expectedClone.itemId = newItemID;
+      expectedClone.item.thumbnail = undefined;
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       group
@@ -720,6 +721,7 @@ describe("Module `group`: manages the creation and deployment of groups", () => 
         itemTemplate
       );
       expectedClone.itemId = newItemID;
+      expectedClone.item.thumbnail = undefined;
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       group


### PR DESCRIPTION
Thumbnail is already part of group item definition, so it is unnecessary to try to fetch the thumbnail again, which wasn't working.  Also have to be careful with thumbnail file because adlib call during cloning breaks the file.

#681