### PR TITLE
Remove references to Coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The API is divided into packages to make it easier to use just the parts that yo
 * `velocity`, which contains functions to support ArcGIS Velocity items
 * `viewer`, which contains functions to support displaying Solution items
 * `web-experience`, which contains functions for Experience Builder items
+* `workflow`, which contains functions for Workflow items
 
 #### Additional information
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-common.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-common/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/creator/README.md
+++ b/packages/creator/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-creator.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-creator/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/deployer/README.md
+++ b/packages/deployer/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-deployer.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-deployer/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/feature-layer/README.md
+++ b/packages/feature-layer/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-feature-layer.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-feature-layer/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/file/README.md
+++ b/packages/file/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-simple-types.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-simple-types/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-form.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-form/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/group/README.md
+++ b/packages/group/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-group.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-group/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/hub-types/README.md
+++ b/packages/hub-types/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-storymap.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-storymap/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/simple-types/README.md
+++ b/packages/simple-types/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-simple-types.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-simple-types/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/storymap/README.md
+++ b/packages/storymap/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-storymap.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-storymap/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/velocity/README.md
+++ b/packages/velocity/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-velocity.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-velocity/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-viewer.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-viewer/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/web-experience/README.md
+++ b/packages/web-experience/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-web-experience.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-storymap/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -1,7 +1,6 @@
 [![npm status][npm-img]][npm-url]
 [![Build status][travis-img]][travis-url]
 [![gzip bundle size][gzip-img]][npm-url]
-[![Coverage status][coverage-img]][coverage-url]
 [![Apache 2.0 licensed][license-img]][license-url]
 
 [npm-img]: https://img.shields.io/npm/v/@esri/solution-workflow.svg?style=round-square&color=blue
@@ -9,8 +8,6 @@
 [travis-img]: https://img.shields.io/travis/com/Esri/solution.js/develop.svg
 [travis-url]: https://travis-ci.org/Esri/solution.js
 [gzip-img]: https://img.badgesize.io/https://unpkg.com/@esri/solution-storymap/dist/esm/index.js?compression=gzip
-[coverage-img]: https://coveralls.io/repos/github/Esri/solution.js/badge.svg
-[coverage-url]: https://coveralls.io/github/Esri/solution.js
 [license-img]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: #license
 


### PR DESCRIPTION
Because we no longer use Coveralls (we use Codecov), these values aren't being updated. Codecov does not appear to do package-level coverage.