### PR TITLE
Add extra typeKeywords checking

### DIFF
--- a/packages/creator/src/creator.ts
+++ b/packages/creator/src/creator.ts
@@ -326,7 +326,10 @@ export function _createSolutionItemModel(options: any): IModel {
     },
     thumbnailurl: options?.thumbnailurl ?? "",
     tags: creationTags.filter((tag: any) => !tag.startsWith("deploy.")),
-    typeKeywords: options?.typeKeywords ?? ["Solution", "Template"].concat(_getDeploymentProperties(creationTags)),
+    typeKeywords:
+      !options?.typeKeywords || !options.typeKeywords.some((keyword) => keyword.includes("solutionid"))
+        ? ["Solution", "Template"].concat(_getDeploymentProperties(creationTags))
+        : options.typeKeywords,
     categories: options?.categories ?? [],
     licenseInfo: options?.licenseInfo ?? "",
   };

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -1138,6 +1138,24 @@ describe("Module `creator`", () => {
       } as hubCommon.IModel);
     });
 
+    it("returns a model, with the same typeKeywords", () => {
+      const opts = {
+        title: "The Title",
+        snippet: "The Snippet",
+        description: "The Desc",
+        thumbnailurl: "https://some.com/thumbnail.jpg",
+        tags: ["deploy.id.3ef"],
+        typeKeywords: ["Solution", "Template", "solutionid-3ef", "solutionversion-1.0", "foo", "bar"],
+        licenseInfo: "arcgis",
+        properties: {
+          schemaVersion: common.CURRENT_SCHEMA_VERSION,
+          relatedSolutions: ["123456"],
+        },
+      };
+      const chk = creator._createSolutionItemModel(opts);
+      expect(chk.item.typeKeywords?.length).toBe(6);
+    });
+
     it("sanitizes the item", () => {
       spyOn(console, "warn").and.callFake(() => {});
       const opts = {


### PR DESCRIPTION
Added check to see if solutionid keyword exists. If it does, it's a deployed solution so just take it, otherwise generate a solutionid since it is probably a new solutiuon.

addresses issue https://devtopia.esri.com/WebGIS/solution-deployment-apps/issues/268#issuecomment-5327244