### PR TITLE
Fix updating resource

### DIFF
--- a/packages/common/src/resourceHelpers.ts
+++ b/packages/common/src/resourceHelpers.ts
@@ -497,7 +497,7 @@ export function removeItemResourceFile(
  * Updates the item's resource that matches the filename with new content
  *
  * @param itemId Id of the item to update
- * @param filename Name of the resource file to update
+ * @param filename Name of the resource file to update; prefix optional (e.g., a/b/file.txt)
  * @param resource The new content to update the resource with
  * @param authentication Credentials for the request to the storage
  * @returns A promise which resolves with a success true/false response
@@ -508,9 +508,15 @@ export function updateItemResourceFile(
   resource: File,
   authentication: UserSession
 ): Promise<IItemResourceResponse> {
+  // Prefix has to be specified separately
+  const prefixedFilenameParts = filename.split("/");
+  const prefix = prefixedFilenameParts.length > 1 ? prefixedFilenameParts.slice(0, prefixedFilenameParts.length - 1).join("/") : undefined;
+  const suffix = prefixedFilenameParts[prefixedFilenameParts.length - 1];
+
   return updateItemResource({
     id: itemId,
-    name: filename,
+    prefix: prefix,
+    name: suffix,
     resource,
     authentication: authentication
   } as IItemResourceOptions);

--- a/packages/common/test/resourceHelpers.test.ts
+++ b/packages/common/test/resourceHelpers.test.ts
@@ -1530,7 +1530,38 @@ describe("Module `resourceHelpers`: common functions involving the management of
           const restjsArg = resourceHelpersSpy.calls.argsFor(0)[0];
           expect(restjsArg).toEqual({
             id: itemId,
+            prefix: undefined,
             name: filename,
+            resource: utils.getSampleImageAsFile(),
+            authentication: MOCK_USER_SESSION
+          });
+          done();
+        },
+        done.fail
+      );
+    });
+
+    it("correctly maps call with prefixed filename", done => {
+      const itemId = "abcde";
+      const filename = "fghij/folder/myfile";
+
+      const resourceHelpersSpy = spyOn(
+        portal,
+        "updateItemResource"
+      ).and.resolveTo({
+        success: true,
+        itemId,
+        owner: "Fred",
+        folder: "MGM"
+      } as portal.IItemResourceResponse);
+      resourceHelpers.updateItemResourceFile(itemId, filename, utils.getSampleImageAsFile(), MOCK_USER_SESSION)
+      .then(
+        () => {
+          const restjsArg = resourceHelpersSpy.calls.argsFor(0)[0];
+          expect(restjsArg).toEqual({
+            id: itemId,
+            prefix: "fghij/folder",
+            name: "myfile",
             resource: utils.getSampleImageAsFile(),
             authentication: MOCK_USER_SESSION
           });


### PR DESCRIPTION
Function wasn't properly handling prefixed filenames, e.g., "a/b/file.txt"