### PR TITLE
B/do not share forms and their deps to site groups 2

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -23,10 +23,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"@types/adlib": "^3.0.1",
 				"rollup": "^1.22.0"
 			},
@@ -36,10 +36,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-html-sanitizer": {
@@ -123,9 +123,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -156,9 +156,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -173,9 +173,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -473,9 +473,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -485,27 +485,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "@types/adlib": "^3.0.1",
     "rollup": "^1.22.0"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/arcgis-html-sanitizer": "~2.5.0",

--- a/packages/creator/package-lock.json
+++ b/packages/creator/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/creator/package.json
+++ b/packages/creator/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/feature-layer/package-lock.json
+++ b/packages/feature-layer/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/feature-layer/package.json
+++ b/packages/feature-layer/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/file/package-lock.json
+++ b/packages/file/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/form/package-lock.json
+++ b/packages/form/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/group/package-lock.json
+++ b/packages/group/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/hub-types/package-lock.json
+++ b/packages/hub-types/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/hub-types/package.json
+++ b/packages/hub-types/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",

--- a/packages/viewer/package-lock.json
+++ b/packages/viewer/package-lock.json
@@ -17,10 +17,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3",
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4",
 				"rollup": "^1.22.0",
 				"typescript": "^4.3.4"
 			},
@@ -30,10 +30,10 @@
 				"@esri/arcgis-rest-portal": "3.4.1",
 				"@esri/arcgis-rest-request": "3.4.1",
 				"@esri/arcgis-rest-service-admin": "3.4.1",
-				"@esri/hub-common": "9.1.3",
-				"@esri/hub-initiatives": "9.1.3",
-				"@esri/hub-sites": "9.1.3",
-				"@esri/hub-teams": "9.1.3"
+				"@esri/hub-common": "9.1.4",
+				"@esri/hub-initiatives": "9.1.4",
+				"@esri/hub-sites": "9.1.4",
+				"@esri/hub-teams": "9.1.4"
 			}
 		},
 		"node_modules/@esri/arcgis-rest-auth": {
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"node_modules/@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"dependencies": {
 				"abab": "^2.0.5",
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^1.13.0"
@@ -326,9 +326,9 @@
 			"dev": true
 		},
 		"@esri/hub-common": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.3.tgz",
-			"integrity": "sha512-jUjhgBUY5JSgpOBC2J5HdszAk0SHYhLPeRo9F3pnV5vMx4tnWXB/HwyT5kJNMeADeBn8fHSP8ymR2Zjj+4LxKA==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-common/-/hub-common-9.1.4.tgz",
+			"integrity": "sha512-RaJk00EbN4qc359KiShVkrTzlPOwA1kMax5cVtWampZ2ukPin5U43VsygLuBHfYht58JANQHp6qIL0sP6jJzQQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.5",
@@ -338,27 +338,27 @@
 			}
 		},
 		"@esri/hub-initiatives": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.3.tgz",
-			"integrity": "sha512-MpVFwwi+ZXKfWwSUdVps/0stHwo4K23Q0UzJ2zAl6Fkltp2/o1kLI5jrsfUH4VML5WV/BRe5LGL1lKYd/KgUWw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-initiatives/-/hub-initiatives-9.1.4.tgz",
+			"integrity": "sha512-dV7zvhUmwUcXoWBpF5434PQ8H1VO2kKsZXPPzEOr573j+OVHgnxplTFw4PojLqJilQhsM+90rfrbgY05sWk3WA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-sites": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.3.tgz",
-			"integrity": "sha512-pIxoB7sW9f4qqi95nBCEHFM7f/2DJ32Eft4NmLRUuEYRRql5l+c0OEGav+UfQSL7CxTuwC3P8HalgJmaK72aGg==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-sites/-/hub-sites-9.1.4.tgz",
+			"integrity": "sha512-RhDjp86d4Ac0tgn7lgAkOf/MW4o5C18XC0bNgCnq0cKM8k+Rm5y9YEXOA9+ngU+ErWmHTcWfkGIe2kz13iaACQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"
 			}
 		},
 		"@esri/hub-teams": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.3.tgz",
-			"integrity": "sha512-f3g1z6h0QbbV7mDBEcpCQk/l9OdnuWle3SbVimMeO/Rvaqi5nCBZ46oxv15YEFXxg+BkzmMwKsDDhjmbQe8q9w==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/@esri/hub-teams/-/hub-teams-9.1.4.tgz",
+			"integrity": "sha512-KP6mRk+CTeWelAgamSVwpsagaVXeC7C/2+14IYyt+2geWxY8CdLxhN/cENRrr2dCJLnOaq3pxI9MJ3wcvGl0RQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.13.0"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -18,10 +18,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3",
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4",
     "rollup": "^1.22.0",
     "typescript": "^4.3.4"
   },
@@ -31,10 +31,10 @@
     "@esri/arcgis-rest-portal": "3.4.1",
     "@esri/arcgis-rest-request": "3.4.1",
     "@esri/arcgis-rest-service-admin": "3.4.1",
-    "@esri/hub-common": "9.1.3",
-    "@esri/hub-initiatives": "9.1.3",
-    "@esri/hub-sites": "9.1.3",
-    "@esri/hub-teams": "9.1.3"
+    "@esri/hub-common": "9.1.4",
+    "@esri/hub-initiatives": "9.1.4",
+    "@esri/hub-sites": "9.1.4",
+    "@esri/hub-teams": "9.1.4"
   },
   "dependencies": {
     "@esri/solution-common": "^1.1.2",


### PR DESCRIPTION
[Hub issue 2325](https://devtopia.esri.com/dc/hub/issues/2325)

Due to security concerns, we should not automatically share `Form` items, or any of their dependent `Feature Service`s to site groups.