### PR TITLE
Use source auth for portal url for creation workflow for Tasks enabled layers

### DIFF
--- a/packages/creator/src/helpers/add-content-to-solution.ts
+++ b/packages/creator/src/helpers/add-content-to-solution.ts
@@ -444,13 +444,12 @@ export async function _postProcessTaskResource(
     },
   } as IRequestOptions;
 
+  const sourcePortal = await srcAuthentication.getPortal();
+
   const resourcePromises = taskKeys.map((k) => {
+    const baseURL = _getSourceBaseOrTemplateBaseURL(sourcePortal, templateDictionary);
     return request(
-      generateSourceResourceUrl(
-        `${templateDictionary.portalBaseUrl}/sharing/rest`,
-        taskResources[k].itemId,
-        taskResources[k].filename,
-      ),
+      generateSourceResourceUrl(baseURL, taskResources[k].itemId, taskResources[k].filename),
       requestOptions,
     );
   });
@@ -798,4 +797,16 @@ export function _templatizeWorkflowConfig(templates: IItemTemplate[], templateDi
       template.properties.configuration = JSON.parse(configStr);
     }
   });
+}
+
+/**
+ * Determines to use the Auth source portal or the portal in template dictionary
+ *
+ * @param sourcePortal THe portal information of the source authentication
+ * @param templateDictionary Hash of key details used for variable replacement
+ */
+export function _getSourceBaseOrTemplateBaseURL(sourcePortal: any, templateDictionary: any): string {
+  return sourcePortal.portalHostname
+    ? `https://${sourcePortal.portalHostname}/sharing/rest`
+    : `${templateDictionary.portalBaseUrl}/sharing/rest`;
 }

--- a/packages/creator/test/helpers/add-content-to-solution.test.ts
+++ b/packages/creator/test/helpers/add-content-to-solution.test.ts
@@ -31,6 +31,7 @@ import {
   _restoreDataFilesToTemplates,
   _simplifyUrlsInItemDescriptions,
   _templatizeWorkflowConfig,
+  _getSourceBaseOrTemplateBaseURL,
 } from "../../src/helpers/add-content-to-solution";
 const fetchMock = require("fetch-mock");
 import * as createItemTemplateModule from "../../src/createItemTemplate";
@@ -1443,5 +1444,29 @@ describe("_templatizeWorkflowConfig", () => {
       templateMocks.getItemTemplate("Web Mapping Application"),
     ];
     expect(templateList).toEqual(expectedTemplateList);
+  });
+});
+
+describe("_getSourceBaseOrTemplateBaseURL", () => {
+  it("Should use source base url", () => {
+    const sourcePortal: any = {
+      portalHostname: "sourcePortal.maps.arcgis.com",
+    };
+    const templateDictionary: any = {
+      portalBaseUrl: "https://myorg.maps.arcgis.com",
+    };
+    const baseUrl = _getSourceBaseOrTemplateBaseURL(sourcePortal, templateDictionary);
+    expect(baseUrl).toEqual("https://sourcePortal.maps.arcgis.com/sharing/rest");
+  });
+
+  it("Should use template dictionary base url", () => {
+    const sourcePortal: any = {
+      portalHostname: undefined,
+    };
+    const templateDictionary: any = {
+      portalBaseUrl: "https://myorg.maps.arcgis.com",
+    };
+    const baseUrl = _getSourceBaseOrTemplateBaseURL(sourcePortal, templateDictionary);
+    expect(baseUrl).toEqual("https://myorg.maps.arcgis.com/sharing/rest");
   });
 });


### PR DESCRIPTION
Use source auth for portal url if it is defined for creation, instead of using template dictionary's portal url