### PR TITLE
Switched `findTransformations` and `project` to GET calls

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,7 +81,7 @@ module.exports = function(config) {
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     //reporters: ["spec", "karma-typescript", "coverage"],
-     reporters: ["dots", "karma-typescript", "coverage"],
+    reporters: ["dots", "karma-typescript", "coverage"],
     coverageReporter: {
       // specify a common output directory
       dir: 'coverage',

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -446,7 +446,10 @@ export function convertExtent(
   geometryServiceUrl: string,
   authentication: UserSession,
 ): Promise<any> {
-  const _requestOptions: any = { authentication };
+  const _requestOptions: any = {
+    authentication,
+    httpMethod: "GET",
+  };
   return new Promise<any>((resolve, reject) => {
     if (extent.spatialReference.wkid === outSR?.wkid || !outSR) {
       resolve(extent);

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -549,8 +549,12 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
         .post(utils.PORTAL_SUBSET.restUrl + "/content/users/casey/aabb123456/createService", mockItems.get400Failure())
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=-1&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
+          mockItems.get400Failure(),
+        )
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=4326&outSR=-1&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
           mockItems.get400Failure(),
         );
 
@@ -1510,18 +1514,18 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", {
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D", {
           transformations: [
             {
               wkid: 3,
             },
           ],
         })
-        .post(geometryServiceUrl + "/project", {
+        .get(geometryServiceUrl + "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=3", {
           geometries: projectedGeometries,
         })
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1534,18 +1538,18 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", {
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D", {
           transformations: [
             {
               geoTransforms: 3,
             },
           ],
         })
-        .post(geometryServiceUrl + "/project", {
+        .get(geometryServiceUrl + "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=%7B%22geoTransforms%22%3A3%7D", {
           geometries: projectedGeometries,
         })
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1558,12 +1562,12 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", {})
-        .post(geometryServiceUrl + "/project", {
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D", {})
+        .get(geometryServiceUrl + "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D", {
           geometries: projectedGeometries,
         })
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1576,14 +1580,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", {
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D", {
           transformations: [{}],
         })
-        .post(geometryServiceUrl + "/project", {
+        .get(geometryServiceUrl + "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D", {
           geometries: projectedGeometries,
         })
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1596,18 +1600,18 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", {
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D", {
           transformations: [
             {
               wkid: 3,
             },
           ],
         })
-        .post(geometryServiceUrl + "/project", {
+        .get(geometryServiceUrl + "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=3", {
           geometries: [],
         })
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       const expected: any = undefined;
 
@@ -1622,16 +1626,17 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", {
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D", {
           transformations: [
             {
               wkid: 3,
             },
           ],
         })
-        .post(geometryServiceUrl + "/project", mockItems.get400Failure())
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=3",
+          mockItems.get400Failure())
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       await expectAsync(
         restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION),
@@ -1645,9 +1650,10 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", mockItems.get400Failure())
-        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .post(geometryServiceUrl + "/project/rest/info", "{}");
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
+          mockItems.get400Failure())
+        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .get(geometryServiceUrl + "/project/rest/info", "{}");
 
       await expectAsync(
         restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION),
@@ -1685,16 +1691,17 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
-        .post(geometryServiceUrl + "/findTransformations", {})
-        .postOnce(
-          geometryServiceUrl + "/project",
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmax%22%3A180%2C%22xmin%22%3A-180%2C%22ymax%22%3A90%2C%22ymin%22%3A-90%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", {})
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", {})
+        .getOnce(
+          geometryServiceUrl + "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-180%2C%22y%22%3A-90%7D%2C%7B%22x%22%3A180%2C%22y%22%3A90%7D%5D%7D",
           {
             geometries: NaNGeoms,
           },
           { overwriteRoutes: false },
         )
-        .postOnce(
-          geometryServiceUrl + "/project",
+        .getOnce(
+          geometryServiceUrl + "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-179%2C%22y%22%3A-89%7D%2C%7B%22x%22%3A179%2C%22y%22%3A89%7D%5D%7D",
           {
             geometries: projectedGeometries,
           },
@@ -1740,9 +1747,10 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
-        .post(geometryServiceUrl + "/findTransformations", {})
-        .postOnce(
-          geometryServiceUrl + "/project",
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmax%22%3A180%2C%22xmin%22%3A-180%2C%22ymax%22%3A90%2C%22ymin%22%3A-90%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", {})
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", {})
+        .getOnce(
+          geometryServiceUrl + "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-180%2C%22y%22%3A-90%7D%2C%7B%22x%22%3A180%2C%22y%22%3A90%7D%5D%7D",
           {
             geometries: NaNGeoms,
           },
@@ -1787,15 +1795,17 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
-        .post(geometryServiceUrl + "/findTransformations", {})
-        .postOnce(
-          geometryServiceUrl + "/project",
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmax%22%3A180%2C%22xmin%22%3A-180%2C%22ymax%22%3A90%2C%22ymin%22%3A-90%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", {})
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", {})
+        .getOnce(
+          geometryServiceUrl + "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-180%2C%22y%22%3A-90%7D%2C%7B%22x%22%3A180%2C%22y%22%3A90%7D%5D%7D",
           {
             geometries: NaNGeoms,
           },
           { overwriteRoutes: false },
         )
-        .postOnce(geometryServiceUrl + "/project", mockItems.get400Failure(), {
+        .getOnce(geometryServiceUrl + "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-179%2C%22y%22%3A-89%7D%2C%7B%22x%22%3A179%2C%22y%22%3A89%7D%5D%7D",
+          mockItems.get400Failure(), {
           overwriteRoutes: false,
         });
 
@@ -3733,7 +3743,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         wkid: 102100,
       };
 
-      fetchMock.post(geometryServiceUrl + "/findTransformations", "{}");
+      fetchMock.get(geometryServiceUrl + "/findTransformations", "{}");
 
       const options = await restHelpers._getCreateServiceOptions(itemTemplate, userSession, templateDictionary);
       expect(options).toEqual({
@@ -3799,7 +3809,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         solutionItemExtent: solutionItemExtent,
       };
 
-      fetchMock.post(
+      fetchMock.get(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -3877,7 +3887,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         },
       };
 
-      fetchMock.post(
+      fetchMock.get(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -3946,7 +3956,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         solutionItemExtent: solutionItemExtent,
       };
 
-      fetchMock.post(
+      fetchMock.get(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -4020,7 +4030,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         solutionItemExtent: solutionItemExtent,
       };
 
-      fetchMock.post(
+      fetchMock.get(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -4099,7 +4109,8 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .post(geometryServiceUrl + "/findTransformations", mockItems.get400Failure())
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=102100&outSR=3857&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D", mockItems.get400Failure())
+        .get(geometryServiceUrl + "/findTransformations?f=json&inSR=4326&outSR=3857&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D", mockItems.get400Failure())
         .post(
           "http://utility/geomServer/findTransformations/rest/info",
           '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',

--- a/packages/creator/test/creator.test.ts
+++ b/packages/creator/test/creator.test.ts
@@ -1331,6 +1331,7 @@ describe("Module `creator`", () => {
       };
 
       spyOn(common, "getItemDataAsJson").and.callFake(() => Promise.resolve(null));
+      const consoleSpy = spyOn(console, "error").and.callFake(() => {});
 
       const chk = await creator._updateCreateOptionForReDeployedTemplate(
         sourceItem.id,
@@ -1339,6 +1340,8 @@ describe("Module `creator`", () => {
         sourceItem,
       );
       expect(chk).toEqual(createOptions);
+      expect(consoleSpy.calls.count()).withContext("should call console.log once").toBe(1);
+      expect(consoleSpy.calls.argsFor(0)[0]).toBe("Item data does not exists, returning create options");
     });
     it("canot get Item Data", async () => {
       const sourceItem = {

--- a/packages/deployer/test/deploySolutionFromTemplate.test.ts
+++ b/packages/deployer/test/deploySolutionFromTemplate.test.ts
@@ -206,16 +206,16 @@ describe("Module `deploySolutionFromTemplate`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/loc1234567890?f=json&token=fake-token",
           testUtils.getSuccessResponse(),
         )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
           testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
           testUtils.getCreateFolderResponse(folderId),
         )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
           testUtils.getProjectResponse(),
         )
         .post(
@@ -287,16 +287,16 @@ describe("Module `deploySolutionFromTemplate`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/loc1234567890?f=json&token=fake-token",
           testUtils.getSuccessResponse(),
         )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
           testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
           testUtils.getCreateFolderResponse(folderId),
         )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
           testUtils.getProjectResponse(),
         )
         .post(
@@ -392,16 +392,16 @@ describe("Module `deploySolutionFromTemplate`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/loc1234567890?f=json&token=fake-token",
           testUtils.getSuccessResponse(),
         )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
           testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
           testUtils.getCreateFolderResponse(folderId),
         )
-        .post(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
+        .get(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
           testUtils.getProjectResponse(),
         )
         .post(

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -279,8 +279,8 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .post(geometryServer + "/project", testUtils.getProjectResponse())
+        .get(geometryServer + "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D", testUtils.getTransformationsResponse())
+        .get(geometryServer + "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D", testUtils.getProjectResponse())
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
           testUtils.getSuccessResponse({
@@ -748,8 +748,8 @@ describe("Module `deployer`", () => {
         )
         .post(imageUrl, expectedImage)
         .post(imageUrl2, expectedImage)
-        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .post(
+        .get(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
+        .get(
           "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
           testUtils.getProjectResponse(),
         )
@@ -852,8 +852,8 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .post(geometryServer + "/project", testUtils.getProjectResponse())
+        .get(geometryServer + "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D", testUtils.getTransformationsResponse())
+        .get(geometryServer + "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D", testUtils.getProjectResponse())
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
           mockItems.get200Failure(),
@@ -965,7 +965,7 @@ describe("Module `deployer`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/" + itemInfo.item.id + "/info/metadata/metadata.xml",
           mockItems.get400Failure(),
         )
-        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
+        .get(geometryServer + "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D", testUtils.getTransformationsResponse())
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
           testUtils.getSuccessResponse({
@@ -1021,7 +1021,7 @@ describe("Module `deployer`", () => {
           "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/refresh",
           testUtils.getSuccessResponse(),
         )
-        .post(geometryServer + "/project", mockItems.get400Failure())
+        .get(geometryServer + "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D", mockItems.get400Failure())
         .get(
           "https://myorg.maps.arcgis.com/sharing/rest/content/items/svc1234567890?f=json&token=fake-token",
           testUtils.getCreateServiceResponse(),
@@ -1124,8 +1124,8 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .post(geometryServer + "/project", testUtils.getProjectResponse())
+        .get(geometryServer + "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D", testUtils.getTransformationsResponse())
+        .get(geometryServer + "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D", testUtils.getProjectResponse())
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
           testUtils.getSuccessResponse({
@@ -1284,8 +1284,8 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .post(geometryServer + "/project", testUtils.getProjectResponse())
+        .get(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
+        .get(geometryServer + "/project", testUtils.getProjectResponse())
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
           testUtils.getSuccessResponse({


### PR DESCRIPTION
["Solutions with feature services fail to deploy on Enterprise 11.5 MultiIWA"](https://devtopia.esri.com/WebGIS/solution-deployment-apps/issues/413)

One of the problems is a "401 Unauthorized" response to a `findTransformations` call.  Because the docs say that [`findTransformations`](https://developers.arcgis.com/rest/services-reference/enterprise/findtransformations/) and [`project`](https://developers.arcgis.com/rest/services-reference/enterprise/project/) (its companion in the same function) can be `GET` calls, with this PR I'm switching both from `POST` to `GET` to see if that will help with this problem.