### PR TITLE
Set up for CI publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ demos/deploy-harness
 demos/**/index-local.html
 
 demos/ember-build-harness
+
+.npmrc

--- a/deprecateVersion.bat
+++ b/deprecateVersion.bat
@@ -1,26 +1,47 @@
 @echo off
 if "%1%"=="" goto syntax
-if "%2%"=="" goto syntax
 set obsoleteVersion=%1%
+if "%2%"=="" goto token
+
 set twoFactorCode=%2%
 @echo on
-call npm deprecate "@esri/solution-common@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-creator@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-deployer@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-feature-layer@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-file@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-form@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-group@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-hub-types@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-simple-types@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-storymap@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-velocity@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-viewer@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-web-experience@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-web-tool@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
-call npm deprecate "@esri/solution-workflow@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-common@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-creator@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-deployer@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-feature-layer@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-file@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-form@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-group@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-hub-types@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-simple-types@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-storymap@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-velocity@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-viewer@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-web-experience@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-web-tool@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
+call npm deprecate "@esri/solution-workflow@%obsoleteVersion%" "obsolete" -otp=%twoFactorCode%
 goto end
+
+:token
+@echo on
+call npm deprecate "@esri/solution-common@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-creator@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-deployer@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-feature-layer@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-file@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-form@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-group@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-hub-types@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-simple-types@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-storymap@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-velocity@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-viewer@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-web-experience@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-web-tool@%obsoleteVersion%" "obsolete"
+call npm deprecate "@esri/solution-workflow@%obsoleteVersion%" "obsolete"
+goto end
+
 :syntax
 @echo on
-rem Syntax: deprecateVersion.bat <obsolete version; e.g., 6.0.3> <two factor code>
+rem Syntax: deprecateVersion.bat <obsolete version; e.g., 6.0.3> [<two factor code if you don't have .npmrc>]
 :end

--- a/deprecateVersion.bat
+++ b/deprecateVersion.bat
@@ -1,0 +1,26 @@
+@echo off
+if "%1%"=="" goto syntax
+if "%2%"=="" goto syntax
+set obsoleteVersion=%1%
+set twoFactorCode=%2%
+@echo on
+call npm deprecate "@esri/solution-common@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-creator@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-deployer@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-feature-layer@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-file@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-form@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-group@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-hub-types@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-simple-types@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-storymap@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-velocity@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-viewer@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-web-experience@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-web-tool@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+call npm deprecate "@esri/solution-workflow@%obsoleteVersion%" "obsolete" --otp=%twoFactorCode%
+goto end
+:syntax
+@echo on
+rem Syntax: deprecateVersion.bat <obsolete version; e.g., 6.0.3> <two factor code>
+:end

--- a/guides/Publishing to npmjs.md
+++ b/guides/Publishing to npmjs.md
@@ -14,7 +14,7 @@
 * \[ \] Run `npm run release:prepare` and pick new version number (works best in Windows shell)
 * \[ \] Run `npm run release:review`
 * \[ \] Run `npm run release:publish-git` in a bash shell
-* \[ \] Run `npm run release:publish-npm` in a Windows shell and enter the npm 2-factor code when requested
+* \[ \] Run `npm run release:publish-npm` in a Windows shell and enter the npm 2-factor code when requested (if you've set up the .npmrc file with an npm granular access token, you won't be prompted for the code; see below)
 * \[ \] Check that publishing worked using `check_npm_package_versions.html` in a browser
 * \[ \] Run `build.bat` to update the package-lock.json files with the latest version.
 * \[ \] Commit package.json files (publishing updates the `gitHead` property in the files) and the package-lock.json files. 
@@ -81,6 +81,16 @@ Copyright (c) 1990-2008 Info-ZIP...
  Note that you won't see the new version in your GitHub client until the next time that you refresh the repository.
 
  It's OK to push the version to GitHub even if not all packages appear to have been published. "Publishing" is sending them to npm and is a separate process that we can patch below.
+
+   - Publishing with a granular access token
+		1. Create a [granular access token on the npmjs.com website](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-granular-access-tokens-on-the-website)
+		    * Set expiration of token
+		    * Skip IP Range
+		    * Grant "Read and write" permissions to "All packages"
+		2. Create a file at the top level of solution.js called `.npmrc` and containing the following text (the generated token is added after the equals sign):
+		```bat
+		//registry.npmjs.org/:_authToken=
+		```
 
 8. Check that publishing worked using the repository's web page `check_npm_package_versions.html`; sometimes, only some of the packages show up in npm. It may take ten or more minutes for a general request such as `https://unpkg.com/@esri/solution-simple-types/dist/umd/simple-types.umd.js` to 302 resolve to the latest version.
 

--- a/setLatestVersion.bat
+++ b/setLatestVersion.bat
@@ -1,7 +1,8 @@
 @echo off
 if "%1%"=="" goto syntax
-if "%2%"=="" goto syntax
 set latestVersion=%1%
+if "%2%"=="" goto syntax
+
 set twoFactorCode=%2%
 @echo on
 call npm dist-tag add "@esri/solution-common@%latestVersion%" latest -otp=%twoFactorCode%
@@ -19,7 +20,27 @@ call npm dist-tag add "@esri/solution-viewer@%latestVersion%" latest -otp=%twoFa
 call npm dist-tag add "@esri/solution-web-experience@%latestVersion%" latest -otp=%twoFactorCode%
 call npm dist-tag add "@esri/solution-web-tool@%latestVersion%" latest -otp=%twoFactorCode%
 call npm dist-tag add "@esri/solution-workflow@%latestVersion%" latest -otp=%twoFactorCode%
+goto end
+
+:token
+@echo on
+call npm dist-tag add "@esri/solution-common@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-creator@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-deployer@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-feature-layer@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-file@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-form@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-group@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-hub-types@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-simple-types@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-storymap@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-velocity@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-viewer@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-web-experience@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-web-tool@%latestVersion%" latest
+call npm dist-tag add "@esri/solution-workflow@%latestVersion%" latest
+
 :syntax
 @echo on
-rem Syntax: setLatestVersion.bat.bat <current version; e.g., 5.22.0> <two factor code>
+rem Syntax: setLatestVersion.bat.bat <current version; e.g., 5.22.0> [<two factor code if you don't have .npmrc>]
 :end

--- a/setLatestVersion.bat
+++ b/setLatestVersion.bat
@@ -1,0 +1,25 @@
+@echo off
+if "%1%"=="" goto syntax
+if "%2%"=="" goto syntax
+set latestVersion=%1%
+set twoFactorCode=%2%
+@echo on
+call npm dist-tag add "@esri/solution-common@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-creator@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-deployer@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-feature-layer@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-file@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-form@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-group@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-hub-types@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-simple-types@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-storymap@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-velocity@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-viewer@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-web-experience@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-web-tool@%latestVersion%" latest -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-workflow@%latestVersion%" latest -otp=%twoFactorCode%
+:syntax
+@echo on
+rem Syntax: setLatestVersion.bat.bat <current version; e.g., 5.22.0> <two factor code>
+:end

--- a/setNextVersion.bat
+++ b/setNextVersion.bat
@@ -1,7 +1,8 @@
 @echo off
 if "%1%"=="" goto syntax
-if "%2%"=="" goto syntax
 set nextVersion=%1%
+if "%2%"=="" goto syntax
+
 set twoFactorCode=%2%
 @echo on
 call npm dist-tag add "@esri/solution-common@%nextVersion%" next -otp=%twoFactorCode%
@@ -19,7 +20,27 @@ call npm dist-tag add "@esri/solution-viewer@%nextVersion%" next -otp=%twoFactor
 call npm dist-tag add "@esri/solution-web-experience@%nextVersion%" next -otp=%twoFactorCode%
 call npm dist-tag add "@esri/solution-web-tool@%nextVersion%" next -otp=%twoFactorCode%
 call npm dist-tag add "@esri/solution-workflow@%nextVersion%" next -otp=%twoFactorCode%
+goto end
+
+:token
+@echo on
+call npm dist-tag add "@esri/solution-common@%nextVersion%" next
+call npm dist-tag add "@esri/solution-creator@%nextVersion%" next
+call npm dist-tag add "@esri/solution-deployer@%nextVersion%" next
+call npm dist-tag add "@esri/solution-feature-layer@%nextVersion%" next
+call npm dist-tag add "@esri/solution-file@%nextVersion%" next
+call npm dist-tag add "@esri/solution-form@%nextVersion%" next
+call npm dist-tag add "@esri/solution-group@%nextVersion%" next
+call npm dist-tag add "@esri/solution-hub-types@%nextVersion%" next
+call npm dist-tag add "@esri/solution-simple-types@%nextVersion%" next
+call npm dist-tag add "@esri/solution-storymap@%nextVersion%" next
+call npm dist-tag add "@esri/solution-velocity@%nextVersion%" next
+call npm dist-tag add "@esri/solution-viewer@%nextVersion%" next
+call npm dist-tag add "@esri/solution-web-experience@%nextVersion%" next
+call npm dist-tag add "@esri/solution-web-tool@%nextVersion%" next
+call npm dist-tag add "@esri/solution-workflow@%nextVersion%" next
+
 :syntax
 @echo on
-rem Syntax: setNextVersion.bat <next version; e.g., 6.0.3> <two factor code>
+rem Syntax: setNextVersion.bat <next version; e.g., 6.0.3> [<two factor code if you don't have .npmrc>]
 :end

--- a/setNextVersion.bat
+++ b/setNextVersion.bat
@@ -1,0 +1,25 @@
+@echo off
+if "%1%"=="" goto syntax
+if "%2%"=="" goto syntax
+set nextVersion=%1%
+set twoFactorCode=%2%
+@echo on
+call npm dist-tag add "@esri/solution-common@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-creator@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-deployer@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-feature-layer@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-file@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-form@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-group@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-hub-types@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-simple-types@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-storymap@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-velocity@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-viewer@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-web-experience@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-web-tool@%nextVersion%" next -otp=%twoFactorCode%
+call npm dist-tag add "@esri/solution-workflow@%nextVersion%" next -otp=%twoFactorCode%
+:syntax
+@echo on
+rem Syntax: setNextVersion.bat <next version; e.g., 6.0.3> <two factor code>
+:end


### PR DESCRIPTION
For publishing without entering an OTP:
1. Create a [granular access token on the npmjs.com website](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-granular-access-tokens-on-the-website)
    * Set expiration of token
    * Skip IP Range
    * Grant "Read and write" permissions to "All packages"
2. Create a file at the top level of solution.js called `.npmrc` and containing the following text (the generated token is added after the equals sign):
```bat
//registry.npmjs.org/:_authToken=
```

Also changed helper batch files to use .npmrc, adding `deprecateVersion` batch file.