### PR TITLE
Revert switching findTransformations and project from POST to GET

### DIFF
--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -446,10 +446,7 @@ export function convertExtent(
   geometryServiceUrl: string,
   authentication: UserSession,
 ): Promise<any> {
-  const _requestOptions: any = {
-    authentication,
-    httpMethod: "GET",
-  };
+  const _requestOptions: any = { authentication };
   return new Promise<any>((resolve, reject) => {
     if (extent.spatialReference.wkid === outSR?.wkid || !outSR) {
       resolve(extent);

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -549,12 +549,8 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
         .post(utils.PORTAL_SUBSET.restUrl + "/content/users/casey/aabb123456/createService", mockItems.get400Failure())
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=-1&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
-          mockItems.get400Failure(),
-        )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=4326&outSR=-1&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
           mockItems.get400Failure(),
         );
 
@@ -1514,26 +1510,18 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          {
-            transformations: [
-              {
-                wkid: 3,
-              },
-            ],
-          },
-        )
-        .get(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=3",
-          {
-            geometries: projectedGeometries,
-          },
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", {
+          transformations: [
+            {
+              wkid: 3,
+            },
+          ],
+        })
+        .post(geometryServiceUrl + "/project", {
+          geometries: projectedGeometries,
+        })
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1546,26 +1534,18 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          {
-            transformations: [
-              {
-                geoTransforms: 3,
-              },
-            ],
-          },
-        )
-        .get(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=%7B%22geoTransforms%22%3A3%7D",
-          {
-            geometries: projectedGeometries,
-          },
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", {
+          transformations: [
+            {
+              geoTransforms: 3,
+            },
+          ],
+        })
+        .post(geometryServiceUrl + "/project", {
+          geometries: projectedGeometries,
+        })
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1578,20 +1558,12 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          {},
-        )
-        .get(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D",
-          {
-            geometries: projectedGeometries,
-          },
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", {})
+        .post(geometryServiceUrl + "/project", {
+          geometries: projectedGeometries,
+        })
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1604,22 +1576,14 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          {
-            transformations: [{}],
-          },
-        )
-        .get(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D",
-          {
-            geometries: projectedGeometries,
-          },
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", {
+          transformations: [{}],
+        })
+        .post(geometryServiceUrl + "/project", {
+          geometries: projectedGeometries,
+        })
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       const _extent = await restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION);
       expect(_extent).toEqual(expectedExtent);
@@ -1632,26 +1596,18 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          {
-            transformations: [
-              {
-                wkid: 3,
-              },
-            ],
-          },
-        )
-        .get(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=3",
-          {
-            geometries: [],
-          },
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", {
+          transformations: [
+            {
+              wkid: 3,
+            },
+          ],
+        })
+        .post(geometryServiceUrl + "/project", {
+          geometries: [],
+        })
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       const expected: any = undefined;
 
@@ -1666,24 +1622,16 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          {
-            transformations: [
-              {
-                wkid: 3,
-              },
-            ],
-          },
-        )
-        .get(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=1&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-131%2C%22y%22%3A16%7D%2C%7B%22x%22%3A-57%2C%22y%22%3A58%7D%5D%7D&transformation=3",
-          mockItems.get400Failure(),
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", {
+          transformations: [
+            {
+              wkid: 3,
+            },
+          ],
+        })
+        .post(geometryServiceUrl + "/project", mockItems.get400Failure())
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       await expectAsync(
         restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION),
@@ -1697,13 +1645,9 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=1&outSR=2&extentOfInterest=%7B%22xmin%22%3A-131%2C%22ymin%22%3A16%2C%22xmax%22%3A-57%2C%22ymax%22%3A58%2C%22spatialReference%22%3A%7B%22wkid%22%3A1%7D%7D",
-          mockItems.get400Failure(),
-        )
-        .get(geometryServiceUrl + "/findTransformations/rest/info", "{}")
-        .get(geometryServiceUrl + "/project/rest/info", "{}");
+        .post(geometryServiceUrl + "/findTransformations", mockItems.get400Failure())
+        .post(geometryServiceUrl + "/findTransformations/rest/info", "{}")
+        .post(geometryServiceUrl + "/project/rest/info", "{}");
 
       await expectAsync(
         restHelpers.convertExtent(extent, serviceSR, geometryServiceUrl, MOCK_USER_SESSION),
@@ -1741,27 +1685,16 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmax%22%3A180%2C%22xmin%22%3A-180%2C%22ymax%22%3A90%2C%22ymin%22%3A-90%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          {},
-        )
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          {},
-        )
-        .getOnce(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-180%2C%22y%22%3A-90%7D%2C%7B%22x%22%3A180%2C%22y%22%3A90%7D%5D%7D",
+        .post(geometryServiceUrl + "/findTransformations", {})
+        .postOnce(
+          geometryServiceUrl + "/project",
           {
             geometries: NaNGeoms,
           },
           { overwriteRoutes: false },
         )
-        .getOnce(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-179%2C%22y%22%3A-89%7D%2C%7B%22x%22%3A179%2C%22y%22%3A89%7D%5D%7D",
+        .postOnce(
+          geometryServiceUrl + "/project",
           {
             geometries: projectedGeometries,
           },
@@ -1807,19 +1740,9 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmax%22%3A180%2C%22xmin%22%3A-180%2C%22ymax%22%3A90%2C%22ymin%22%3A-90%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          {},
-        )
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          {},
-        )
-        .getOnce(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-180%2C%22y%22%3A-90%7D%2C%7B%22x%22%3A180%2C%22y%22%3A90%7D%5D%7D",
+        .post(geometryServiceUrl + "/findTransformations", {})
+        .postOnce(
+          geometryServiceUrl + "/project",
           {
             geometries: NaNGeoms,
           },
@@ -1864,32 +1787,17 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", SERVER_INFO)
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmax%22%3A180%2C%22xmin%22%3A-180%2C%22ymax%22%3A90%2C%22ymin%22%3A-90%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          {},
-        )
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=2&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          {},
-        )
-        .getOnce(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-180%2C%22y%22%3A-90%7D%2C%7B%22x%22%3A180%2C%22y%22%3A90%7D%5D%7D",
+        .post(geometryServiceUrl + "/findTransformations", {})
+        .postOnce(
+          geometryServiceUrl + "/project",
           {
             geometries: NaNGeoms,
           },
           { overwriteRoutes: false },
         )
-        .getOnce(
-          geometryServiceUrl +
-            "/project?f=json&outSR=2&inSR=4326&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-179%2C%22y%22%3A-89%7D%2C%7B%22x%22%3A179%2C%22y%22%3A89%7D%5D%7D",
-          mockItems.get400Failure(),
-          {
-            overwriteRoutes: false,
-          },
-        );
+        .postOnce(geometryServiceUrl + "/project", mockItems.get400Failure(), {
+          overwriteRoutes: false,
+        });
 
       await expectAsync(
         restHelpers.convertExtentWithFallback(ext, undefined, serviceSR, geometryServiceUrl, MOCK_USER_SESSION),
@@ -3825,7 +3733,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         wkid: 102100,
       };
 
-      fetchMock.get(geometryServiceUrl + "/findTransformations", "{}");
+      fetchMock.post(geometryServiceUrl + "/findTransformations", "{}");
 
       const options = await restHelpers._getCreateServiceOptions(itemTemplate, userSession, templateDictionary);
       expect(options).toEqual({
@@ -3891,7 +3799,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         solutionItemExtent: solutionItemExtent,
       };
 
-      fetchMock.get(
+      fetchMock.post(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -3969,7 +3877,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         },
       };
 
-      fetchMock.get(
+      fetchMock.post(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -4038,7 +3946,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         solutionItemExtent: solutionItemExtent,
       };
 
-      fetchMock.get(
+      fetchMock.post(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -4112,7 +4020,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         solutionItemExtent: solutionItemExtent,
       };
 
-      fetchMock.get(
+      fetchMock.post(
         "http://utility/geomServer/findTransformations/rest/info",
         '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',
       );
@@ -4191,16 +4099,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           utils.getPortalsSelfResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", utils.getPortalsSelfResponse())
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=102100&outSR=3857&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
-          mockItems.get400Failure(),
-        )
-        .get(
-          geometryServiceUrl +
-            "/findTransformations?f=json&inSR=4326&outSR=3857&extentOfInterest=%7B%22xmin%22%3A-179%2C%22xmax%22%3A179%2C%22ymin%22%3A-89%2C%22ymax%22%3A89%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D",
-          mockItems.get400Failure(),
-        )
+        .post(geometryServiceUrl + "/findTransformations", mockItems.get400Failure())
         .post(
           "http://utility/geomServer/findTransformations/rest/info",
           '{"error":{"code":403,"message":"Access not allowed request","details":[]}}',

--- a/packages/deployer/test/deploySolutionFromTemplate.test.ts
+++ b/packages/deployer/test/deploySolutionFromTemplate.test.ts
@@ -206,16 +206,16 @@ describe("Module `deploySolutionFromTemplate`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/loc1234567890?f=json&token=fake-token",
           testUtils.getSuccessResponse(),
         )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
           testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
           testUtils.getCreateFolderResponse(folderId),
         )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
           testUtils.getProjectResponse(),
         )
         .post(
@@ -287,16 +287,16 @@ describe("Module `deploySolutionFromTemplate`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/loc1234567890?f=json&token=fake-token",
           testUtils.getSuccessResponse(),
         )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
           testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
           testUtils.getCreateFolderResponse(folderId),
         )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
           testUtils.getProjectResponse(),
         )
         .post(
@@ -392,16 +392,16 @@ describe("Module `deploySolutionFromTemplate`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/loc1234567890?f=json&token=fake-token",
           testUtils.getSuccessResponse(),
         )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/findTransformations",
           testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/createFolder",
           testUtils.getCreateFolderResponse(folderId),
         )
-        .get(
-          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
+        .post(
+          "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
           testUtils.getProjectResponse(),
         )
         .post(

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -756,8 +756,8 @@ describe("Module `deployer`", () => {
         )
         .post(imageUrl, expectedImage)
         .post(imageUrl2, expectedImage)
-        .get(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .get(
+        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
+        .post(
           "https://utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project",
           testUtils.getProjectResponse(),
         )
@@ -1316,8 +1316,8 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .get(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
-        .get(geometryServer + "/project", testUtils.getProjectResponse())
+        .post(geometryServer + "/findTransformations", testUtils.getTransformationsResponse())
+        .post(geometryServer + "/project", testUtils.getProjectResponse())
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
           testUtils.getSuccessResponse({

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -279,15 +279,11 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .get(
-          geometryServer +
-            "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
-          testUtils.getTransformationsResponse(),
+        .post(
+          geometryServer + "/findTransformations", testUtils.getTransformationsResponse(),
         )
-        .get(
-          geometryServer +
-            "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
-          testUtils.getProjectResponse(),
+        .post(
+          geometryServer + "/project", testUtils.getProjectResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
@@ -860,15 +856,11 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .get(
-          geometryServer +
-            "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
-          testUtils.getTransformationsResponse(),
+        .post(
+          geometryServer + "/findTransformations", testUtils.getTransformationsResponse(),
         )
-        .get(
-          geometryServer +
-            "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
-          testUtils.getProjectResponse(),
+        .post(
+          geometryServer + "/project", testUtils.getProjectResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
@@ -981,10 +973,8 @@ describe("Module `deployer`", () => {
           testUtils.PORTAL_SUBSET.restUrl + "/content/items/" + itemInfo.item.id + "/info/metadata/metadata.xml",
           mockItems.get400Failure(),
         )
-        .get(
-          geometryServer +
-            "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
-          testUtils.getTransformationsResponse(),
+        .post(
+          geometryServer + "/findTransformations", testUtils.getTransformationsResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",
@@ -1041,10 +1031,8 @@ describe("Module `deployer`", () => {
           "https://services123.arcgis.com/org1234567890/arcgis/rest/admin/services/ROWPermits_publiccomment/FeatureServer/refresh",
           testUtils.getSuccessResponse(),
         )
-        .get(
-          geometryServer +
-            "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
-          mockItems.get400Failure(),
+        .post(
+          geometryServer + "/project", mockItems.get400Failure(),
         )
         .get(
           "https://myorg.maps.arcgis.com/sharing/rest/content/items/svc1234567890?f=json&token=fake-token",
@@ -1148,15 +1136,11 @@ describe("Module `deployer`", () => {
           testUtils.getCreateFolderResponse(),
         )
         .post("https://utility.arcgisonline.com/arcgis/rest/info", testUtils.UTILITY_SERVER_INFO)
-        .get(
-          geometryServer +
-            "/findTransformations?f=json&inSR=102100&outSR=4326&extentOfInterest=%7B%22xmin%22%3A-9821384.714217981%2C%22ymin%22%3A5117339.123090005%2C%22xmax%22%3A-9797228.384715842%2C%22ymax%22%3A5137789.39951188%2C%22spatialReference%22%3A%7B%22wkid%22%3A102100%7D%7D",
-          testUtils.getTransformationsResponse(),
+        .post(
+          geometryServer + "/findTransformations", testUtils.getTransformationsResponse(),
         )
-        .get(
-          geometryServer +
-            "/project?f=json&outSR=4326&inSR=102100&geometries=%7B%22geometryType%22%3A%22esriGeometryPoint%22%2C%22geometries%22%3A%5B%7B%22x%22%3A-9821384.714217981%2C%22y%22%3A5117339.123090005%7D%2C%7B%22x%22%3A-9797228.384715842%2C%22y%22%3A5137789.39951188%7D%5D%7D",
-          testUtils.getProjectResponse(),
+        .post(
+          geometryServer + "/project", testUtils.getProjectResponse(),
         )
         .post(
           testUtils.PORTAL_SUBSET.restUrl + "/content/users/casey/a4468da125a64526b359b70d8ba4a9dd/addItem",


### PR DESCRIPTION
Reverting commit a3d1bf6f577a7cdf92d04f43547578d5ae79986f, which was an experiment to see if GET would be more amenable to passing credentials to the affiliated server than POST. That was not the problem, so reverting to original code.