### PR TITLE
Improve cleanup when Solution fails to deploy

### DIFF
--- a/packages/common/src/deleteHelpers/deleteSolutionContents.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionContents.ts
@@ -1,0 +1,167 @@
+/** @license
+ * Copyright 2021 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides a function for deleting a deployed Solution item and all of the items that were created
+ * as part of that deployment.
+ *
+ * @module deleteSolution
+ */
+
+import {
+  EItemProgressStatus,
+  IDeleteSolutionOptions,
+  ISolutionPrecis,
+  IStatusResponse,
+  UserSession
+} from "../interfaces";
+import * as deleteEmptyGroups from "./deleteEmptyGroups";
+import * as deleteSolutionFolder from "./deleteSolutionFolder";
+import * as deleteSolutionItem from "./deleteSolutionItem";
+import * as removeItems from "./removeItems";
+import * as reportProgress from "./reportProgress";
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+/**
+ * Deletes a deployed Solution item and and all of the items that were created
+ * as part of that deployment.
+ *
+ * @param solutionItemId Id of a deployed Solution
+ * @param solutionSummary List of items in the solution that would be deleted
+ * @param authentication Credentials for the request
+ * @param options Progress reporting options
+ * @return Promise that will resolve with a list of two solution summaries: successful deletions
+ * and failed deletions. Ignored items (e.g., already deleted) and items shared with more than
+ * one Solution will not be in either list.
+ * Note that Solution item and its deployment folder will only be deleted if all of its deployed
+ * items were deleted (the failure list is empty). This makes it possible to re-attempted
+ * deletion using the solutionItemId.
+ */
+export function deleteSolutionContents(
+  solutionItemId: string,
+  solutionSummary: ISolutionPrecis,
+  authentication: UserSession,
+  options?: IDeleteSolutionOptions
+): Promise<ISolutionPrecis[]> {
+  const deleteOptions: IDeleteSolutionOptions = options || {};
+  let progressPercentStep = 0;
+  let percentDone = 0;
+  let solutionDeletedSummary: ISolutionPrecis;
+  let solutionFailureSummary: ISolutionPrecis;
+  let solutionIds = [] as string[];
+
+  return new Promise<ISolutionPrecis[]>(resolve => {
+    let removalPromise: Promise<ISolutionPrecis[]> = Promise.resolve([
+      {
+        id: solutionSummary.id,
+        title: solutionSummary.title,
+        folder: solutionSummary.folder,
+        items: [],
+        groups: []
+      },
+      {
+        id: solutionSummary.id,
+        title: solutionSummary.title,
+        folder: solutionSummary.folder,
+        items: [],
+        groups: []
+      }
+    ] as ISolutionPrecis[]);
+
+    if (solutionSummary.items.length > 0) {
+      // Save a copy of the Solution item ids for the deleteSolutionFolder call because removeItems
+      // destroys the solutionSummary.items list
+      solutionIds = solutionSummary.items
+        .map(item => item.id)
+        .concat([solutionItemId]);
+
+      const hubSiteItemIds: string[] = solutionSummary.items
+        .filter((item: any) => item.type === "Hub Site Application")
+        .map((item: any) => item.id);
+
+      // Delete the items
+      progressPercentStep = 100 / (solutionSummary.items.length + 2); // one extra for starting plus one extra for solution itself
+      reportProgress.reportProgress(
+        (percentDone += progressPercentStep),
+        deleteOptions
+      ); // let the caller know that we've started
+
+      // Proceed with the deletion
+      removalPromise = removeItems.removeItems(
+        solutionSummary,
+        hubSiteItemIds,
+        authentication,
+        percentDone,
+        progressPercentStep,
+        deleteOptions
+      );
+    }
+
+    removalPromise
+      .then((results: ISolutionPrecis[]) => {
+        [solutionDeletedSummary, solutionFailureSummary] = results;
+
+        // Attempt to delete groups; we won't be checking success
+        return new Promise<ISolutionPrecis[]>(resolve2 => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          deleteEmptyGroups
+            .deleteEmptyGroups(solutionSummary.groups, authentication)
+            .then(() => {
+              resolve2(results);
+            });
+        });
+      })
+      .then(() => {
+        // If there were no failed deletes, it's OK to delete Solution item
+        if (solutionFailureSummary.items.length === 0) {
+          return deleteSolutionItem.deleteSolutionItem(
+            solutionItemId,
+            authentication
+          );
+        } else {
+          // Not all items were deleted, so don't delete solution
+          return Promise.resolve({ success: false, itemId: solutionItemId });
+        }
+      })
+      .then((solutionItemDeleteStatus: IStatusResponse) => {
+        // If all deletes succeeded, see if we can delete the folder that contained them
+        if (solutionItemDeleteStatus.success) {
+          reportProgress.reportProgress(
+            99,
+            deleteOptions,
+            solutionItemId,
+            EItemProgressStatus.Finished
+          );
+
+          // Can't delete if folder contains non-solution items
+          return deleteSolutionFolder.deleteSolutionFolder(
+            solutionIds,
+            solutionSummary.folder,
+            authentication
+          );
+        } else {
+          return Promise.resolve(false);
+        }
+      })
+      .then(() => {
+        resolve([solutionDeletedSummary, solutionFailureSummary]);
+      })
+      .catch(() => {
+        resolve([solutionDeletedSummary, solutionFailureSummary]);
+      });
+  });
+}

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -1342,27 +1342,6 @@ export function removeItemOrGroup(
 }
 
 /**
- * Removes a list of items and/or groups from AGO.
- *
- * @param itemIds Ids of items or groups to delete
- * @param authentication Credentials for the request to AGO
- * @return A promise that will resolve when deletion is done or fails
- */
-export function removeListOfItemsOrGroups(
-  itemIds: string[],
-  authentication: UserSession
-): Promise<void> {
-  return new Promise<void>(resolve => {
-    Promise.all(
-      itemIds.map(itemId => removeItemOrGroup(itemId, authentication))
-    ).then(
-      () => resolve(null),
-      () => resolve(null)
-    );
-  });
-}
-
-/**
  * Searches for groups matching criteria.
  *
  * @param searchString Text for which to search, e.g., 'redlands+map', 'type:"Web Map" -type:"Web Mapping Application"'

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -2931,33 +2931,6 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
     });
   });
 
-  describe("removeListOfItemsOrGroups", () => {
-    it("handles failure to remove all of a list of items", done => {
-      const itemIds = ["itm1234567890"];
-
-      fetchMock
-        .post(
-          utils.PORTAL_SUBSET.restUrl +
-            "/content/users/casey/items/" +
-            itemIds[0] +
-            "/delete",
-          utils.getFailureResponse()
-        )
-        .post(
-          utils.PORTAL_SUBSET.restUrl +
-            "/community/groups/" +
-            itemIds[0] +
-            "/delete",
-          utils.getFailureResponse()
-        );
-
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      restHelpers
-        .removeListOfItemsOrGroups(itemIds, MOCK_USER_SESSION)
-        .then(() => done());
-    });
-  });
-
   describe("searchGroups", () => {
     it("can handle no results from searching groups", done => {
       const query: string = "My Group";

--- a/packages/deployer/src/deploySolutionFromTemplate.ts
+++ b/packages/deployer/src/deploySolutionFromTemplate.ts
@@ -242,6 +242,7 @@ export function deploySolutionFromTemplate(
           solutionTemplateData.templates,
           storageAuthentication,
           templateDictionary,
+          deployedSolutionId,
           authentication,
           options
         );
@@ -324,43 +325,7 @@ export function deploySolutionFromTemplate(
           deployedFolderId
         );
       })
-      .then(
-        () => resolve(solutionTemplateBase.id),
-        error => {
-          // Cleanup deployed solution item and solution folder
-          // Have to do it in stages because folder deletion is faster than item deletion,
-          // and thus fails if solution is not yet unprotected
-          let cleanupPromise = Promise.resolve({
-            success: true,
-            itemId: solutionTemplateBase.id
-          } as common.IStatusResponse);
-          if (deployedSolutionId) {
-            cleanupPromise = common.deleteSolutionItem(
-              deployedSolutionId,
-              authentication
-            );
-          }
-
-          cleanupPromise
-            .then(() => {
-              let cleanupPromise2 = Promise.resolve({
-                success: true,
-                folder: null
-              } as common.IFolderStatusResponse);
-              if (deployedFolderId) {
-                cleanupPromise2 = common.removeFolder(
-                  deployedFolderId,
-                  authentication
-                );
-              }
-              return cleanupPromise2;
-            })
-            .then(
-              () => reject(error),
-              () => reject(error)
-            );
-        }
-      );
+      .then(() => resolve(solutionTemplateBase.id), reject);
   });
 }
 

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -192,6 +192,7 @@ export function deploySolutionItems(
                 const progressOptions: common.IDeleteSolutionOptions = {
                   consoleProgress: true
                 };
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 common
                   .deleteSolutionByComponents(
                     deployedSolutionId,
@@ -201,9 +202,8 @@ export function deploySolutionItems(
                     destinationAuthentication,
                     progressOptions
                   )
-                  .then(
-                    () => reject(common.failWithIds(failedTemplateItemIds)),
-                    () => reject(common.failWithIds(failedTemplateItemIds))
+                  .then(() =>
+                    reject(common.failWithIds(failedTemplateItemIds))
                   );
               }
             }

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -35,6 +35,7 @@ const UNSUPPORTED: common.moduleHandler = null;
  * @param templates A collection of AGO item templates
  * @param storageAuthentication Credentials for the organization with the source items
  * @param templateDictionary Hash of facts: org URL, adlib replacements
+ * @param deployedSolutionId Id of deployed Solution item
  * @param destinationAuthentication Credentials for the destination organization
  * @param options Options to tune deployment
  * @return A promise that will resolve with the list of information about the created items
@@ -45,6 +46,7 @@ export function deploySolutionItems(
   templates: common.IItemTemplate[],
   storageAuthentication: common.UserSession,
   templateDictionary: any,
+  deployedSolutionId: string,
   destinationAuthentication: common.UserSession,
   options: common.IDeploySolutionOptions
 ): Promise<common.ICreateItemFromTemplateResponse[]> {
@@ -187,14 +189,21 @@ export function deploySolutionItems(
                 resolve(clonedSolutionItems);
               } else {
                 // Delete created items
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                const progressOptions: common.IDeleteSolutionOptions = {
+                  consoleProgress: true
+                };
                 common
-                  .removeListOfItemsOrGroups(
+                  .deleteSolutionByComponents(
+                    deployedSolutionId,
                     deployedItemIds,
-                    destinationAuthentication
+                    templates,
+                    templateDictionary,
+                    destinationAuthentication,
+                    progressOptions
                   )
-                  .then(() =>
-                    reject(common.failWithIds(failedTemplateItemIds))
+                  .then(
+                    () => reject(common.failWithIds(failedTemplateItemIds)),
+                    () => reject(common.failWithIds(failedTemplateItemIds))
                   );
               }
             }

--- a/packages/deployer/test/deploySolutionFromTemplate.test.ts
+++ b/packages/deployer/test/deploySolutionFromTemplate.test.ts
@@ -250,7 +250,7 @@ describe("Module `deploySolutionFromTemplate`", () => {
           const deployFnCall = deployFnStub.getCall(0);
           expect(deployFnCall.args[0]).toEqual(MOCK_USER_SESSION.portal); // portalSharingUrl
           expect(deployFnCall.args[3].portal).toEqual(MOCK_USER_SESSION.portal); // storageAuthentication
-          expect(deployFnCall.args[5].portal).toEqual(MOCK_USER_SESSION.portal); // destinationAuthentication
+          expect(deployFnCall.args[6].portal).toEqual(MOCK_USER_SESSION.portal); // destinationAuthentication
 
           deployFnStub.restore();
           postProcessFnStub.restore();
@@ -387,7 +387,7 @@ describe("Module `deploySolutionFromTemplate`", () => {
           expect(deployFnCall.args[3].portal).toEqual(
             MOCK_USER_SESSION_ALT.portal
           ); // storageAuthentication
-          expect(deployFnCall.args[5].portal).toEqual(MOCK_USER_SESSION.portal); // destinationAuthentication
+          expect(deployFnCall.args[6].portal).toEqual(MOCK_USER_SESSION.portal); // destinationAuthentication
 
           deployFnStub.restore();
           postProcessFnStub.restore();

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -60,6 +60,7 @@ describe("Module `deploySolutionItems`", () => {
           [template],
           MOCK_USER_SESSION,
           {},
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: false,
@@ -172,6 +173,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -263,6 +265,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -359,6 +362,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -462,6 +466,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -579,6 +584,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -637,6 +643,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -707,6 +714,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -783,6 +791,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -858,6 +867,22 @@ describe("Module `deploySolutionItems`", () => {
           utils.getFailureResponse({
             groupId: "aa4a6047326243b290f625e80ebe6531"
           })
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//unprotect",
+          { success: true }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//delete",
+          { success: true }
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/self?f=json&token=fake-token",
+          utils.getPortalsSelfResponse()
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/search?f=json&q=owner%3Acasey%20AND%20orgid%3A%20AND%20ownerfolder%3A&token=fake-token",
+          {}
         );
       spyOn(console, "error").and.callFake(() => {});
 
@@ -885,6 +910,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             jobId: "abc",
@@ -1032,7 +1058,23 @@ describe("Module `deploySolutionItems`", () => {
             ]
           }
         )
-        .post(url2, mockItems.get500Failure());
+        .post(url2, mockItems.get500Failure())
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//unprotect",
+          { success: true }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//delete",
+          { success: true }
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/self?f=json&token=fake-token",
+          utils.getPortalsSelfResponse()
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/search?f=json&q=owner%3Acasey%20AND%20orgid%3A%20AND%20ownerfolder%3A&token=fake-token",
+          {}
+        );
 
       spyOn(console, "error").and.callFake(() => {});
       deploySolution
@@ -1042,6 +1084,7 @@ describe("Module `deploySolutionItems`", () => {
           [itemTemplate],
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: true,
@@ -1051,7 +1094,7 @@ describe("Module `deploySolutionItems`", () => {
         .then(() => done.fail(), done);
     });
 
-    it("handle failure to use exiting items", done => {
+    it("handle failure to use existing items", done => {
       const _templates: common.IItemTemplate[] = [];
 
       const sourceId: string = "aa4a6047326243b290f625e80ebe6531";
@@ -1089,7 +1132,24 @@ describe("Module `deploySolutionItems`", () => {
       spyOn(common, "getLayerSettings").and.callFake(() => {});
       spyOn(console, "error").and.callFake(() => {});
 
-      fetchMock.post(newFsUrl, mockItems.get400Failure());
+      fetchMock
+        .post(newFsUrl, mockItems.get400Failure())
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//unprotect",
+          { success: true }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//delete",
+          { success: true }
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/search?f=json&q=owner%3Acasey%20AND%20orgid%3A%20AND%20ownerfolder%3A&token=fake-token",
+          {}
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/community/self?f=json&token=fake-token",
+          {}
+        );
 
       deploySolution
         .deploySolutionItems(
@@ -1098,6 +1158,7 @@ describe("Module `deploySolutionItems`", () => {
           _templates,
           MOCK_USER_SESSION,
           templateDictionary,
+          "",
           MOCK_USER_SESSION,
           {
             enableItemReuse: false,

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -1076,7 +1076,9 @@ describe("Module `deploySolutionItems`", () => {
           {}
         );
 
+      spyOn(console, "log").and.callFake(() => {});
       spyOn(console, "error").and.callFake(() => {});
+
       deploySolution
         .deploySolutionItems(
           utils.PORTAL_URL,
@@ -1130,6 +1132,7 @@ describe("Module `deploySolutionItems`", () => {
       };
 
       spyOn(common, "getLayerSettings").and.callFake(() => {});
+      spyOn(console, "log").and.callFake(() => {});
       spyOn(console, "error").and.callFake(() => {});
 
       fetchMock

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -1632,6 +1632,7 @@ describe("Module `deployer`", () => {
       const geometryServer: string =
         portalsSelfResponse.helperServices.geometry.url;
 
+      const consoleSpy = spyOn(console, "log");
       fetchMock
         .get(
           testUtils.PORTAL_SUBSET.restUrl +
@@ -1767,6 +1768,18 @@ describe("Module `deployer`", () => {
         .post(
           "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/map1234567890/unprotect",
           { success: true }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/svc1234567890/unprotect",
+          { success: true }
+        )
+        .post(
+          "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items//delete",
+          { success: true }
+        )
+        .get(
+          "https://myorg.maps.arcgis.com/sharing/rest/search?f=json&q=owner%3Acasey%20AND%20orgid%3Aorg1234567890%20AND%20ownerfolder%3Aa4468da125a64526b359b70d8ba4a9dd&token=fake-token",
+          {}
         );
       spyOn(console, "error").and.callFake(() => {});
 


### PR DESCRIPTION
Instead of just deleting all items and groups in the Solution, delete in reverse order of creation (feature service views before their feature services) and use hub.js to delete Hub items.

#675