### PR TITLE
Updated deploySolution demo with additional Solutions group

### DIFF
--- a/demos/deploySolution/data/appConfig.js
+++ b/demos/deploySolution/data/appConfig.js
@@ -1,3 +1,4 @@
 const appConfig = {
-    "solutionsGroupId" : "966b251241bb4e3bb9ee3f2b92921aa5"
+  "primarySolutionsGroupId" : "966b251241bb4e3bb9ee3f2b92921aa5",
+  "agoBasedEnterpriseSolutionsGroupId": "133b192ad9354e428ec650c01e0df5ad"
 }

--- a/demos/deploySolution/index.html
+++ b/demos/deploySolution/index.html
@@ -200,11 +200,12 @@
 
 
         // Populate solution picklist
-        const groupId = appConfig.solutionsGroupId;
         const solutionsSelect = document.getElementById("solutionPicklist");
         solutionsSelect.add(document.createElement("option"));
 
-        main.getTemplates(groupId).then((solutions) => {
+        main.getTemplates(
+          appConfig.primarySolutionsGroupId, appConfig.agoBasedEnterpriseSolutionsGroupId
+        ).then((solutions) => {
           solutions.forEach((solution) => {
             var option = document.createElement("option");
             option.value = solution.id


### PR DESCRIPTION
The deploySolution demo needed to be configured to support the change in the name of the property holding the primary group of Solution templates as well as to include the property for the additional (Enterprise) group of templates.

The two sets are each in alphabetical order by title. The sets are displayed in the dropdown sequentially to make the source of the template clearer.