### PR TITLE
Update deploySolution plus test updates to get them to pass

### DIFF
--- a/demos/deploySolution/data/appConfig.js
+++ b/demos/deploySolution/data/appConfig.js
@@ -1,4 +1,4 @@
 const appConfig = {
-  "primarySolutionsGroupId" : "966b251241bb4e3bb9ee3f2b92921aa5",
+  "primarySolutionsGroupId" : "",
   "agoBasedEnterpriseSolutionsGroupId": "133b192ad9354e428ec650c01e0df5ad"
 }

--- a/jasmine.json
+++ b/jasmine.json
@@ -3,5 +3,6 @@
   "spec_files": ["*/test/**/*.test.ts"],
   "helpers": ["../support/test-helpers.js"],
   "stopSpecOnExpectationFailure": false,
-  "random": false
+  "random": true,
+  "verboseDeprecations": true
 }

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -1955,9 +1955,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
 
       restHelpers
         .convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION)
-        .then(_extent => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("can handle unmatched wkid and failure on findTransformations", done => {
@@ -1976,9 +1981,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
 
       restHelpers
         .convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION)
-        .then(_extent => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 
@@ -2142,7 +2152,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           geometryServiceUrl,
           MOCK_USER_SESSION
         )
-        .then(done.fail, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 
@@ -3595,7 +3612,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
 
       restHelpers
         .updateGroup(grp, MOCK_USER_SESSION)
-        .then(() => done.fail, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 
@@ -4731,7 +4755,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         );
       restHelpers
         ._getCreateServiceOptions(itemTemplate, userSession, templateDictionary)
-        .then(done.fail, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 

--- a/packages/common/test/workforceHelpers.test.ts
+++ b/packages/common/test/workforceHelpers.test.ts
@@ -44,7 +44,14 @@ describe("Module `workforceHelpers`: manages the creation and deployment of work
     it("will handle no edits", done => {
       workforceHelpers
         ._applyEdits("http://url", [], MOCK_USER_SESSION)
-        .then(done, done.fail);
+        .then(
+          () => {
+            done();
+          },
+          () => {
+            done.fail();
+          }
+        );
     });
   });
   describe("_extractDependencies", () => {
@@ -361,7 +368,14 @@ describe("Module `workforceHelpers`: manages the creation and deployment of work
 
       workforceHelpers
         .getWorkforceServiceInfo(props, url, MOCK_USER_SESSION)
-        .then(() => done.fail, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("can handle _getAssignmentIntegrationInfos failure", done => {

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -780,7 +780,14 @@ describe("Module `deploySolutionItems`", () => {
             progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
           }
         )
-        .then(() => done.fail(), done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("can handle error on find items by tag", done => {
@@ -857,7 +864,14 @@ describe("Module `deploySolutionItems`", () => {
             progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
           }
         )
-        .then(() => done.fail(), done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("handles failure to delete all items when unwinding after failure to deploy", done => {
@@ -1152,7 +1166,14 @@ describe("Module `deploySolutionItems`", () => {
             progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
           }
         )
-        .then(() => done.fail(), done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("handle failure to use existing items", done => {
@@ -1231,7 +1252,14 @@ describe("Module `deploySolutionItems`", () => {
             progressCallback: utils.SOLUTION_PROGRESS_CALLBACK
           }
         )
-        .then(() => done.fail(), done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 
@@ -2616,7 +2644,14 @@ describe("Module `deploySolutionItems`", () => {
     it("will handle no custom item id requests", done => {
       deploySolution
         ._setTypekeywordForExisting([], {}, MOCK_USER_SESSION)
-        .then(done);
+        .then(
+          () => {
+            done();
+          },
+          () => {
+            done.fail();
+          }
+        );
     });
   });
 });

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -704,9 +704,14 @@ describe("Module `deployer`", () => {
             };
             deployer
               .deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options)
-              .then(done, e => {
-                done.fail(e);
-              });
+              .then(
+                () => {
+                  done();
+                },
+                e => {
+                  done.fail(e);
+                }
+              );
           },
           e => {
             done.fail(e);
@@ -1028,9 +1033,14 @@ describe("Module `deployer`", () => {
 
       deployer
         .deploySolution(itemInfoCard.id, MOCK_USER_SESSION, options)
-        .then(() => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("can handle error on createItemWithData", done => {

--- a/packages/feature-layer/test/feature-layer.test.ts
+++ b/packages/feature-layer/test/feature-layer.test.ts
@@ -337,9 +337,14 @@ describe("Module `feature-layer`: manages the creation and deployment of feature
           MOCK_USER_SESSION,
           templateDictionary
         )
-        .then(r => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("should handle error on getItemData", done => {
@@ -384,7 +389,14 @@ describe("Module `feature-layer`: manages the creation and deployment of feature
           MOCK_USER_SESSION,
           templateDictionary
         )
-        .then(done, done.fail);
+        .then(
+          () => {
+            done();
+          },
+          e => {
+            done.fail(e);
+          }
+        );
     });
 
     it("should handle error on getServiceLayersAndTables", done => {
@@ -426,9 +438,14 @@ describe("Module `feature-layer`: manages the creation and deployment of feature
           MOCK_USER_SESSION,
           templateDictionary
         )
-        .then(r => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 
@@ -2749,7 +2766,14 @@ describe("Module `feature-layer`: manages the creation and deployment of feature
 
       featureLayer
         .postProcess("", "", [], template, [], {}, MOCK_USER_SESSION)
-        .then(done, done.fail);
+        .then(
+          () => {
+            done();
+          },
+          e => {
+            done.fail(e);
+          }
+        );
     });
   });
 });

--- a/packages/simple-types/test/oic.test.ts
+++ b/packages/simple-types/test/oic.test.ts
@@ -92,33 +92,36 @@ describe("Module `webmap`: manages the creation and deployment of OIC (Oriented 
   });
 
   describe("_extractDependencies", () => {
-    it("handles missing data or properties", done => {
+    it("handles missing data or properties", () => {
       const expectedDependencies = {
         dependencies: [] as string[],
         urlHash: {} as any
       };
+      let itemTemplate: common.IItemTemplate;
 
-      oic
-        ._extractDependencies(templates.getItemTemplateSkeleton(), null)
-        .then(actual => {
-          expect(actual).toEqual(expectedDependencies);
-          done();
-        }, done.fail);
-
-      const itemTemplate = templates.getItemTemplate(
-        "Oriented Imagery Catalog"
-      );
-      itemTemplate.data.properties = null;
-      oic._extractDependencies(itemTemplate, null).then(actual => {
+      return oic._extractDependencies(templates.getItemTemplateSkeleton(), null)
+      .then(actual => {
         expect(actual).toEqual(expectedDependencies);
-        done();
-      }, done.fail);
 
-      itemTemplate.data = null;
-      oic._extractDependencies(itemTemplate, null).then(actual => {
+        itemTemplate = templates.getItemTemplate(
+          "Oriented Imagery Catalog"
+        );
+        itemTemplate.data.properties = null;
+        return oic._extractDependencies(itemTemplate, null);
+      })
+      .then(actual => {
         expect(actual).toEqual(expectedDependencies);
-        done();
-      }, done.fail);
+
+        itemTemplate.data = null;
+        return oic._extractDependencies(itemTemplate, null);
+      })
+      .then(actual => {
+        expect(actual).toEqual(expectedDependencies);
+        return Promise.resolve();
+      })
+      .catch(error => {
+        return Promise.reject(error);
+      });
     });
 
     it("handles both of the URL properties", done => {

--- a/packages/simple-types/test/webmappingapplication.test.ts
+++ b/packages/simple-types/test/webmappingapplication.test.ts
@@ -1143,9 +1143,14 @@ describe("Module `webmappingapplication`: manages the creation and deployment of
 
       webmappingapplication
         .convertItemToTemplate(infoLookupTemplate, MOCK_USER_SESSION, MOCK_USER_SESSION)
-        .then(template => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
   });
 

--- a/packages/simple-types/test/workforce.test.ts
+++ b/packages/simple-types/test/workforce.test.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 
 describe("Module `workforce`: manages the creation and deployment of workforce project item types", () => {
   describe("convertItemToTemplate", () => {
-    it("should extract dependencies", done => {
+    it("should extract dependencies 1", done => {
       const itemTemplate: common.IItemTemplate = mockItems.getAGOLItem(
         "Workforce Project",
         null
@@ -67,8 +67,40 @@ describe("Module `workforce`: manages the creation and deployment of workforce p
 
           expectedDependencies.forEach(d => {
             expect(newDependencies.indexOf(d)).toBeGreaterThan(-1);
-            done();
           });
+          done();
+        }, done.fail);
+    });
+
+    it("should extract dependencies 2", done => {
+      const itemTemplate: common.IItemTemplate = mockItems.getAGOLItem(
+        "Workforce Project",
+        null
+      );
+      itemTemplate.data = mockItems.getAGOLItemData("Workforce Project");
+
+      const expectedDependencies: string[] = [
+        "abc116555b16437f8435e079033128d0",
+        "abc26a244163430590151395821fb845",
+        "abc302ec12b74d2f9f2b3cc549420086",
+        "abc4494043c3459faabcfd0e1ab557fc",
+        "abc5dd4bdd18437f8d5ff1aa2d25fd7c",
+        "abc64329e69144c59f69f3f3e0d45269",
+        "abc715c2df2b466da05577776e82d044",
+        "cad3483e025c47338d43df308c117308",
+        "bad3483e025c47338d43df308c117308"
+      ];
+
+      workforce
+        .convertItemToTemplate(itemTemplate, MOCK_USER_SESSION, MOCK_USER_SESSION)
+        .then(newItemTemplate => {
+          const newDependencies: string[] = newItemTemplate.dependencies;
+          expect(newDependencies.length).toEqual(expectedDependencies.length);
+
+          expectedDependencies.forEach(d => {
+            expect(newDependencies.indexOf(d)).toBeGreaterThan(-1);
+          });
+          done();
         }, done.fail);
     });
 
@@ -169,38 +201,6 @@ describe("Module `workforce`: manages the creation and deployment of workforce p
         }, done.fail);
     });
 
-    it("should extract dependencies", done => {
-      const itemTemplate: common.IItemTemplate = mockItems.getAGOLItem(
-        "Workforce Project",
-        null
-      );
-      itemTemplate.data = mockItems.getAGOLItemData("Workforce Project");
-
-      const expectedDependencies: string[] = [
-        "abc116555b16437f8435e079033128d0",
-        "abc26a244163430590151395821fb845",
-        "abc302ec12b74d2f9f2b3cc549420086",
-        "abc4494043c3459faabcfd0e1ab557fc",
-        "abc5dd4bdd18437f8d5ff1aa2d25fd7c",
-        "abc64329e69144c59f69f3f3e0d45269",
-        "abc715c2df2b466da05577776e82d044",
-        "cad3483e025c47338d43df308c117308",
-        "bad3483e025c47338d43df308c117308"
-      ];
-
-      workforce
-        .convertItemToTemplate(itemTemplate, MOCK_USER_SESSION, MOCK_USER_SESSION)
-        .then(newItemTemplate => {
-          const newDependencies: string[] = newItemTemplate.dependencies;
-          expect(newDependencies.length).toEqual(expectedDependencies.length);
-
-          expectedDependencies.forEach(d => {
-            expect(newDependencies.indexOf(d)).toBeGreaterThan(-1);
-            done();
-          });
-        }, done.fail);
-    });
-
     it("should handle workforce projects without data", done => {
       const itemTemplate: common.IItemTemplate = mockItems.getAGOLItem(
         "Workforce Project"
@@ -245,9 +245,14 @@ describe("Module `workforce`: manages the creation and deployment of workforce p
 
       workforce
         .convertItemToTemplate(itemTemplate, MOCK_USER_SESSION, MOCK_USER_SESSION)
-        .then(() => {
-          done.fail();
-        }, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("should handle url without layer id", done => {
@@ -426,7 +431,14 @@ describe("Module `workforce`: manages the creation and deployment of workforce p
 
       workforce
         .fineTuneCreatedItem(itemTemplate, MOCK_USER_SESSION, {})
-        .then(done.fail, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("should handle error on getUser", done => {
@@ -447,7 +459,14 @@ describe("Module `workforce`: manages the creation and deployment of workforce p
 
       workforce
         .fineTuneCreatedItem(itemTemplate, MOCK_USER_SESSION, {})
-        .then(done.fail, done);
+        .then(
+          () => {
+            done.fail();
+          },
+          () => {
+            done();
+          }
+        );
     });
 
     it("should not update dispatchers service if it contains records", done => {

--- a/packages/velocity/test/velocity-processor.test.ts
+++ b/packages/velocity/test/velocity-processor.test.ts
@@ -276,11 +276,14 @@ describe("convertItemToTemplate", () => {
       agolItems.get500Failure()
     );
 
-    convertItemToTemplate(solutionItemId, itemInfo, MOCK_USER_SESSION, MOCK_USER_SESSION, {}).then(
+    convertItemToTemplate(solutionItemId, itemInfo, MOCK_USER_SESSION, MOCK_USER_SESSION, {})
+    .then(
       () => {
         done.fail();
       },
-      done
+      () => {
+        done();
+      }
     );
   });
 
@@ -298,11 +301,14 @@ describe("convertItemToTemplate", () => {
       }
     );
 
-    convertItemToTemplate(solutionItemId, itemInfo, MOCK_USER_SESSION, MOCK_USER_SESSION, {}).then(
+    convertItemToTemplate(solutionItemId, itemInfo, MOCK_USER_SESSION, MOCK_USER_SESSION, {})
+    .then(
       () => {
         done.fail();
       },
-      done
+      () => {
+        done();
+      }
     );
   });
 });
@@ -550,7 +556,14 @@ describe("createItemFromTemplate", () => {
       templateDictionary,
       destinationAuthentication,
       utils.ITEM_PROGRESS_CALLBACK
-    ).then(() => done.fail, done);
+    ).then(
+      () => {
+        done.fail();
+      },
+      () => {
+        done();
+      }
+    );
   });
 });
 
@@ -580,7 +593,7 @@ describe("postProcess", () => {
     const url: string = "https://myorg.maps.arcgis.com/sharing/rest/content/users/casey/items/thisismyitemid/"
 
     fetchMock.post(
-      `${url}move`, 
+      `${url}move`,
       {success: true}
     )
     .post(


### PR DESCRIPTION
1. Only query the alternate group for the deploySolution demo to illustrate that the two groups are independent.
2. Fix Jasmine deprecations:
  * DEPRECATION: Any argument passed to a done callback will be treated as an error in a future release. Call the done callback without arguments if you don't want to trigger a spec failure.
  * DEPRECATION: An asynchronous function called its 'done' callback more than once. This is a bug in the spec, beforeAll, beforeEach, afterAll, or afterEach function in question. This will be treated as an error in a future version. See<https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#deprecations-due-to-calling-done-multiple-times> for more information.
3. Switched to random unit-test ordering, which may help to flush out problems when tests aren't fully independent.