### PR TITLE
Patch getDomainCredentials to handle URLs with mismatching cases

### DIFF
--- a/packages/common/src/arcgisRestJS.ts
+++ b/packages/common/src/arcgisRestJS.ts
@@ -72,7 +72,24 @@ import {
   addToServiceDefinition,
 } from "@esri/arcgis-rest-service-admin";
 
-export { ICredential, IUserRequestOptions, IUserSessionOptions, UserSession } from "@esri/arcgis-rest-auth";
+export { ICredential, IUserRequestOptions, IUserSessionOptions } from "@esri/arcgis-rest-auth";
+
+import { UserSession as UserSession_rest } from "@esri/arcgis-rest-auth";
+UserSession_rest.prototype.getDomainCredentials = function (url) {
+  const trustedDomains: string[] = this["trustedDomains"] || [];
+  if (!trustedDomains || !trustedDomains.length) {
+    return "same-origin";
+  }
+
+  url = url.toLocaleLowerCase();
+  return trustedDomains.some(function (domainWithProtocol: string) {
+    return url.startsWith(domainWithProtocol.toLocaleLowerCase());
+  })
+    ? "include"
+    : "same-origin";
+};
+export { UserSession_rest as UserSession };
+
 export {
   IFeature,
   IQueryRelatedOptions,

--- a/packages/common/test/arcgisRestJS.test.ts
+++ b/packages/common/test/arcgisRestJS.test.ts
@@ -97,4 +97,39 @@ describe("Module arcgisRestJS", () => {
     await arcgisRestJS.unprotectItem(requestOptions);
     expect(unprotectItemSpy.called);
   });
+
+  it("tests getDomainCredentials with no trusted domains property", () => {
+    MOCK_USER_SESSION["trustedDomains"] = undefined;
+    const url: string = "https://www.arcgis.com";
+    const originValue: string = MOCK_USER_SESSION.getDomainCredentials(url);
+    expect(originValue).toBe("same-origin");
+  });
+
+  it("tests getDomainCredentials with trusted domains that doesn't include supplied url", () => {
+    MOCK_USER_SESSION["trustedDomains"] = ["https://www.example.com"];
+    const url: string = "https://www.arcgis.com";
+    const originValue: string = MOCK_USER_SESSION.getDomainCredentials(url);
+    expect(originValue).toBe("same-origin");
+  });
+
+  it("tests getDomainCredentials with trusted domains that includes supplied url", () => {
+    MOCK_USER_SESSION["trustedDomains"] = ["https://www.example.com", "https://www.arcgis.com"];
+    const url: string = "https://www.arcgis.com";
+    const originValue: string = MOCK_USER_SESSION.getDomainCredentials(url);
+    expect(originValue).toBe("include");
+  });
+
+  it("tests getDomainCredentials with trusted domains that includes supplied url but with different casing in authorized domains", () => {
+    MOCK_USER_SESSION["trustedDomains"] = ["https://www.example.com", "https://www.ARCGIS.com"];
+    const url: string = "https://www.arcgis.com";
+    const originValue: string = MOCK_USER_SESSION.getDomainCredentials(url);
+    expect(originValue).toBe("include");
+  });
+
+  it("tests getDomainCredentials with trusted domains that includes supplied url but with different casing in supplied url", () => {
+    MOCK_USER_SESSION["trustedDomains"] = ["https://www.example.com", "https://www.arcgis.com"];
+    const url: string = "https://www.ARCGIS.com";
+    const originValue: string = MOCK_USER_SESSION.getDomainCredentials(url);
+    expect(originValue).toBe("include");
+  });
 });


### PR DESCRIPTION
It is possible for an Enterprise system to be configured where the casing of domain names in a list of authorized domains doesn't match the URL being requested. Because domain names are case insensitive, this PR changes getDomainCredentials to perform a case-insensitive comparison.