### PR TITLE
addcancelcheck to deploysolution

### DIFF
--- a/demos/deploySolution/src/deploy-solution-main.ts
+++ b/demos/deploySolution/src/deploy-solution-main.ts
@@ -25,7 +25,6 @@ export interface ISolutionInfoCard {
   version: string;
 }
 
-
 export function deploySolutionsInFolder (
   folderId: string,
   srcAuthentication: common.UserSession,
@@ -33,7 +32,7 @@ export function deploySolutionsInFolder (
   progressCallback: common.ISolutionProgressCallback,
   enableItemReuse: boolean,
   dontCreateSolutionItem: boolean,
-  customParams: any
+  customParams: any,
 ): Promise<string> {
   const query = new common.SearchQueryBuilder()
     .match(folderId).in("ownerfolder").and()
@@ -145,7 +144,8 @@ export function deployAndDisplaySolution (
   progressCallback: common.ISolutionProgressCallback,
   enableItemReuse: boolean,
   dontCreateSolutionItem: boolean,
-  customParams: any
+  customParams: any,
+  abortController?: AbortController
 ): Promise<string> {
   // Deploy a solution described by the supplied id
   // only pass custom params to the templateDictionary
@@ -158,7 +158,8 @@ export function deployAndDisplaySolution (
     templateDictionary: isJsonStr(customParams) ? {
       params: JSON.parse(customParams)
     } : {},
-    dontCreateSolutionItem
+    dontCreateSolutionItem,
+    abortController
   };
 
   return deployer.deploySolution(templateSolutionId, destAuthentication, options)

--- a/demos/deploySolution/src/index.ts
+++ b/demos/deploySolution/src/index.ts
@@ -79,14 +79,15 @@ function deploySolution(
       createdItems.push(progressEvent.data);
     }
 
-    // Create base progress HTML
-    const html = "Deploying " + jobId + "..." + percentDone.toFixed().toString() + "%" + "<br>";
-
     // Get the output container
     const outputEl = document.getElementById("output");
     if (outputEl) {
+      outputEl.innerHTML = '';
+
       // Set HTML status part
-      outputEl.innerHTML = html;
+      const header = document.createElement("div");
+      header.innerHTML = "Deploying " + jobId + "..." + percentDone.toFixed().toString() + "%" + "<br>";
+      outputEl.appendChild(header);
 
       // Only add the cancel button if it doesn't already exist
       if (!document.getElementById("cancelButton")) {
@@ -95,17 +96,12 @@ function deploySolution(
         cancelButton.textContent = "Cancel";
         cancelButton.onclick = cancelDeploy;
         cancelButton.style.marginTop = "10px";
-
         outputEl.appendChild(cancelButton);
       }
 
-      let htmlResultList = "<br><br>Finished items:<ol>";
-      createdItems.forEach(function (item) {
-        htmlResultList += "<li>" + item + "</li>";
-      });
-      htmlResultList += "</ol>";
-
-      outputEl.innerHTML = outputEl.innerHTML + htmlResultList;
+      const list = document.createElement("div");
+      list.innerHTML = "<br><br>Finished items:<ol>" + createdItems.map(item => `<li>${item}</li>`).join('') + "</ol>";
+      outputEl.appendChild(list);
 
     }
   } as common.ISolutionProgressCallback;
@@ -148,6 +144,7 @@ function deploySolution(
 
 function cancelDeploy() {
   abortController.abort();
+  console.log(abortController.signal.aborted);
 }
 
 /**

--- a/demos/deploySolution/src/index.ts
+++ b/demos/deploySolution/src/index.ts
@@ -24,6 +24,7 @@ declare var fetchFoldersFcn: any;
 declare var goFcn: any;
 declare var updateDestAuthFcn: any;
 
+let abortController: AbortController;
 //--------------------------------------------------------------------------------------------------------------------//
 
 function fetchFolders(
@@ -67,20 +68,49 @@ function deploySolution(
   dontCreateSolutionItem: boolean,
   customParams: any
 ): void {
+  abortController = new AbortController();
   const startTime = Date.now();
   const createdItems = [] as any[];
 
   let deployPromise = Promise.resolve("<i>No Solution(s) provided</i>");
   const progressFcn =
-    function (percentDone, jobId, progressEvent) {
-      if (progressEvent) {
-        createdItems.push(progressEvent.data);
+  function (percentDone, jobId, progressEvent) {
+    if (progressEvent) {
+      createdItems.push(progressEvent.data);
+    }
+
+    // Create base progress HTML
+    const html = "Deploying " + jobId + "..." + percentDone.toFixed().toString() + "%" + "<br>";
+
+    // Get the output container
+    const outputEl = document.getElementById("output");
+    if (outputEl) {
+      // Set HTML status part
+      outputEl.innerHTML = html;
+
+      // Only add the cancel button if it doesn't already exist
+      if (!document.getElementById("cancelButton")) {
+        const cancelButton = document.createElement("button");
+        cancelButton.id = "cancelButton";
+        cancelButton.textContent = "Cancel";
+        cancelButton.onclick = cancelDeploy;
+        cancelButton.style.marginTop = "10px";
+
+        outputEl.appendChild(cancelButton);
       }
-      let html = "Deploying " + jobId + "..." + percentDone.toFixed().toString() + "%" + "<br><br>Finished items:<ol>";
-      createdItems.forEach(function (item) { return html += "<li>" + item + "</li>" });
-      html += "</ol>";
-      document.getElementById("output").innerHTML = html;
-    } as common.ISolutionProgressCallback;
+
+      let htmlResultList = "<br><br>Finished items:<ol>";
+      createdItems.forEach(function (item) {
+        htmlResultList += "<li>" + item + "</li>";
+      });
+      htmlResultList += "</ol>";
+
+      outputEl.innerHTML = outputEl.innerHTML + htmlResultList;
+
+    }
+  } as common.ISolutionProgressCallback;
+
+
   if (solutionId.length > 0) {
     deployPromise = main.deployAndDisplaySolution(
       solutionId,
@@ -89,7 +119,8 @@ function deploySolution(
       progressFcn,
       useExisting,
       dontCreateSolutionItem,
-      customParams
+      customParams,
+      abortController
     );
   } else if (folderId.length > 0) {
     deployPromise = main.deploySolutionsInFolder(
@@ -113,6 +144,10 @@ function deploySolution(
       document.getElementById("output").innerHTML = "<span style=\"color:red\">" + message + "</span>";
     }
   );
+}
+
+function cancelDeploy() {
+  abortController.abort();
 }
 
 /**

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -683,6 +683,10 @@ export interface IDeploySolutionOptions {
    * Determines if the solution item should be created during deployment; default: false
    */
   dontCreateSolutionItem?: boolean;
+  /**
+   * Flag to signal that the process has been aborted or cancelled
+   */
+  abortController?: AbortController;
 }
 
 /**

--- a/packages/deployer/src/deploySolutionFromTemplate.ts
+++ b/packages/deployer/src/deploySolutionFromTemplate.ts
@@ -29,6 +29,21 @@ export async function deploySolutionFromTemplate(
   authentication: common.UserSession,
   options: common.IDeploySolutionOptions,
 ): Promise<string> {
+  /**
+   * function to abort the current process. Will delete solution and reject the promise
+   *
+   * @return a reject on the parent promise.
+   */
+  function checkCancelled() {
+    if (options && options.abortController) {
+      if (options.abortController.signal.aborted) {
+        throw new Error("Operation was cancelled");
+      }
+    }
+  }
+
+  checkCancelled();
+
   options.storageVersion = common.extractSolutionVersion(solutionTemplateData);
 
   // It is possible to provide a separate authentication for the source
@@ -100,6 +115,8 @@ export async function deploySolutionFromTemplate(
     (group: common.IGroup) => group.owner === templateDictionary.user.username,
   );
 
+  checkCancelled();
+
   // Add information needed for workflow manager
   const user = await common.getUser(authentication);
   templateDictionary.workflowBaseUrl = await common.getWorkflowBaseURL(authentication, portalResponse, user.orgId);
@@ -125,6 +142,7 @@ export async function deploySolutionFromTemplate(
     authentication,
   );
 
+  checkCancelled();
   // Await completion of async actions: folder creation & extents conversion
   const folderExtentsResponses = await Promise.all([folderPromise, extentsPromise, trackingOwnerPromise]);
   const [folderResponse, wgs84Extent, trackingOwnerResponse] = folderExtentsResponses;
@@ -159,6 +177,7 @@ export async function deploySolutionFromTemplate(
       createSolutionItemBase.typeKeywords = ["Solution"].concat(options.additionalTypeKeywords);
     }
 
+    checkCancelled();
     // Create deployed solution item
     createSolutionItemBase.thumbnail = options.thumbnail;
     const createSolutionResponse = await common.createItemWithData(
@@ -170,6 +189,7 @@ export async function deploySolutionFromTemplate(
 
     deployedSolutionId = createSolutionResponse.id;
 
+    checkCancelled();
     // Protect the solution item
     const protectOptions: common.IUserItemOptions = {
       id: deployedSolutionId,
@@ -188,6 +208,8 @@ export async function deploySolutionFromTemplate(
     solutionTemplateBase.url = _checkedReplaceAll(solutionTemplateBase.url, templateSolutionId, deployedSolutionId);
   }
 
+  checkCancelled();
+
   // Handle the contained item templates
   const clonedSolutionsResponse: common.ICreateItemFromTemplateResponse[] = await deployItems.deploySolutionItems(
     storageAuthentication.portal,
@@ -201,6 +223,7 @@ export async function deploySolutionFromTemplate(
   );
 
   solutionTemplateData.templates = solutionTemplateData.templates.map((itemTemplate: common.IItemTemplate) => {
+    checkCancelled();
     // Update ids present in template dictionary
     itemTemplate.itemId = common.getProp(templateDictionary, `${itemTemplate.itemId}.itemId`);
 
@@ -216,6 +239,8 @@ export async function deploySolutionFromTemplate(
     solutionTemplateData.templates,
     clonedSolutionsResponse.map((response) => response.id),
   );
+
+  checkCancelled();
 
   // Wrap up with post-processing, in which we deal with groups and cycle remnants
   await postProcess(
@@ -257,6 +282,8 @@ export async function deploySolutionFromTemplate(
     if (templateDictionary.params) {
       solutionTemplateBase.data.params = templateDictionary.params;
     }
+
+    checkCancelled();
 
     await common.updateItem(solutionTemplateBase, authentication, deployedFolderId);
   }

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -51,6 +51,19 @@ export function deploySolutionItems(
   options: common.IDeploySolutionOptions,
 ): Promise<common.ICreateItemFromTemplateResponse[]> {
   return new Promise((resolve, reject) => {
+    /**
+     * function to abort the current process. Will delete solution and reject the promise
+     *
+     * @return a reject on the parent promise.
+     */
+    function checkCancelled() {
+      if (options && options.abortController) {
+        if (options.abortController.signal.aborted) {
+          reject(new Error(`Operation was cancelled`));
+        }
+      }
+    }
+
     // Prepare feedback mechanism
     const totalEstimatedCost = _estimateDeploymentCost(templates) + 1; // solution items, plus avoid divide by 0
     let percentDone: number = 10; // allow for previous deployment work
@@ -59,6 +72,8 @@ export function deploySolutionItems(
     const failedTemplateItemIds: string[] = [];
     const deployedItemIds: string[] = [];
     let statusOK = true;
+
+    checkCancelled();
 
     // TODO: move to separate fn
     const itemProgressCallback: common.IItemProgressCallback = (
@@ -122,6 +137,8 @@ export function deploySolutionItems(
     //   * add created item's id into the template dictionary
     const awaitAllItems = [] as Array<Promise<common.ICreateItemFromTemplateResponse>>;
 
+    checkCancelled();
+
     const reuseItemsDef: Promise<any> = _reuseDeployedItems(
       templates,
       options.enableItemReuse ?? false,
@@ -131,6 +148,7 @@ export function deploySolutionItems(
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     reuseItemsDef.then(
       () => {
+        checkCancelled();
         const useExistingItemsDef: Promise<any> = _useExistingItems(
           templates,
           common.getProp(templateDictionary, "params.useExisting"),
@@ -139,6 +157,8 @@ export function deploySolutionItems(
         );
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         useExistingItemsDef.then(() => {
+          checkCancelled();
+
           templates = common.setNamesAndTitles(templates);
 
           buildOrder.forEach((id: string) => {
@@ -168,6 +188,7 @@ export function deploySolutionItems(
                 templateDictionary,
                 destinationAuthentication,
                 itemProgressCallback,
+                options.abortController,
               ),
             );
           });
@@ -175,6 +196,8 @@ export function deploySolutionItems(
           // Wait until all items have been created
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           Promise.all(awaitAllItems).then((clonedSolutionItems: common.ICreateItemFromTemplateResponse[]) => {
+            checkCancelled();
+
             if (failedTemplateItemIds.length === 0) {
               // Do we have any items to be patched (i.e., they refer to dependencies using the template id rather
               // than the cloned id because the item had to be created before the dependency)? Flag these items
@@ -907,7 +930,21 @@ export function _createItemFromTemplateWhenReady(
   templateDictionary: any,
   destinationAuthentication: common.UserSession,
   itemProgressCallback: common.IItemProgressCallback,
+  abortController?: AbortController,
 ): Promise<common.ICreateItemFromTemplateResponse> {
+  /**
+   * function to abort the current process. Will delete solution and reject the promise
+   *
+   * @return a reject on the parent promise.
+   */
+  function checkCancelled() {
+    if (abortController) {
+      if (abortController.signal.aborted) {
+        throw new Error(`Operation was cancelled`);
+      }
+    }
+  }
+
   const sourceItemId = template.itemId;
 
   // ensure this is present
@@ -918,6 +955,7 @@ export function _createItemFromTemplateWhenReady(
     !templateDictionary.hasOwnProperty(template.itemId) ||
     !common.getProp(templateDictionary[template.itemId], "def")
   ) {
+    checkCancelled();
     let createResponse: common.ICreateItemFromTemplateResponse;
     let statusCode: common.EItemProgressStatus = common.EItemProgressStatus.Unknown;
     let itemHandler: common.IItemTemplateConversions;
@@ -953,6 +991,7 @@ export function _createItemFromTemplateWhenReady(
 
       Promise.all(awaitDependencies)
         .then(() => {
+          checkCancelled();
           // Find the conversion handler for this item type
           const templateType = template.type;
           itemHandler = moduleMap[templateType];
@@ -973,6 +1012,7 @@ export function _createItemFromTemplateWhenReady(
           return common.getThumbnailFromStorageItem(storageAuthentication, resourceFilePaths);
         })
         .then((thumbnail) => {
+          checkCancelled();
           template.item.thumbnail = thumbnail;
 
           // Delegate the creation of the item to the handler
@@ -985,6 +1025,8 @@ export function _createItemFromTemplateWhenReady(
           );
         })
         .then(async (response: common.ICreateItemFromTemplateResponse) => {
+          checkCancelled();
+
           if (response.id === "") {
             statusCode = common.EItemProgressStatus.Failed;
             throw new Error("handled"); // fails to create item
@@ -1013,12 +1055,14 @@ export function _createItemFromTemplateWhenReady(
               });
 
               if (formZipFilePath) {
+                checkCancelled();
                 // Fetch the form's zip file and send it to the item
                 const zipObject = await common.fetchZipObject(formZipFilePath.url, storageAuthentication);
                 await common.updateItemWithZipObject(zipObject, destinationItemId, destinationAuthentication);
               }
             }
 
+            checkCancelled();
             // Copy resources, metadata
             return common.copyFilesFromStorageItem(
               storageAuthentication,

--- a/packages/deployer/src/deployer.ts
+++ b/packages/deployer/src/deployer.ts
@@ -26,8 +26,6 @@ import { deploySolutionFromTemplate } from "./deploySolutionFromTemplate";
 import { getSolutionTemplateItem, isSolutionTemplateItem, updateDeployOptions } from "./deployerUtils";
 import { IModel } from "@esri/hub-common";
 
-let abortSignal: boolean = false;
-
 /**
  * Deploy a Solution
  *
@@ -49,9 +47,16 @@ export async function deploySolution(
     return Promise.reject(common.fail("The Solution Template id is missing"));
   }
 
-  function checkCancelled(content?: any) {
-    if (abortSignal) {
-      return Promise.reject(content);
+  /**
+   * function to abort the current process. Will delete solution and reject the promise
+   *
+   * @return a reject on the parent promise.
+   */
+  function checkCancelled() {
+    if (options && options.abortController) {
+      if (options.abortController.signal.aborted) {
+        throw new Error("Operation was cancelled");
+      }
     }
   }
 
@@ -67,11 +72,11 @@ export async function deploySolution(
     ? deployOptions.storageAuthentication
     : authentication;
 
-  checkCancelled();
+  void checkCancelled();
   // deal with maybe getting an item or an id
   return getSolutionTemplateItem(maybeModel, storageAuthentication)
     .then((model) => {
-      checkCancelled(model);
+      void checkCancelled();
       if (!isSolutionTemplateItem(model.item)) {
         return Promise.reject(common.fail(`${model.item.id} is not a Solution Template`));
       } else {
@@ -80,7 +85,6 @@ export async function deploySolution(
       }
     })
     .then((responses) => {
-      checkCancelled(responses);
       // extract responses
       const [itemBase, itemData] = responses;
       // sanitize all the things
@@ -95,7 +99,7 @@ export async function deploySolution(
       // Clone before mutating? This was messing me up in some testing...
       common.deleteItemProps(item);
 
-      checkCancelled(responses);
+      checkCancelled();
       return deploySolutionFromTemplate(itemId, item, data, authentication, deployOptions);
     })
     .then(
@@ -116,6 +120,28 @@ export async function deploySolution(
       },
     )
     .catch((ex) => {
+      deployCatchHandler(ex, authentication);
       throw ex;
     });
+}
+
+export function deployCatchHandler(ex: any, authentication: common.UserSession) {
+  const progressFcn = function () {
+    // Create base progress HTML
+    const html = "Deleting from Deployer";
+
+    // Get the output container
+    const outputEl = document.getElementById("output");
+    if (outputEl) {
+      // Set HTML status part
+      outputEl.innerHTML = html;
+    }
+  } as common.ISolutionProgressCallback;
+
+  const options: common.IDeleteSolutionOptions = {
+    progressCallback: progressFcn,
+    consoleProgress: true,
+    sendToRecycling: false,
+  };
+  void common.deleteSolution(ex.trim(), authentication, options);
 }

--- a/packages/deployer/src/deployer.ts
+++ b/packages/deployer/src/deployer.ts
@@ -26,6 +26,8 @@ import { deploySolutionFromTemplate } from "./deploySolutionFromTemplate";
 import { getSolutionTemplateItem, isSolutionTemplateItem, updateDeployOptions } from "./deployerUtils";
 import { IModel } from "@esri/hub-common";
 
+let abortSignal: boolean = false;
+
 /**
  * Deploy a Solution
  *
@@ -46,6 +48,13 @@ export async function deploySolution(
   if (!maybeModel) {
     return Promise.reject(common.fail("The Solution Template id is missing"));
   }
+
+  function checkCancelled(content?: any) {
+    if (abortSignal) {
+      return Promise.reject(content);
+    }
+  }
+
   let deployOptions: common.IDeploySolutionOptions = options || {};
 
   /* istanbul ignore else */
@@ -58,9 +67,11 @@ export async function deploySolution(
     ? deployOptions.storageAuthentication
     : authentication;
 
+  checkCancelled();
   // deal with maybe getting an item or an id
   return getSolutionTemplateItem(maybeModel, storageAuthentication)
     .then((model) => {
+      checkCancelled(model);
       if (!isSolutionTemplateItem(model.item)) {
         return Promise.reject(common.fail(`${model.item.id} is not a Solution Template`));
       } else {
@@ -69,6 +80,7 @@ export async function deploySolution(
       }
     })
     .then((responses) => {
+      checkCancelled(responses);
       // extract responses
       const [itemBase, itemData] = responses;
       // sanitize all the things
@@ -83,6 +95,7 @@ export async function deploySolution(
       // Clone before mutating? This was messing me up in some testing...
       common.deleteItemProps(item);
 
+      checkCancelled(responses);
       return deploySolutionFromTemplate(itemId, item, data, authentication, deployOptions);
     })
     .then(

--- a/packages/deployer/src/deployer.ts
+++ b/packages/deployer/src/deployer.ts
@@ -126,20 +126,7 @@ export async function deploySolution(
 }
 
 export function deployCatchHandler(ex: any, authentication: common.UserSession) {
-  const progressFcn = function () {
-    // Create base progress HTML
-    const html = "Deleting from Deployer";
-
-    // Get the output container
-    const outputEl = document.getElementById("output");
-    if (outputEl) {
-      // Set HTML status part
-      outputEl.innerHTML = html;
-    }
-  } as common.ISolutionProgressCallback;
-
   const options: common.IDeleteSolutionOptions = {
-    progressCallback: progressFcn,
     consoleProgress: true,
     sendToRecycling: false,
   };

--- a/packages/deployer/test/deploySolutionFromTemplate.test.ts
+++ b/packages/deployer/test/deploySolutionFromTemplate.test.ts
@@ -331,6 +331,31 @@ describe("Module `deploySolutionFromTemplate`", () => {
       expect(deployFnCall.args[6].portal).toEqual(MOCK_USER_SESSION.portal); // destinationAuthentication
     });
 
+    it("deploySolutionFromTemplate should error on user abort", async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      const templates: common.IItemTemplate[] = [mockTemplates.getItemTemplate("Web Map")];
+      const solution: common.ISolutionItem = mockTemplates.getSolutionTemplateItem(templates);
+      const templateSolutionId: string = "sln1234567890";
+      const solutionTemplateBase: any = solution.item;
+      const solutionTemplateData: any = solution.data;
+      const authentication: common.UserSession = MOCK_USER_SESSION;
+      const options: common.IDeploySolutionOptions = {
+        abortController,
+      };
+
+      return deploySolutionFromTemplate(
+        templateSolutionId,
+        solutionTemplateBase,
+        solutionTemplateData,
+        authentication,
+        options,
+      ).then(
+        () => fail(),
+        () => Promise.resolve(),
+      );
+    });
+
     it("allows distinct authentication to the solution template", async () => {
       const SERVER_INFO = {
         currentVersion: 10.1,

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -847,20 +847,11 @@ describe("Module `deploySolutionItems`", () => {
       abortController.abort();
 
       return deploySolution
-        .deploySolutionItems(
-          utils.PORTAL_URL,
-          "sln1234567890",
-          [],
-          MOCK_USER_SESSION,
-          {},
-          "",
-          MOCK_USER_SESSION,
-          {
-            enableItemReuse: true,
-            progressCallback: utils.SOLUTION_PROGRESS_CALLBACK,
-            abortController,
-          },
-        )
+        .deploySolutionItems(utils.PORTAL_URL, "sln1234567890", [], MOCK_USER_SESSION, {}, "", MOCK_USER_SESSION, {
+          enableItemReuse: true,
+          progressCallback: utils.SOLUTION_PROGRESS_CALLBACK,
+          abortController,
+        })
         .then(
           () => fail(),
           () => Promise.resolve(),

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -842,6 +842,31 @@ describe("Module `deploySolutionItems`", () => {
         );
     });
 
+    it("can handle error on abort by user", async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+
+      return deploySolution
+        .deploySolutionItems(
+          utils.PORTAL_URL,
+          "sln1234567890",
+          [],
+          MOCK_USER_SESSION,
+          {},
+          "",
+          MOCK_USER_SESSION,
+          {
+            enableItemReuse: true,
+            progressCallback: utils.SOLUTION_PROGRESS_CALLBACK,
+            abortController,
+          },
+        )
+        .then(
+          () => fail(),
+          () => Promise.resolve(),
+        );
+    });
+
     it("handles failure to delete all items when unwinding after failure to deploy", async () => {
       const id: string = "aa4a6047326243b290f625e80ebe6531";
       const newItemID: string = "ba4a6047326243b290f625e80ebe6531";
@@ -1220,6 +1245,35 @@ describe("Module `deploySolutionItems`", () => {
         utils.ITEM_PROGRESS_CALLBACK,
       );
       expect(response).toEqual(templates.getFailedItem(itemTemplate.type));
+    });
+
+    it("Error on user aborted", async () => {
+      const itemTemplate: common.IItemTemplate = templates.getItemTemplate("Geoprocessing Service");
+      itemTemplate.item.thumbnail = null;
+      const resourceFilePaths: common.IDeployFileCopyPath[] = [];
+      const templateDictionary: any = {};
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      try {
+        await deploySolution._createItemFromTemplateWhenReady(
+          itemTemplate,
+          resourceFilePaths,
+          MOCK_USER_SESSION,
+          templateDictionary,
+          MOCK_USER_SESSION,
+          utils.ITEM_PROGRESS_CALLBACK,
+          abortController,
+        );
+        fail("Expected error was not thrown");
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error.message).toEqual("Operation was cancelled");
+        } else {
+          fail(`Caught non-Error type: ${JSON.stringify(error)}`);
+        }
+      }
     });
 
     it("skips Geoprocessing Service that is not a Web Tool", async () => {

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -1440,6 +1440,83 @@ describe("Module `deployer`", () => {
         () => Promise.resolve(),
       );
     });
+    it("can handle abort by user", async () => {
+      // get templates
+      const itemInfo: any = templates.getSolutionTemplateItem([templates.getItemTemplate("Feature Service")]);
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const options: common.IDeploySolutionOptions = {
+        progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK,
+        abortController,
+      };
+      try {
+        // Act
+        await deployer.deploySolution(itemInfo.item.id, MOCK_USER_SESSION, options);
+
+        // If no error thrown, fail the test
+        fail("Expected deploySolution to throw an error due to user abort");
+      } catch (ex) {
+        // Assert
+        expect(ex instanceof Error).toBeTrue();
+        //expect(ex.message).toBe("Operation was cancelled");
+      }
+    });
+    it("Error should catch and throw EX", async () => {
+      // get templates
+      const itemInfo: any = templates.getSolutionTemplateItem([templates.getItemTemplate("Feature Service")]);
+
+      const options: common.IDeploySolutionOptions = {
+        progressCallback: testUtils.SOLUTION_PROGRESS_CALLBACK,
+      };
+
+      spyOn(deployUtils, "getSolutionTemplateItem").and.callFake(() =>
+        Promise.reject("57a059ec717c4b1282705132fd4720a0"),
+      );
+
+      try {
+        // Act
+        await deployer.deploySolution("57a059ec717c4b1282705132fd4720a0", MOCK_USER_SESSION, options);
+
+        // If no error thrown, fail the test
+        fail("Expected deploySolution to throw an error");
+      } catch (ex) {
+        expect(ex).toBe("57a059ec717c4b1282705132fd4720a0");
+      }
+    });
+    it("Error should be handle in catch and update output dom", async () => {
+      // get templates
+      const itemInfo: any = templates.getSolutionTemplateItem([templates.getItemTemplate("Feature Service")]);
+
+      const outputElement = document.createElement("div");
+      outputElement.id = "output";
+      document.body.appendChild(outputElement);
+
+      // Spy on getElementById to return our mock
+      spyOn(document, "getElementById").and.returnValue(outputElement);
+
+      // Spy on deleteSolution to intercept and trigger callback
+      const deleteSolutionSpy = spyOn(common, "deleteSolution").and.callFake(
+        (
+          solutionItemId: string,
+          authentication: common.UserSession,
+          options?: common.IDeleteSolutionOptions,
+        ): Promise<common.ISolutionPrecis[]> => {
+          if (options?.progressCallback) {
+            options.progressCallback(0);
+          }
+
+          const fakeResult: common.ISolutionPrecis[] = [];
+          return Promise.resolve(fakeResult);
+        },
+      );
+
+      deployer.deployCatchHandler(itemInfo.item.id, MOCK_USER_SESSION);
+      expect(document.getElementById).toHaveBeenCalledWith("output");
+      expect(outputElement.innerHTML).toBe("Deleting from Deployer");
+      expect(deleteSolutionSpy).toHaveBeenCalled();
+    });
   });
   describe("_replaceParamVariables", () => {
     it("should update custom sr prop", () => {

--- a/packages/deployer/test/deployer.test.ts
+++ b/packages/deployer/test/deployer.test.ts
@@ -1460,7 +1460,6 @@ describe("Module `deployer`", () => {
       } catch (ex) {
         // Assert
         expect(ex instanceof Error).toBeTrue();
-        //expect(ex.message).toBe("Operation was cancelled");
       }
     });
     it("Error should catch and throw EX", async () => {
@@ -1484,38 +1483,6 @@ describe("Module `deployer`", () => {
       } catch (ex) {
         expect(ex).toBe("57a059ec717c4b1282705132fd4720a0");
       }
-    });
-    it("Error should be handle in catch and update output dom", async () => {
-      // get templates
-      const itemInfo: any = templates.getSolutionTemplateItem([templates.getItemTemplate("Feature Service")]);
-
-      const outputElement = document.createElement("div");
-      outputElement.id = "output";
-      document.body.appendChild(outputElement);
-
-      // Spy on getElementById to return our mock
-      spyOn(document, "getElementById").and.returnValue(outputElement);
-
-      // Spy on deleteSolution to intercept and trigger callback
-      const deleteSolutionSpy = spyOn(common, "deleteSolution").and.callFake(
-        (
-          solutionItemId: string,
-          authentication: common.UserSession,
-          options?: common.IDeleteSolutionOptions,
-        ): Promise<common.ISolutionPrecis[]> => {
-          if (options?.progressCallback) {
-            options.progressCallback(0);
-          }
-
-          const fakeResult: common.ISolutionPrecis[] = [];
-          return Promise.resolve(fakeResult);
-        },
-      );
-
-      deployer.deployCatchHandler(itemInfo.item.id, MOCK_USER_SESSION);
-      expect(document.getElementById).toHaveBeenCalledWith("output");
-      expect(outputElement.innerHTML).toBe("Deleting from Deployer");
-      expect(deleteSolutionSpy).toHaveBeenCalled();
     });
   });
   describe("_replaceParamVariables", () => {

--- a/packages/simple-types/src/helpers/create-item-from-template.ts
+++ b/packages/simple-types/src/helpers/create-item-from-template.ts
@@ -24,8 +24,24 @@ export function createItemFromTemplate(
   templateDictionary: any,
   destinationAuthentication: common.UserSession,
   itemProgressCallback: common.IItemProgressCallback,
+  abortController?: AbortController,
 ): Promise<common.ICreateItemFromTemplateResponse> {
-  return new Promise<common.ICreateItemFromTemplateResponse>((resolve) => {
+  return new Promise<common.ICreateItemFromTemplateResponse>((resolve, reject) => {
+    /**
+     * function to abort the current process. Will delete solution and reject the promise
+     *
+     * @return a reject on the parent promise.
+     */
+    function checkCancelled() {
+      if (abortController) {
+        if (abortController.signal.aborted) {
+          reject(new Error(`Operation was cancelled`));
+        }
+      }
+    }
+
+    checkCancelled();
+
     // Interrupt process if progress callback returns `false`
     if (!itemProgressCallback(template.itemId, common.EItemProgressStatus.Started, 0)) {
       itemProgressCallback(template.itemId, common.EItemProgressStatus.Ignored, 0);
@@ -66,6 +82,7 @@ export function createItemFromTemplate(
         )
         .then(
           (createResponse) => {
+            checkCancelled();
             // Interrupt process if progress callback returns `false`
             if (
               !itemProgressCallback(
@@ -100,6 +117,8 @@ export function createItemFromTemplate(
               const originalURL = newItemTemplate.item.url;
               newItemTemplate = common.replaceInTemplate(newItemTemplate, templateDictionary);
 
+              checkCancelled();
+
               // Update relationships
               let relationshipsDef = Promise.resolve([] as common.IStatusResponse[]);
               if (newItemTemplate.relatedItems) {
@@ -117,6 +136,7 @@ export function createItemFromTemplate(
                 );
               }
 
+              checkCancelled();
               // Check for extra processing for web mapping application et al.
               let customProcDef: Promise<void>;
               if (
@@ -162,6 +182,7 @@ export function createItemFromTemplate(
                   destinationAuthentication,
                 );
               } else if (originalURL !== newItemTemplate.item.url) {
+                checkCancelled();
                 // For web mapping applications that are not Web AppBuilder apps
                 customProcDef = new Promise<void>((resolve2, reject2) => {
                   common
@@ -172,6 +193,7 @@ export function createItemFromTemplate(
                 customProcDef = Promise.resolve(null);
               }
 
+              checkCancelled();
               Promise.all([relationshipsDef, customProcDef]).then(
                 () => {
                   // Interrupt process if progress callback returns `false`

--- a/packages/simple-types/src/simple-types.ts
+++ b/packages/simple-types/src/simple-types.ts
@@ -68,7 +68,17 @@ export function createItemFromTemplate(
   templateDictionary: any,
   destinationAuthentication: UserSession,
   itemProgressCallback: IItemProgressCallback,
+  abortController?: AbortController,
 ): Promise<ICreateItemFromTemplateResponse> {
+  if (abortController) {
+    return simpleTypeHelpers.createItemFromTemplate(
+      template,
+      templateDictionary,
+      destinationAuthentication,
+      itemProgressCallback,
+      abortController,
+    );
+  }
   return simpleTypeHelpers.createItemFromTemplate(
     template,
     templateDictionary,

--- a/packages/simple-types/test/simple-types.test.ts
+++ b/packages/simple-types/test/simple-types.test.ts
@@ -436,6 +436,31 @@ describe("Module `simple-types`: manages the creation and deployment of simple i
       );
       expect(response).toEqual(templates.getFailedItem(itemTemplate.type));
     });
+
+    it("should handle cancellation by user aborting", async () => {
+      const itemTemplate: common.IItemTemplate = templates.getItemTemplate("Web Map");
+      const templateDictionary: any = {};
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      try {
+        await simpleTypes.createItemFromTemplate(
+          itemTemplate,
+          templateDictionary,
+          MOCK_USER_SESSION,
+          utils.ITEM_PROGRESS_CALLBACK,
+          abortController,
+        );
+        fail("Expected error was not thrown");
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error.message).toEqual("Operation was cancelled");
+        } else {
+          fail(`Caught non-Error type: ${JSON.stringify(error)}`);
+        }
+      }
+    });
   });
 
   describe("postProcessFieldReferences", () => {


### PR DESCRIPTION
Added abortController as an optional property on IDeploySolutionOptions interface.

Added abortController function and checks in various sports in the deployment workflow.  I tried to put checks, before and after async callbacks functions. Since the state of abort can change at any time.
Throws an error or rejects, causing the deploy to fall into the Catch clause of deploySolution, and rollback and delete the solution.

Updated unit tests