### PR TITLE
fix source code links in API Reference

### DIFF
--- a/docs/src/api/_declaration.html
+++ b/docs/src/api/_declaration.html
@@ -592,7 +592,7 @@
   {% endfor %}
 {% endif %}
 
-<small class="font-size--2">{{kindString}} defined in <a href="https://github.com/Esri/solution.js/blob/master/{{sources[0].fileName}}#L{{sources[0].line}}">packages/{{sources[0].fileName}}:{{sources[0].line}}</a></small>
+<small class="font-size--2">{{kindString}} defined in <a href="https://github.com/Esri/solution.js/blob/master/packages/{{sources[0].fileName}}#L{{sources[0].line}}">packages/{{sources[0].fileName}}:{{sources[0].line}}</a></small>
 
 {% if isDev %}
   <details class="leader-1">


### PR DESCRIPTION
The links to source code in API Reference seem to be missing the `packages/` subdirectory.