### PR TITLE
Modify MIME type handling for Firefox

### DIFF
--- a/packages/common/src/restHelpersGet.ts
+++ b/packages/common/src/restHelpersGet.ts
@@ -829,7 +829,12 @@ export function getThumbnailFile(
  */
 export function _fixTextBlobType(blob: Blob): Promise<Blob> {
   return new Promise<Blob>((resolve, reject) => {
-    if (blob && blob.size > 0 && blob.type.startsWith("text/plain")) {
+    if (
+      blob &&
+      blob.size > 0 &&
+      (blob.type.startsWith("text/plain") ||
+        blob.type.startsWith("application/json"))
+    ) {
       blobToText(blob).then(
         blobText => {
           // Convertible to JSON?


### PR DESCRIPTION
Firefox is handling "application/json" files in a way that causes them to be rejected. This change treats "application/json" the same as "text/plain".