### PR TITLE
Abort Deployment - clean up deletion items and folder

### DIFF
--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -53,6 +53,7 @@ export function deploySolutionItems(
 ): Promise<common.ICreateItemFromTemplateResponse[]> {
   return new Promise((resolve, reject) => {
     const timeStamp = Date.now();
+    let cancelExecuting = false;
     /**
      * function to abort the current process. Will delete solution and reject the promise
      *
@@ -60,7 +61,8 @@ export function deploySolutionItems(
      */
     function checkCancelled() {
       if (options && options.abortController) {
-        if (options.abortController.signal.aborted) {
+        if (!cancelExecuting && options.abortController.signal.aborted) {
+          cancelExecuting = true;
           const deployedItemIdsList = _getItemIdsFromTemplateDictionary(templates, templateDictionary);
           const existingItems = _findExistingItemByKeyword(templates, templateDictionary, destinationAuthentication);
           const progressOptions: common.IDeleteSolutionOptions = {
@@ -78,13 +80,18 @@ export function deploySolutionItems(
                 destinationAuthentication,
                 progressOptions,
               )
-              .then(() => {
+              .then(async () => {
                 //because of possible deletion lag and agol query, try to delete folder again if it was still around.
-                common.deleteSolutionFolder(
-                  FilteredListToDelete,
-                  templateDictionary.folderId,
-                  destinationAuthentication,
-                );
+                try {
+                  await common.deleteSolutionFolder(
+                    FilteredListToDelete,
+                    templateDictionary.folderId,
+                    destinationAuthentication,
+                  );
+                } catch (err) {
+                  console.warn("deleteSolutionFolder failed (ignored during cleanup):", err);
+                }
+
                 reject(common.failWithIds(failedTemplateItemIds));
               });
           });

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -68,9 +68,7 @@ export function deploySolutionItems(
           };
 
           Promise.all(existingItems.existingItemsDefs).then((defs) => {
-            const FilteredListToDelete = _findExistingItemsCreatedPrevious(timeStamp, defs, deployedItemIdsList).filter(
-              (item) => item !== undefined,
-            );
+            const FilteredListToDelete = _findExistingItemsCreatedPrevious(timeStamp, defs, deployedItemIdsList);
             common
               .deleteSolutionByComponents(
                 deployedSolutionId,
@@ -1211,5 +1209,6 @@ export function _findExistingItemsCreatedPrevious(
   });
 
   const olderItemsSet = new Set(olderItems);
-  return controlList.filter((item) => !olderItemsSet.has(item));
+  controlList = controlList.filter((item) => !olderItemsSet.has(item));
+  return controlList.filter((item) => item !== undefined);
 }

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -52,6 +52,7 @@ export function deploySolutionItems(
   options: common.IDeploySolutionOptions,
 ): Promise<common.ICreateItemFromTemplateResponse[]> {
   return new Promise((resolve, reject) => {
+    const timeStamp = Date.now();
     /**
      * function to abort the current process. Will delete solution and reject the promise
      *
@@ -60,21 +61,35 @@ export function deploySolutionItems(
     function checkCancelled() {
       if (options && options.abortController) {
         if (options.abortController.signal.aborted) {
-          // Delete created items
+          const deployedItemIdsList = _getItemIdsFromTemplateDictionary(templates, templateDictionary);
+          const existingItems = _findExistingItemByKeyword(templates, templateDictionary, destinationAuthentication);
           const progressOptions: common.IDeleteSolutionOptions = {
             consoleProgress: true,
           };
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          common
-            .deleteSolutionByComponents(
-              deployedSolutionId,
-              deployedItemIds,
-              templates,
-              templateDictionary,
-              destinationAuthentication,
-              progressOptions,
-            )
-            .then(() => reject(common.failWithIds(failedTemplateItemIds)));
+
+          Promise.all(existingItems.existingItemsDefs).then((defs) => {
+            const FilteredListToDelete = _findExistingItemsCreatedPrevious(timeStamp, defs, deployedItemIdsList).filter(
+              (item) => item !== undefined,
+            );
+            common
+              .deleteSolutionByComponents(
+                deployedSolutionId,
+                FilteredListToDelete,
+                templates,
+                templateDictionary,
+                destinationAuthentication,
+                progressOptions,
+              )
+              .then(() => {
+                //because of possible deletion lag and agol query, try to delete folder again if it was still around.
+                common.deleteSolutionFolder(
+                  FilteredListToDelete,
+                  templateDictionary.folderId,
+                  destinationAuthentication,
+                );
+                reject(common.failWithIds(failedTemplateItemIds));
+              });
+          });
         }
       }
     }
@@ -1158,4 +1173,43 @@ export function _getGroupUpdates(
       common.isTrackingViewTemplate(template) ? templateDictionary.locationTracking.owner : undefined,
     );
   });
+}
+
+/**
+ * Gets the deployed item ids from the template dictionary
+ *
+ * @param templates Templates to extract ids
+ * @param templateDictionary Hash of facts: using the templates id as a lookup into this hash
+ * @returns An array of strings that represent item ids
+ * @private
+ */
+export function _getItemIdsFromTemplateDictionary(
+  templates: common.IItemTemplate[],
+  templateDictionary: any,
+): Array<string> {
+  return templates
+    .map((template) => {
+      return template.itemId;
+    })
+    .map((template) => {
+      return templateDictionary[template].itemId;
+    });
+}
+
+export function _findExistingItemsCreatedPrevious(
+  checkTime: number,
+  resultSets: Array<any>,
+  controlList: Array<string>,
+): Array<string> {
+  const olderItems: Array<string> = [];
+  resultSets.filter((set) => {
+    set.results.forEach((result) => {
+      if (result.created < checkTime) {
+        olderItems.push(result.id);
+      }
+    });
+  });
+
+  const olderItemsSet = new Set(olderItems);
+  return controlList.filter((item) => !olderItemsSet.has(item));
 }

--- a/packages/deployer/src/deploySolutionItems.ts
+++ b/packages/deployer/src/deploySolutionItems.ts
@@ -1201,6 +1201,15 @@ export function _getItemIdsFromTemplateDictionary(
     });
 }
 
+/**
+ * Finds items older than timestamp that might signify item reuse
+ *
+ * @param checkTime Current time stamp
+ * @param resultSets Existing items in the org
+ * @param controlList List of items that the Solution will deploy
+ * @returns An array of items left than checkTime
+ * @private
+ */
 export function _findExistingItemsCreatedPrevious(
   checkTime: number,
   resultSets: Array<any>,

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -2515,4 +2515,22 @@ describe("Module `deploySolutionItems`", () => {
       return deploySolution._setTypekeywordForExisting([], {}, MOCK_USER_SESSION);
     });
   });
+
+  describe("_getItemIdsFromTemplateDictionary", () => {
+    it("will get an array of item ids", () => {
+      const templates = [
+        { itemId: "t1", type: "Web Map", item: { title: "test title" } },
+        { itemId: "t2", type: "Web Map", item: { title: "test title 2" } },
+      ] as any[];
+
+      const templateDictionary: any = {
+        t1: { itemId: "d1" }, // deployed item id derived from t1
+        t2: { itemId: "d2" }, // deployed item id derived from t2
+      };
+
+      const itemlist = deploySolution._getItemIdsFromTemplateDictionary(templates, templateDictionary);
+
+      expect(itemlist).toEqual(["d1", "d2"]);
+    });
+  });
 });

--- a/packages/deployer/test/deploySolutionItems.test.ts
+++ b/packages/deployer/test/deploySolutionItems.test.ts
@@ -2533,4 +2533,64 @@ describe("Module `deploySolutionItems`", () => {
       expect(itemlist).toEqual(["d1", "d2"]);
     });
   });
+
+  describe("_findExistingItemsCreatedPrevious", () => {
+    it("removes items older than checkTime, keeps boundary/newer, ignores results not in controlList, and strips undefined from controlList", () => {
+      const checkTime = 2000;
+      const resultSets = [
+        {
+          results: [
+            { id: "A", created: 1999 }, // older -> should be removed
+            { id: "B", created: 2000 }, // boundary (not older) -> keep
+            { id: "C", created: 2500 }, // newer -> keep
+          ],
+        },
+        {
+          results: [
+            { id: "A", created: 1500 }, // duplicate older -> still removed via Set
+            { id: "X", created: 1000 }, // older but NOT in controlList -> no effect
+          ],
+        },
+      ];
+
+      // Includes duplicates and undefined to exercise the new final filter
+      const controlList = ["A", undefined as unknown as string, "B", "C", "D", "A"];
+
+      const actual = deploySolution._findExistingItemsCreatedPrevious(checkTime, resultSets, controlList);
+
+      // Expect: all "A" entries removed (older), "B" kept (== checkTime), "C" kept (newer), "D" kept (never in results),
+      // and undefined removed by the final filter
+      expect(actual).toEqual(["B", "C", "D"]);
+    });
+
+    it("keeps all when nothing is older; also handles empty controlList, empty resultSets, and undefined removal", () => {
+      const checkTime = 1000;
+
+      // Case 1: non-empty controlList, resultSets with only boundary/newer -> no removals
+      const resultSets1 = [
+        {
+          results: [
+            { id: "M", created: 1000 },
+            { id: "N", created: 3000 },
+          ],
+        }, // boundary + newer
+      ];
+      const controlList1 = ["M", "N", "P", undefined as unknown as string];
+      const actual1 = deploySolution._findExistingItemsCreatedPrevious(checkTime, resultSets1, controlList1);
+      // Undefined should be stripped; others kept
+      expect(actual1).toEqual(["M", "N", "P"]);
+
+      // Case 2: empty controlList -> always returns empty
+      const resultSets2 = [{ results: [{ id: "Q", created: 0 }] }];
+      const controlList2: string[] = [];
+      const actual2 = deploySolution._findExistingItemsCreatedPrevious(checkTime, resultSets2, controlList2);
+      expect(actual2).toEqual([]);
+
+      // Case 3: empty resultSets -> no removals, only undefined stripped
+      const resultSets3: Array<any> = [];
+      const controlList3 = ["R", undefined as unknown as string, "S"];
+      const actual3 = deploySolution._findExistingItemsCreatedPrevious(checkTime, resultSets3, controlList3);
+      expect(actual3).toEqual(["R", "S"]);
+    });
+  });
 });


### PR DESCRIPTION
Folders along with items could be left behind during aborting because of the transactional state of items being written

1) delete based on template dictionary instead of deployed array
2) add timestamp to not delete older items from dictionary (as those items could be shared)
3) add try/catch to second pass on folder deletion
4) add executing flag so more abort calls are ignored if there is already an abort in progress.