### PR TITLE
Include defaults when not specified in ISearchOptions

### DIFF
--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -341,14 +341,20 @@ export function convertToISearchOptions(
   };
 
   if (typeof search === "string") {
+    // Insert query into defaults
     searchOptions.q = search;
 
   } else if (search instanceof SearchQueryBuilder) {
+    // Insert query into defaults
     searchOptions.q = search.toParam();
 
   } else { // search is ISearchOptions
-    searchOptions = search;
+    searchOptions = {
+      ...searchOptions, // defaults
+      ...search // request
+    }
   }
+
 
   return searchOptions;
 }

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -579,6 +579,20 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
       expect(constructedOptions).toEqual(expectedOptions);
     });
 
+    it("can handle an ISearchOptions with defaults", () => {
+      const q = "my search";
+      const search = {
+        q
+      } as portal.ISearchOptions;
+      const expectedOptions = {
+        q,
+        start: 1,
+        num: 100
+      } as portal.ISearchOptions;
+      const constructedOptions = restHelpers.convertToISearchOptions(search);
+      expect(constructedOptions).toEqual(expectedOptions);
+    });
+
     it("can handle a SearchQueryBuilder", () => {
       const q = "my search";
       const search = new portal.SearchQueryBuilder().match(q)


### PR DESCRIPTION
One can call `common` function `convertToISearchOptions` with three variants:
* a query string
* an ISearchOptions structure
* a SearchQueryBuilder instance

For ISearchOptions, one does not have to supply the `start` or `num` properties, and so `convertToISearchOptions` provides default values (1 and 100) for these properties.