### PR TITLE
Updated axios due to security flaw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/node": "^20.12.11",
         "@typescript-eslint/eslint-plugin": "^7.9.0",
         "@typescript-eslint/parser": "^7.9.0",
+        "axios": "^1.7.4",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
@@ -5242,9 +5243,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/node": "^20.12.11",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
+    "axios": "^1.7.4",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
retire.js reported a security flaw in the axios package:
> axios 1.7.3 has known vulnerabilities: severity: high; summary: Server-Side Request Forgery in axios, CVE: CVE-2024-39338, githubID: GHSA-8hc4-vh64-cxmj; https://github.com/advisories/GHSA-8hc4-vh64-cxmj https://nvd.nist.gov/vuln/detail/CVE-2024-39338 https://github.com/axios/axios/issues/6463 https://github.com/axios/axios/pull/6539 https://github.com/axios/axios/pull/6543 https://github.com/axios/axios/commit/6b6b605eaf73852fb2dae033f1e786155959de3a https://github.com/axios/axios https://github.com/axios/axios/releases https://github.com/axios/axios/releases/tag/v1.7.4 https://jeffhacks.com/advisories/2024/06/24/CVE-2024-39338.html

axios is only used by lerna, which we're using at its latest version.  Updated axios, and lerna accepted it.