### PR TITLE
Fix resource handling during creation to skip non-existent files

### DIFF
--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -164,7 +164,7 @@ export interface IAssociatedFileInfo {
   /**
    * An internal classification of the type of file: data, metadata, resource
    */
-  type: EFileType;
+  type?: EFileType;
 
   /**
    * The mime type of the file
@@ -175,6 +175,11 @@ export interface IAssociatedFileInfo {
    * URL where a resource, metadata, or thumbnail of an item or group can be found
    */
   url?: string;
+
+  /**
+   * File holding a resource, metadata, or thumbnail of an item or group
+   */
+  file?: File;
 }
 
 export interface IBuildOrdering {
@@ -732,6 +737,23 @@ export interface ISolutionProgressEvent {
   data?: any;
 }
 
+export interface ISourceFile {
+  /**
+   * Resource file
+   */
+  file: File;
+
+  /**
+   * Resource's "folder"--the prefix before the filename
+   */
+  folder: string;
+
+  /**
+   * Resource's filename
+   */
+  filename: string;
+}
+
 /**
  *  Information for storing a resource in a storage item.
  */
@@ -742,12 +764,12 @@ export interface ISourceFileCopyPath {
   url: string;
 
   /**
-   * Folder for storing a resource in a storage item
+   * Resource's "folder"--the prefix before the filename
    */
   folder: string;
 
   /**
-   * Filename for storing a resource in a storage item
+   * Resource's filename
    */
   filename: string;
 }
@@ -967,7 +989,7 @@ export interface IZipInfo {
   /**
    * List of files included in this zip
    */
-  filelist: IAssociatedFileInfo[];
+  filelist: any[];
 }
 
 //#endregion ---------------------------------------------------------------------------------------------------------//

--- a/packages/common/src/resourceHelpers.ts
+++ b/packages/common/src/resourceHelpers.ts
@@ -53,6 +53,7 @@ import {
   IAssociatedFileInfo,
   IDeployFileCopyPath,
   IFileMimeTyped,
+  ISourceFile,
   ISourceFileCopyPath,
   UserSession
 } from "./interfaces";
@@ -68,8 +69,8 @@ import { convertItemResourceToStorageResource } from "./resources/convert-item-r
 import { convertStorageResourceToItemResource } from "./resources/convert-storage-resource-to-item-resource";
 import { getThumbnailFile } from "./restHelpersGet";
 import {
-  copyAssociatedFilesAsResources,
-  copyAssociatedFilesByType
+  copyAssociatedFilesByType,
+  copyFilesAsResources
 } from "./resources/copyAssociatedFiles";
 
 // ------------------------------------------------------------------------------------------------------------------ //
@@ -193,43 +194,38 @@ export function copyFilesFromStorageItem(
 }
 
 /**
- * Copies the files described by a list of full URLs and storage folder/filename combinations for storing
- * the resources, metadata, and thumbnail of an item or group to a storage item.
+ * Copies the files for storing the resources, metadata, and thumbnail of an item or group to a storage item
+ * with a specified path.
  *
- * @param sourceAuthentication Credentials for the request to the source
- * @param filePaths List of item files' URLs and folder/filenames for storing the files
+ * @param files List of item files and paths for storing the files
  * @param storageItemId Id of item to receive copy of resource/metadata
  * @param storageAuthentication Credentials for the request to the storage
  * @return A promise which resolves to a list of the filenames under which the resource/metadata are stored
  */
 export function copyFilesToStorageItem(
-  sourceAuthentication: UserSession,
-  filePaths: ISourceFileCopyPath[],
+  files: ISourceFile[],
   storageItemId: string,
   storageAuthentication: UserSession
 ): Promise<string[]> {
   return new Promise<string[]>(resolve => {
     // tslint:disable-next-line: no-floating-promises
-    void copyAssociatedFilesAsResources(
-      filePaths as IAssociatedFileInfo[],
-      sourceAuthentication,
-      storageItemId,
-      storageAuthentication
-    ).then((results: IAssociatedFileCopyResults[]) => {
-      resolve(
-        results
-          // Filter out failures
-          .filter(
-            (result: IAssociatedFileCopyResults) =>
-              result.fetchedFromSource && result.copiedToDestination
-          )
-          // Return folder and filename in storage item's resources
-          .map(
-            (result: IAssociatedFileCopyResults) =>
-              result.folder + "/" + result.filename
-          )
-      );
-    });
+    void copyFilesAsResources(files, storageItemId, storageAuthentication).then(
+      (results: IAssociatedFileCopyResults[]) => {
+        resolve(
+          results
+            // Filter out failures
+            .filter(
+              (result: IAssociatedFileCopyResults) =>
+                result.fetchedFromSource && result.copiedToDestination
+            )
+            // Return folder and filename in storage item's resources
+            .map(
+              (result: IAssociatedFileCopyResults) =>
+                result.folder + "/" + result.filename
+            )
+        );
+      }
+    );
   });
 }
 

--- a/packages/common/src/resources/copyResourceIntoZip.ts
+++ b/packages/common/src/resources/copyResourceIntoZip.ts
@@ -30,7 +30,6 @@ import { getBlobAsFile } from "../restHelpersGet";
  * Copies a resource into a zipfile.
  *
  * @param file Information about the source and destination of the file such as its URL, folder, filename
- * @param sourceAuthentication Credentials for the request to the source
  * @param zipInfo Information about a zipfile such as its name and its zip object
  * @return The result of the copy
  */

--- a/packages/common/src/resources/copyResourceIntoZip.ts
+++ b/packages/common/src/resources/copyResourceIntoZip.ts
@@ -17,6 +17,7 @@
 import {
   IAssociatedFileCopyResults,
   IAssociatedFileInfo,
+  ISourceFile,
   IZipInfo,
   UserSession
 } from "../interfaces";
@@ -28,12 +29,36 @@ import { getBlobAsFile } from "../restHelpersGet";
 /**
  * Copies a resource into a zipfile.
  *
+ * @param file Information about the source and destination of the file such as its URL, folder, filename
+ * @param sourceAuthentication Credentials for the request to the source
+ * @param zipInfo Information about a zipfile such as its name and its zip object
+ * @return The result of the copy
+ */
+export function copyResourceIntoZip(
+  file: ISourceFile,
+  zipInfo: IZipInfo
+): IAssociatedFileCopyResults {
+  // Add it to the zip
+  if (file.folder) {
+    zipInfo.zip
+      .folder(file.folder)
+      .file(file.filename, file.file, { binary: true });
+  } else {
+    zipInfo.zip.file(file.filename, file.file, { binary: true });
+  }
+  zipInfo.filelist.push(file);
+  return createCopyResults(file, true) as IAssociatedFileCopyResults;
+}
+
+/**
+ * Copies a resource into a zipfile.
+ *
  * @param fileInfo Information about the source and destination of the file such as its URL, folder, filename
  * @param sourceAuthentication Credentials for the request to the source
  * @param zipInfo Information about a zipfile such as its name and its zip object
  * @return A promise which resolves to the result of the copy
  */
-export function copyResourceIntoZip(
+export function copyResourceIntoZipFromInfo(
   fileInfo: IAssociatedFileInfo,
   sourceAuthentication: UserSession,
   zipInfo: IZipInfo

--- a/packages/common/src/resources/createCopyResults.ts
+++ b/packages/common/src/resources/createCopyResults.ts
@@ -32,7 +32,7 @@ import {
  * @return IAssociatedFileCopyResults object
  */
 export function createCopyResults(
-  fileInfo: IAssociatedFileInfo | IZipInfo,
+  fileInfo: any,
   fetchedFromSource: boolean,
   copiedToDestination?: boolean
 ): IAssociatedFileCopyResults | IZipCopyResults {

--- a/packages/common/src/resources/getItemResourcesFilesFromPaths.ts
+++ b/packages/common/src/resources/getItemResourcesFilesFromPaths.ts
@@ -23,6 +23,7 @@ import { getBlobAsFile } from "../restHelpersGet";
  * Fetches a set of resources defined by paths.
  *
  * @param resourceItemFilePaths Paths to resources in source
+ * @param authentication Credentials for the request to the source
  * @return A promise which resolves with an array of resource files
  */
 export function getItemResourcesFilesFromPaths(

--- a/packages/common/src/resources/getItemResourcesFilesFromPaths.ts
+++ b/packages/common/src/resources/getItemResourcesFilesFromPaths.ts
@@ -1,0 +1,54 @@
+/** @license
+ * Copyright 2021 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISourceFile, ISourceFileCopyPath, UserSession } from "../interfaces";
+import { getBlobAsFile } from "../restHelpersGet";
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+/**
+ * Fetches a set of resources defined by paths.
+ *
+ * @param resourceItemFilePaths Paths to resources in source
+ * @return A promise which resolves with an array of resource files
+ */
+export function getItemResourcesFilesFromPaths(
+  resourceItemFilePaths: ISourceFileCopyPath[],
+  authentication: UserSession
+): Promise<ISourceFile[]> {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  return Promise.all(
+    resourceItemFilePaths.map(fileInfo => {
+      return new Promise<ISourceFile>(resolve => {
+        getBlobAsFile(fileInfo.url, fileInfo.filename, authentication).then(
+          file => {
+            resolve({
+              file,
+              folder: fileInfo.folder,
+              filename: fileInfo.filename
+            } as ISourceFile);
+          },
+          () => {
+            resolve(null);
+          }
+        );
+      });
+    })
+  ).then((files: ISourceFile[]) => {
+    // Discard failures
+    return files.filter(file => !!file);
+  });
+}

--- a/packages/common/src/resources/getItemResourcesPaths.ts
+++ b/packages/common/src/resources/getItemResourcesPaths.ts
@@ -18,6 +18,8 @@ import { getItemResources } from "../restHelpersGet";
 import { generateSourceFilePaths } from "../resourceHelpers";
 import { IItemTemplate, ISourceFileCopyPath, UserSession } from "../interfaces";
 
+// ------------------------------------------------------------------------------------------------------------------ //
+
 /**
  * Updates the solution item with resources from the itemTemplate
  *

--- a/packages/common/src/resources/index.ts
+++ b/packages/common/src/resources/index.ts
@@ -25,5 +25,6 @@ export * from "./copyResourceIntoZip";
 export * from "./copyZipIntoItem";
 export * from "./createCopyResults";
 export * from "./get-blob";
+export * from "./getItemResourcesFilesFromPaths";
 export * from "./getItemResourcesPaths";
 export * from "./solution-resource";

--- a/packages/common/test/resourceHelpers.test.ts
+++ b/packages/common/test/resourceHelpers.test.ts
@@ -594,18 +594,13 @@ describe("Module `resourceHelpers`: common functions involving the management of
   describe("copyFilesToStorageItem", () => {
     it("empty files list", done => {
       const sourceUserSession = MOCK_USER_SESSION;
-      const filePaths: interfaces.ISourceFileCopyPath[] = [] as interfaces.ISourceFileCopyPath[];
+      const filePaths: interfaces.ISourceFile[] = [] as interfaces.ISourceFile[];
       const storageItemId: string = "itm1234567890";
       const storageAuthentication = MOCK_USER_SESSION;
       const expected: string[] = [];
 
       resourceHelpers
-        .copyFilesToStorageItem(
-          sourceUserSession,
-          filePaths,
-          storageItemId,
-          storageAuthentication
-        )
+        .copyFilesToStorageItem(filePaths, storageItemId, storageAuthentication)
         .then((response: any) => {
           expect(response).toEqual(expected);
           done();
@@ -614,11 +609,11 @@ describe("Module `resourceHelpers`: common functions involving the management of
 
     it("single file to copy", done => {
       const sourceUserSession = MOCK_USER_SESSION;
-      const filePaths: interfaces.ISourceFileCopyPath[] = [
+      const files: interfaces.ISourceFile[] = [
         {
           folder: "storageFolder",
           filename: "storageFilename.png",
-          url: "https://myserver/images/thumbnail.png"
+          file: utils.getSampleImageAsFile()
         }
       ];
       const storageItemId: string = "itm1234567890";
@@ -642,12 +637,7 @@ describe("Module `resourceHelpers`: common functions involving the management of
         .post(fetchUrl, expectedFetch)
         .post(updateUrl, expectedUpdate);
       resourceHelpers
-        .copyFilesToStorageItem(
-          sourceUserSession,
-          filePaths,
-          storageItemId,
-          storageAuthentication
-        )
+        .copyFilesToStorageItem(files, storageItemId, storageAuthentication)
         .then((response: any) => {
           expect(response).toEqual(expectedUpdate);
           done();

--- a/packages/common/test/resources/copyAssociatedFiles.test.ts
+++ b/packages/common/test/resources/copyAssociatedFiles.test.ts
@@ -30,7 +30,7 @@ import * as resourceHelpers from "../../src/resourceHelpers";
 import * as restHelpers from "../../src/restHelpers";
 import * as restHelpersGet from "../../src/restHelpersGet";
 import {
-  copyAssociatedFilesAsResources,
+  copyFilesAsResources,
   copyAssociatedFilesByType
 } from "../../src/resources/copyAssociatedFiles";
 import { createCopyResults } from "../../src/resources/createCopyResults";
@@ -93,7 +93,7 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
       const copyResourceIntoZipSpy = spyOn(
         copyResourceIntoZip,
         "copyResourceIntoZip"
-      ).and.rejectWith(mockItems.get400Failure());
+      ).and.returnValue(null);
       const copyZipIntoItemSpy = spyOn(
         copyZipIntoItem,
         "copyZipIntoItem"
@@ -117,12 +117,17 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
     });
 
     it("copies ignoring file type", done => {
-      const fileInfos: interfaces.IAssociatedFileInfo[] = [
-        _createIAssociatedFileInfo(interfaces.EFileType.Data),
-        _createIAssociatedFileInfo(interfaces.EFileType.Info),
-        _createIAssociatedFileInfo(interfaces.EFileType.Metadata),
-        _createIAssociatedFileInfo(interfaces.EFileType.Resource),
-        _createIAssociatedFileInfo(interfaces.EFileType.Thumbnail)
+      const files: interfaces.ISourceFile[] = [
+        {
+          folder: "storageFolder",
+          filename: "metadata.xml",
+          file: utils.getSampleMetadataAsFile()
+        },
+        {
+          folder: "storageFolder",
+          filename: "storageFilename.png",
+          file: utils.getSampleImageAsFile()
+        }
       ];
 
       const copyDataIntoItemSpy = spyOn(
@@ -142,54 +147,34 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
         "copyZipIntoItem"
       ).and.resolveTo(
         _createIZipCopyResults(true, true, [
-          _createIAssociatedFileInfo(interfaces.EFileType.Data),
-          _createIAssociatedFileInfo(interfaces.EFileType.Info),
           _createIAssociatedFileInfo(interfaces.EFileType.Metadata),
-          _createIAssociatedFileInfo(interfaces.EFileType.Resource),
-          _createIAssociatedFileInfo(interfaces.EFileType.Thumbnail)
+          _createIAssociatedFileInfo(interfaces.EFileType.Resource)
         ])
       );
 
-      copyAssociatedFilesAsResources(
-        fileInfos,
-        MOCK_USER_SESSION,
-        "itm1234567890",
-        MOCK_USER_SESSION
-      ).then((results: interfaces.IAssociatedFileCopyResults[]) => {
-        expect(results).toEqual([
-          _createIAssociatedFileCopyResults(
-            true,
-            true,
-            interfaces.EFileType.Data
-          ),
-          _createIAssociatedFileCopyResults(
-            true,
-            true,
-            interfaces.EFileType.Info
-          ),
-          _createIAssociatedFileCopyResults(
-            true,
-            true,
-            interfaces.EFileType.Metadata
-          ),
-          _createIAssociatedFileCopyResults(
-            true,
-            true,
-            interfaces.EFileType.Resource
-          ),
-          _createIAssociatedFileCopyResults(
-            true,
-            true,
-            interfaces.EFileType.Thumbnail
-          )
-        ] as interfaces.IAssociatedFileCopyResults[]);
+      copyFilesAsResources(files, "itm1234567890", MOCK_USER_SESSION).then(
+        (results: interfaces.IAssociatedFileCopyResults[]) => {
+          expect(results).toEqual([
+            _createIAssociatedFileCopyResults(
+              true,
+              true,
+              interfaces.EFileType.Metadata
+            ),
+            _createIAssociatedFileCopyResults(
+              true,
+              true,
+              interfaces.EFileType.Resource
+            )
+          ] as interfaces.IAssociatedFileCopyResults[]);
 
-        expect(copyDataIntoItemSpy).not.toHaveBeenCalled();
-        expect(copyMetadataIntoItemSpy).not.toHaveBeenCalled();
-        expect(copyZipIntoItemSpy).toHaveBeenCalled();
+          expect(copyDataIntoItemSpy).not.toHaveBeenCalled();
+          expect(copyMetadataIntoItemSpy).not.toHaveBeenCalled();
+          expect(copyZipIntoItemSpy).toHaveBeenCalled();
 
-        done();
-      }, done.fail);
+          done();
+        },
+        done.fail
+      );
     });
 
     it("copies based on file type", done => {
@@ -290,7 +275,7 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
         "copyZipIntoItem"
       ).and.rejectWith(mockItems.get400Failure());
 
-      copyAssociatedFilesAsResources(
+      copyAssociatedFilesByType(
         fileInfos,
         MOCK_USER_SESSION,
         "itm1234567890",
@@ -502,34 +487,39 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
   });
 
   describe("copyResourceIntoZip", () => {
-    it("should handle success copying item not in a folder", done => {
-      const fileInfo = _createIAssociatedFileInfo();
-      fileInfo.folder = "";
+    it("should handle success copying item not in a folder", () => {
+      const file = {
+        folder: "",
+        filename: "storageFilename.png",
+        file: utils.getSampleImageAsFile("storageFilename.png")
+      };
       const zipInfo = _createIZipInfo();
-      const getBlobAsFileSpy = spyOn(
-        restHelpersGet,
-        "getBlobAsFile"
-      ).and.resolveTo(utils.getSampleImageAsFile());
 
-      copyResourceIntoZip
-        .copyResourceIntoZip(fileInfo, MOCK_USER_SESSION, zipInfo)
-        .then((results: interfaces.IAssociatedFileCopyResults) => {
-          const fileInfoResults = _createIAssociatedFileCopyResults(true);
-          fileInfoResults.folder = "";
-          expect(results).toEqual(fileInfoResults);
-          expect(getBlobAsFileSpy).toHaveBeenCalled();
-          expect(Object.keys(zipInfo.zip.files).length).toEqual(1); // file
-          expect(zipInfo.zip.files["Data"]).toBeDefined();
-          expect(zipInfo.filelist.length).toEqual(1); // file
-          expect(zipInfo.filelist[0]).toEqual({
-            folder: "",
-            filename: "Data",
-            type: 0,
-            mimeType: "text",
-            url: "http://esri.com"
-          });
-          done();
-        }, done.fail);
+      const results: interfaces.IAssociatedFileCopyResults = copyResourceIntoZip.copyResourceIntoZip(
+        file,
+        zipInfo
+      );
+      expect(results)
+        .withContext("results")
+        .toEqual({
+          folder: "",
+          filename: "storageFilename.png",
+          file: utils.getSampleImageAsFile("storageFilename.png"),
+          fetchedFromSource: true,
+          copiedToDestination: undefined
+        } as interfaces.IAssociatedFileCopyResults);
+      expect(Object.keys(zipInfo.zip.files).length)
+        .withContext("zip object count")
+        .toEqual(1); // file
+      expect(zipInfo.zip.files["storageFilename.png"])
+        .withContext("zip object")
+        .toBeDefined();
+      expect(zipInfo.filelist.length)
+        .withContext("zip file count")
+        .toEqual(1); // file
+      expect(zipInfo.filelist[0])
+        .withContext("zip file")
+        .toEqual(file);
     });
 
     it("should handle success copying item in a folder", done => {
@@ -541,7 +531,7 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
       ).and.resolveTo(utils.getSampleImageAsFile());
 
       copyResourceIntoZip
-        .copyResourceIntoZip(fileInfo, MOCK_USER_SESSION, zipInfo)
+        .copyResourceIntoZipFromInfo(fileInfo, MOCK_USER_SESSION, zipInfo)
         .then((results: interfaces.IAssociatedFileCopyResults) => {
           expect(results).toEqual(_createIAssociatedFileCopyResults(true));
           expect(getBlobAsFileSpy).toHaveBeenCalled();
@@ -552,7 +542,7 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
           expect(zipInfo.filelist[0]).toEqual({
             folder: "fld",
             filename: "Data",
-            type: 0,
+            type: interfaces.EFileType.Data,
             mimeType: "text",
             url: "http://esri.com"
           });
@@ -569,7 +559,7 @@ describe("Module `copyAssociatedFiles`: functions for sending resources to AGO",
       ).and.rejectWith(mockItems.get400Failure());
 
       copyResourceIntoZip
-        .copyResourceIntoZip(fileInfo, MOCK_USER_SESSION, zipInfo)
+        .copyResourceIntoZipFromInfo(fileInfo, MOCK_USER_SESSION, zipInfo)
         .then((results: interfaces.IAssociatedFileCopyResults) => {
           expect(results).toEqual(_createIAssociatedFileCopyResults(false));
           expect(getBlobAsFileSpy).toHaveBeenCalled();

--- a/packages/creator/src/createItemTemplate.ts
+++ b/packages/creator/src/createItemTemplate.ts
@@ -181,7 +181,7 @@ export function createItemTemplate(
                       srcAuthentication,
                       SolutionTemplateFormatVersion
                     ).then((resourceItemFilePaths: ISourceFileCopyPath[]) => {
-                      itemTemplate.item.thumbnail = null; // not needed; handled as a resource
+                      itemTemplate.item.thumbnail = null; // not needed in this property; handled as a resource
 
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
                       getItemResourcesFilesFromPaths(
@@ -246,7 +246,7 @@ export function createItemTemplate(
                                 EItemProgressStatus.Finished,
                                 1
                               );
-                              dependentResourceItemFiles.reduce(
+                              resourceItemFiles = dependentResourceItemFiles.reduce(
                                 (accumulator, currentValue) =>
                                   accumulator.concat(currentValue),
                                 resourceItemFiles

--- a/packages/creator/src/createItemTemplate.ts
+++ b/packages/creator/src/createItemTemplate.ts
@@ -33,7 +33,9 @@ import {
   IItemGeneralized,
   IItemProgressCallback,
   IItemTemplate,
+  ISourceFile,
   ISourceFileCopyPath,
+  getItemResourcesFilesFromPaths,
   getItemResourcesPaths,
   replaceTemplate,
   sanitizeJSONAndReportChanges,
@@ -54,7 +56,7 @@ import { moduleMap, UNSUPPORTED } from "./module-map";
  * @param srcAuthentication Credentials for requests to source items
  * @param destAuthentication Authentication for requesting information from AGO about items to be included in solution item
  * @param existingTemplates A collection of AGO item templates that can be referenced by newly-created templates
- * @return A promise which resolves with an array of paths to resources for the item and uts dependencies
+ * @return A promise which resolves with an array of resources for the item and its dependencies
  * @protected
  */
 export function createItemTemplate(
@@ -65,7 +67,7 @@ export function createItemTemplate(
   destAuthentication: UserSession,
   existingTemplates: IItemTemplate[],
   itemProgressCallback: IItemProgressCallback
-): Promise<ISourceFileCopyPath[]> {
+): Promise<ISourceFile[]> {
   return new Promise(resolve => {
     // Check if item and its dependents are already in list or are queued
     if (findTemplateInList(existingTemplates, itemId)) {
@@ -181,72 +183,79 @@ export function createItemTemplate(
                     ).then((resourceItemFilePaths: ISourceFileCopyPath[]) => {
                       itemTemplate.item.thumbnail = null; // not needed; handled as a resource
 
-                      // update the template's resources
-                      itemTemplate.resources = itemTemplate.resources.concat(
-                        resourceItemFilePaths.map(
-                          (file: ISourceFileCopyPath) =>
-                            file.folder + "/" + file.filename
-                        )
-                      );
-
-                      // Set the value keyed by the id to the created template, replacing the placeholder template
-                      replaceTemplate(
-                        existingTemplates,
-                        itemTemplate.itemId,
-                        itemTemplate
-                      );
-
-                      // Trace item dependencies
-                      if (itemTemplate.dependencies.length === 0) {
-                        itemProgressCallback(
-                          itemId,
-                          EItemProgressStatus.Finished,
-                          1
+                      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                      getItemResourcesFilesFromPaths(
+                        resourceItemFilePaths,
+                        srcAuthentication
+                      ).then((resourceItemFiles: ISourceFile[]) => {
+                        // update the template's resources
+                        itemTemplate.resources = itemTemplate.resources.concat(
+                          resourceItemFiles.map(
+                            (file: ISourceFile) =>
+                              file.folder + "/" + file.filename
+                          )
                         );
-                        resolve(resourceItemFilePaths);
-                      } else {
-                        // Get its dependencies, asking each to get its dependents via
-                        // recursive calls to this function
-                        const dependentDfds: Array<Promise<
-                          ISourceFileCopyPath[]
-                        >> = [];
-                        itemTemplate.dependencies.forEach(dependentId => {
-                          if (
-                            !findTemplateInList(existingTemplates, dependentId)
-                          ) {
-                            dependentDfds.push(
-                              createItemTemplate(
-                                solutionItemId,
-                                dependentId,
-                                templateDictionary,
-                                srcAuthentication,
-                                destAuthentication,
+
+                        // Set the value keyed by the id to the created template, replacing the placeholder template
+                        replaceTemplate(
+                          existingTemplates,
+                          itemTemplate.itemId,
+                          itemTemplate
+                        );
+
+                        // Trace item dependencies
+                        if (itemTemplate.dependencies.length === 0) {
+                          itemProgressCallback(
+                            itemId,
+                            EItemProgressStatus.Finished,
+                            1
+                          );
+                          resolve(resourceItemFiles);
+                        } else {
+                          // Get its dependencies, asking each to get its dependents via
+                          // recursive calls to this function
+                          const dependentDfds: Array<Promise<
+                            ISourceFile[]
+                          >> = [];
+                          itemTemplate.dependencies.forEach(dependentId => {
+                            if (
+                              !findTemplateInList(
                                 existingTemplates,
-                                itemProgressCallback
+                                dependentId
                               )
-                            );
-                          }
-                        });
-                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        Promise.all(dependentDfds).then(
-                          (
-                            dependentResourceItemFilePaths: ISourceFileCopyPath[][]
-                          ) => {
-                            // Templatization of item and its dependencies done
-                            itemProgressCallback(
-                              itemId,
-                              EItemProgressStatus.Finished,
-                              1
-                            );
-                            dependentResourceItemFilePaths.reduce(
-                              (accumulator, currentValue) =>
-                                accumulator.concat(currentValue),
-                              resourceItemFilePaths
-                            );
-                            resolve(resourceItemFilePaths);
-                          }
-                        );
-                      }
+                            ) {
+                              dependentDfds.push(
+                                createItemTemplate(
+                                  solutionItemId,
+                                  dependentId,
+                                  templateDictionary,
+                                  srcAuthentication,
+                                  destAuthentication,
+                                  existingTemplates,
+                                  itemProgressCallback
+                                )
+                              );
+                            }
+                          });
+                          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                          Promise.all(dependentDfds).then(
+                            (dependentResourceItemFiles: ISourceFile[][]) => {
+                              // Templatization of item and its dependencies done
+                              itemProgressCallback(
+                                itemId,
+                                EItemProgressStatus.Finished,
+                                1
+                              );
+                              dependentResourceItemFiles.reduce(
+                                (accumulator, currentValue) =>
+                                  accumulator.concat(currentValue),
+                                resourceItemFiles
+                              );
+                              resolve(resourceItemFiles);
+                            }
+                          );
+                        }
+                      });
                     });
                   },
                   error => {

--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -27,6 +27,7 @@ import {
   IItemTemplate,
   IItemUpdate,
   ISolutionItemData,
+  ISourceFile,
   ISourceFileCopyPath,
   isWorkforceProject,
   removeTemplate,
@@ -145,7 +146,7 @@ export function addContentToSolution(
 
     // Handle a list of one or more AGO ids by stepping through the list
     // and calling this function recursively
-    const getItemsPromise: Array<Promise<ISourceFileCopyPath[]>> = [];
+    const getItemsPromise: Array<Promise<ISourceFile[]>> = [];
     options.itemIds.forEach(itemId => {
       const createDef = createItemTemplate(
         solutionItemId,
@@ -161,7 +162,7 @@ export function addContentToSolution(
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     Promise.all(getItemsPromise).then(
-      (multipleResourceItemFilePaths: ISourceFileCopyPath[][]) => {
+      (multipleResourceItemFiles: ISourceFile[][]) => {
         if (failedItemIds.length > 0) {
           reject(
             failWithIds(
@@ -172,16 +173,15 @@ export function addContentToSolution(
         } else {
           if (solutionTemplates.length > 0) {
             // Coalesce the resource file paths from the created templates
-            const resourceItemFilePaths: ISourceFileCopyPath[] = multipleResourceItemFilePaths.reduce(
+            const resourceItemFiles: ISourceFile[] = multipleResourceItemFiles.reduce(
               (accumulator, currentValue) => accumulator.concat(currentValue),
-              [] as ISourceFileCopyPath[]
+              [] as ISourceFile[]
             );
 
             // Send the accumulated resources to the solution item
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             copyFilesToStorageItem(
-              srcAuthentication,
-              resourceItemFilePaths,
+              resourceItemFiles,
               solutionItemId,
               destAuthentication
             ).then(() => {


### PR DESCRIPTION
* Changed sending of resources to a Solution during Solution creation. Previously, only the resources from a single item were zipped. Now, resources are accumulated from all items and are zipped together.
* Fetch resources from source items to make sure that they exist before adding a reference to them in the created Solution. Previously, a reference to an item's resource was added to the item's template and fetching occurred later--when the item's resources were to be fetched, zipped, and sent to the created Solution. Now, the resource file itself is collected when the item's template is created (not just the path to it) and only zipping and sending occur at the end of the creation process.

see issue #679