### PR TITLE
Changed spatial ref `required` property to match existing manual settings

### DIFF
--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -1306,7 +1306,7 @@ export interface ISolutionItemDataWkidParams {
  * Attributes of the default spatial reference for a solution item.
  */
 export interface ISolutionItemDataWkidAttrsParams {
-  required: boolean;
+  required: string;
 }
 
 /**


### PR DESCRIPTION
Trivial editing change; significant functional change