### PR TITLE
Add solutionOwner to request options

### DIFF
--- a/packages/common/src/deleteHelpers/deleteSolutionContents.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionContents.ts
@@ -118,7 +118,16 @@ export function deleteSolutionContents(
         if (solutionItemId) {
           // 9-5-25: Change in logic to delete solution item regardless if there were any failed deleted items.
           const permanentDelete = !deleteOptions.sendToRecycling;
-          return deleteSolutionItem.deleteSolutionItem(solutionItemId, authentication, permanentDelete);
+          if (deleteOptions?.solutionOwner) {
+            return deleteSolutionItem.deleteSolutionItem(
+              solutionItemId,
+              authentication,
+              permanentDelete,
+              deleteOptions?.solutionOwner,
+            );
+          } else {
+            return deleteSolutionItem.deleteSolutionItem(solutionItemId, authentication, permanentDelete);
+          }
         } else {
           return Promise.resolve({ success: true, itemId: "" });
         }
@@ -129,7 +138,16 @@ export function deleteSolutionContents(
           reportProgress.reportProgress(99, deleteOptions, solutionItemId, EItemProgressStatus.Finished);
 
           // Can't delete if folder contains non-solution items
-          return deleteSolutionFolder.deleteSolutionFolder(solutionIds, solutionSummary.folder, authentication);
+          if (deleteOptions?.solutionOwner) {
+            return deleteSolutionFolder.deleteSolutionFolder(
+              solutionIds,
+              solutionSummary.folder,
+              authentication,
+              deleteOptions?.solutionOwner,
+            );
+          } else {
+            return deleteSolutionFolder.deleteSolutionFolder(solutionIds, solutionSummary.folder, authentication);
+          }
         } else {
           return Promise.resolve(false);
         }

--- a/packages/common/src/deleteHelpers/deleteSolutionContents.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionContents.ts
@@ -118,12 +118,12 @@ export function deleteSolutionContents(
         if (solutionItemId) {
           // 9-5-25: Change in logic to delete solution item regardless if there were any failed deleted items.
           const permanentDelete = !deleteOptions.sendToRecycling;
-          if (deleteOptions?.solutionOwner) {
+          if (deleteOptions.solutionOwner) {
             return deleteSolutionItem.deleteSolutionItem(
               solutionItemId,
               authentication,
               permanentDelete,
-              deleteOptions?.solutionOwner,
+              deleteOptions.solutionOwner,
             );
           } else {
             return deleteSolutionItem.deleteSolutionItem(solutionItemId, authentication, permanentDelete);
@@ -138,12 +138,12 @@ export function deleteSolutionContents(
           reportProgress.reportProgress(99, deleteOptions, solutionItemId, EItemProgressStatus.Finished);
 
           // Can't delete if folder contains non-solution items
-          if (deleteOptions?.solutionOwner) {
+          if (deleteOptions.solutionOwner) {
             return deleteSolutionFolder.deleteSolutionFolder(
               solutionIds,
               solutionSummary.folder,
               authentication,
-              deleteOptions?.solutionOwner,
+              deleteOptions.solutionOwner,
             );
           } else {
             return deleteSolutionFolder.deleteSolutionFolder(solutionIds, solutionSummary.folder, authentication);

--- a/packages/common/src/deleteHelpers/deleteSolutionFolder.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionFolder.ts
@@ -42,6 +42,7 @@ export function deleteSolutionFolder(
   solutionIds: string[],
   folderId: string,
   authentication: UserSession,
+  solutionOwner?: string,
 ): Promise<boolean> {
   // See if the deployment folder is empty and can be deleted; first, we need info about user
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -77,7 +78,7 @@ export function deleteSolutionFolder(
         // OK to delete the folder
         return restRemoveFolder({
           folderId: folderId,
-          owner: authentication.username,
+          owner: solutionOwner ?? authentication.username,
           authentication,
         });
       } else {

--- a/packages/common/src/deleteHelpers/deleteSolutionFolder.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionFolder.ts
@@ -35,6 +35,7 @@ import {
  * @param solutionFolderId Id of the folder of a deployed Solution
  * @param deletedItemIds Ids in the Solution, including the Solution item; used to deal with lagging folder deletion
  * @param authentication Credentials for the request
+ * @param solutionOwner Optional. The owner of the solution item if it is not the logged on user
  * @returns Promise that will resolve if deletion was successful and fail if any part of it failed;
  * if the folder has a non-Solution item, it will not be deleted, but the function will return true
  */

--- a/packages/common/src/deleteHelpers/deleteSolutionItem.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionItem.ts
@@ -34,6 +34,7 @@ import { removeItem } from "../restHelpers";
  * @param authentication Credentials for the request
  * @param permanentDelete If true (the default), the item is permanently deleted; if false and the item type
  * supports the recycle bin, the item will be put into the recycle bin
+ * @param solutionOwner Optional. The owner of the solution item if it is not the logged on user
  * @returns Promise that will resolve with the status of deleting the item
  */
 export function deleteSolutionItem(
@@ -49,10 +50,8 @@ export function deleteSolutionItem(
   if (solutionOwner) {
     protectOptions.owner = solutionOwner;
   }
-  console.log("*****");
   return unprotectItem(protectOptions)
     .then((result) => {
-      console.log("$$$$$");
       if (result.success) {
         if (solutionOwner) {
           return removeItem(solutionItemId, authentication, permanentDelete, solutionOwner);

--- a/packages/common/src/deleteHelpers/deleteSolutionItem.ts
+++ b/packages/common/src/deleteHelpers/deleteSolutionItem.ts
@@ -40,15 +40,25 @@ export function deleteSolutionItem(
   solutionItemId: string,
   authentication: UserSession,
   permanentDelete?: boolean,
+  solutionOwner?: string,
 ): Promise<IStatusResponse> {
   const protectOptions: IUserItemOptions = {
     id: solutionItemId,
     authentication,
   };
+  if (solutionOwner) {
+    protectOptions.owner = solutionOwner;
+  }
+  console.log("*****");
   return unprotectItem(protectOptions)
     .then((result) => {
+      console.log("$$$$$");
       if (result.success) {
-        return removeItem(solutionItemId, authentication, permanentDelete);
+        if (solutionOwner) {
+          return removeItem(solutionItemId, authentication, permanentDelete, solutionOwner);
+        } else {
+          return removeItem(solutionItemId, authentication, permanentDelete);
+        }
       } else {
         return Promise.resolve(result);
       }

--- a/packages/common/src/deleteHelpers/removeItems.ts
+++ b/packages/common/src/deleteHelpers/removeItems.ts
@@ -63,10 +63,18 @@ export function removeItems(
         [solutionDeletedSummary, solutionFailureSummary] = results;
 
         // Remove any delete protection on item
-        return unprotectItem({
-          id: itemToDelete.id,
-          authentication: authentication,
-        });
+        if (deleteOptions.solutionOwner) {
+          return unprotectItem({
+            id: itemToDelete.id,
+            authentication: authentication,
+            owner: deleteOptions.solutionOwner,
+          });
+        } else {
+          return unprotectItem({
+            id: itemToDelete.id,
+            authentication: authentication,
+          });
+        }
       })
       .then(async () => {
         // Delete the item
@@ -78,7 +86,11 @@ export function removeItems(
           return workflowHelpers.deleteWorkflowItem(itemToDelete.id, workflowBaseUrl, authentication);
         } else {
           const permanentDelete = !deleteOptions.sendToRecycling;
-          return removeItem(itemToDelete.id, authentication, permanentDelete);
+          if (deleteOptions.solutionOwner) {
+            return removeItem(itemToDelete.id, authentication, permanentDelete, deleteOptions.solutionOwner);
+          } else {
+            return removeItem(itemToDelete.id, authentication, permanentDelete);
+          }
         }
       })
       .then(() => {

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -569,6 +569,11 @@ export interface IDeleteSolutionOptions {
    * delete the item permanently; this flag overrides that behavior.
    */
   sendToRecycling?: boolean;
+
+  /**
+   * The owner of the solution to delete/unprotect/update if it is not logged on user.
+   */
+  solutionOwner?: string;
 }
 
 /**

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -1448,6 +1448,7 @@ export function removeGroup(groupId: string, authentication: UserSession): Promi
  * @param authentication Credentials for the request to AGO
  * @param permanentDelete If true (the default), the item is permanently deleted; if false and the item type
  * supports the recycle bin, the item will be put into the recycle bin
+ * @param solutionOwner Optional. The owner of the solution item if it is not the logged on user
  * @returns A promise that will resolve with the result of the request
  */
 export function removeItem(

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -1897,6 +1897,7 @@ export function updateItemExtended(
   thumbnail?: File,
   access?: string | undefined,
   templateDictionary?: any,
+  solutionOwner?: string,
 ): Promise<IUpdateItemResponse> {
   return new Promise<IUpdateItemResponse>((resolve, reject) => {
     const updateOptions: IUpdateItemOptions = {
@@ -1911,6 +1912,10 @@ export function updateItemExtended(
     }
     if (isTrackingViewTemplate(undefined, itemInfo) && templateDictionary) {
       updateOptions.owner = templateDictionary.locationTracking.owner;
+    } else {
+      if (solutionOwner) {
+        updateOptions.owner = solutionOwner;
+      }
     }
 
     portalUpdateItem(updateOptions).then(

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -1454,6 +1454,7 @@ export function removeItem(
   itemId: string,
   authentication: UserSession,
   permanentDelete = true,
+  solutionOwner?: string,
 ): Promise<IStatusResponse> {
   return new Promise<IStatusResponse>((resolve, reject) => {
     const requestOptions: IUserItemOptions = {
@@ -1463,6 +1464,9 @@ export function removeItem(
         permanentDelete,
       },
     };
+    if (solutionOwner) {
+      requestOptions.owner = solutionOwner;
+    }
     portalRemoveItem(requestOptions).then((result) => (result.success ? resolve(result) : reject(result)), reject);
   });
 }
@@ -1827,6 +1831,9 @@ export function updateItem(
         ...(additionalParams ?? {}),
       },
     };
+    if (additionalParams?.solutionOwner) {
+      updateOptions.owner = additionalParams.solutionOwner;
+    }
     if (itemInfo?.data instanceof File) {
       //updateOptions.file = itemInfo.data;
       updateOptions.params.file = itemInfo.data;

--- a/packages/common/src/restHelpers.ts
+++ b/packages/common/src/restHelpers.ts
@@ -1888,6 +1888,8 @@ export function updateGroup(
  * @param authentication Credentials for requests
  * @param thumbnail optional thumbnail to update
  * @param access "public" or "org"
+ * @param templateDictionary Hash of facts: folder id, org URL, adlib replacements
+ * @param solutionOwner The owner of the solution for rest request
  * @return
  */
 export function updateItemExtended(

--- a/packages/common/test/deleteHelpers/deleteSolutionItem.test.ts
+++ b/packages/common/test/deleteHelpers/deleteSolutionItem.test.ts
@@ -1,0 +1,130 @@
+/** @license
+ * Copyright 2021 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides tests for functions for deleting a deployed Solution item and all of the items that were created
+ * as part of that deployment.
+ */
+
+import * as arcGISRestJS from "../../src/arcgisRestJS";
+import * as deleteSolutionItem from "../../src/deleteHelpers/deleteSolutionItem";
+import * as interfaces from "../../src/interfaces";
+import * as restHelpers from "../../src/restHelpers";
+import * as utils from "../mocks/utils";
+
+let MOCK_USER_SESSION: arcGISRestJS.UserSession;
+
+beforeEach(() => {
+  MOCK_USER_SESSION = utils.createRuntimeMockUserSession();
+});
+
+// ------------------------------------------------------------------------------------------------------------------ //
+
+describe("Module `deleteSolutionItem`: functions for deleting a Solution item", () => {
+
+  describe("deleteSolutionItem", () => {
+    const itemId = "abc123";
+    const owner = "someOwner";
+
+    it("sets protectOptions.owner and calls removeItem with owner when solutionOwner is provided", async () => {
+      // Arrange
+      const unprotectSpy = spyOn(arcGISRestJS, "unprotectItem").and.callFake(
+        (opts: arcGISRestJS.IUserItemOptions) => {
+          // Assert inside spy: owner should be set on protectOptions
+          expect(opts.id).toBe(itemId);
+          expect(opts.authentication).toBe(MOCK_USER_SESSION);
+          expect((opts as any).owner).toBe(owner);
+          return Promise.resolve({ success: true } as any);
+        },
+      );
+
+      const removeSpy = spyOn(restHelpers, "removeItem").and.resolveTo({
+        success: true,
+      } as any);
+
+      // Act
+      const result: interfaces.IStatusResponse = await deleteSolutionItem.deleteSolutionItem(
+        itemId,
+        MOCK_USER_SESSION,
+        true,
+        owner,
+      );
+
+      // Assert: unprotect called once and removeItem called WITH owner
+      expect(unprotectSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(itemId, MOCK_USER_SESSION, true, owner);
+
+      // Function returns a normalized response
+      expect(result).toEqual({ success: true, itemId });
+    });
+
+    it("does NOT set protectOptions.owner and calls removeItem WITHOUT owner when solutionOwner is not provided", async () => {
+      // Arrange
+      const unprotectSpy = spyOn(arcGISRestJS, "unprotectItem").and.callFake(
+        (opts: arcGISRestJS.IUserItemOptions) => {
+          // owner should not exist
+          expect(opts.id).toBe(itemId);
+          expect(opts.authentication).toBe(MOCK_USER_SESSION);
+          expect((opts as any).owner).toBeUndefined();
+          return Promise.resolve({ success: true } as any);
+        },
+      );
+
+      const removeSpy = spyOn(restHelpers, "removeItem").and.resolveTo({
+        success: true,
+      } as any);
+
+      // Act
+      const result: interfaces.IStatusResponse = await deleteSolutionItem.deleteSolutionItem(
+        itemId,
+        MOCK_USER_SESSION,
+        false,
+        undefined, // no owner
+      );
+
+      // Assert: removeItem called WITHOUT owner
+      expect(unprotectSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(itemId, MOCK_USER_SESSION, false);
+
+      expect(result).toEqual({ success: true, itemId });
+    });
+
+    it("when unprotectItem fails, it does NOT call removeItem (covers the else branch inside the first then)", async () => {
+      // Arrange
+      spyOn(arcGISRestJS, "unprotectItem").and.resolveTo({
+        success: false,
+      } as any);
+
+      const removeSpy = spyOn(restHelpers, "removeItem").and.resolveTo({
+        success: true,
+      } as any);
+
+      // Act
+      const result: interfaces.IStatusResponse = await deleteSolutionItem.deleteSolutionItem(
+        itemId,
+        MOCK_USER_SESSION,
+        true,
+        owner,
+      );
+
+      // Assert
+      expect(removeSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: false, itemId });
+    });
+  });
+
+
+});

--- a/packages/common/test/deleteHelpers/deleteSolutionItem.test.ts
+++ b/packages/common/test/deleteHelpers/deleteSolutionItem.test.ts
@@ -34,22 +34,19 @@ beforeEach(() => {
 // ------------------------------------------------------------------------------------------------------------------ //
 
 describe("Module `deleteSolutionItem`: functions for deleting a Solution item", () => {
-
   describe("deleteSolutionItem", () => {
     const itemId = "abc123";
     const owner = "someOwner";
 
     it("sets protectOptions.owner and calls removeItem with owner when solutionOwner is provided", async () => {
       // Arrange
-      const unprotectSpy = spyOn(arcGISRestJS, "unprotectItem").and.callFake(
-        (opts: arcGISRestJS.IUserItemOptions) => {
-          // Assert inside spy: owner should be set on protectOptions
-          expect(opts.id).toBe(itemId);
-          expect(opts.authentication).toBe(MOCK_USER_SESSION);
-          expect((opts as any).owner).toBe(owner);
-          return Promise.resolve({ success: true } as any);
-        },
-      );
+      const unprotectSpy = spyOn(arcGISRestJS, "unprotectItem").and.callFake((opts: arcGISRestJS.IUserItemOptions) => {
+        // Assert inside spy: owner should be set on protectOptions
+        expect(opts.id).toBe(itemId);
+        expect(opts.authentication).toBe(MOCK_USER_SESSION);
+        expect((opts as any).owner).toBe(owner);
+        return Promise.resolve({ success: true } as any);
+      });
 
       const removeSpy = spyOn(restHelpers, "removeItem").and.resolveTo({
         success: true,
@@ -73,15 +70,13 @@ describe("Module `deleteSolutionItem`: functions for deleting a Solution item", 
 
     it("does NOT set protectOptions.owner and calls removeItem WITHOUT owner when solutionOwner is not provided", async () => {
       // Arrange
-      const unprotectSpy = spyOn(arcGISRestJS, "unprotectItem").and.callFake(
-        (opts: arcGISRestJS.IUserItemOptions) => {
-          // owner should not exist
-          expect(opts.id).toBe(itemId);
-          expect(opts.authentication).toBe(MOCK_USER_SESSION);
-          expect((opts as any).owner).toBeUndefined();
-          return Promise.resolve({ success: true } as any);
-        },
-      );
+      const unprotectSpy = spyOn(arcGISRestJS, "unprotectItem").and.callFake((opts: arcGISRestJS.IUserItemOptions) => {
+        // owner should not exist
+        expect(opts.id).toBe(itemId);
+        expect(opts.authentication).toBe(MOCK_USER_SESSION);
+        expect((opts as any).owner).toBeUndefined();
+        return Promise.resolve({ success: true } as any);
+      });
 
       const removeSpy = spyOn(restHelpers, "removeItem").and.resolveTo({
         success: true,
@@ -125,6 +120,4 @@ describe("Module `deleteSolutionItem`: functions for deleting a Solution item", 
       expect(result).toEqual({ success: false, itemId });
     });
   });
-
-
 });

--- a/packages/common/test/deleteHelpers/removeItems.test.ts
+++ b/packages/common/test/deleteHelpers/removeItems.test.ts
@@ -278,18 +278,11 @@ describe("Module `removeItems`: removing items from AGO", () => {
       50, // percentDone
       10, // progressPercentStep
       {
-        solutionOwner: "pwong"
+        solutionOwner: "pwong",
       }, // deleteOptions
     );
 
-    expect(removeItemSpy).toHaveBeenCalledWith(
-      "itm1234567890",
-      MOCK_USER_SESSION,
-      true,
-      "pwong"
-    );
+    expect(removeItemSpy).toHaveBeenCalledWith("itm1234567890", MOCK_USER_SESSION, true, "pwong");
     expect(result).toEqual(expectedResult);
   });
-
-
 });

--- a/packages/common/test/deleteHelpers/removeItems.test.ts
+++ b/packages/common/test/deleteHelpers/removeItems.test.ts
@@ -223,4 +223,73 @@ describe("Module `removeItems`: removing items from AGO", () => {
     );
     expect(result).toEqual(expectedResult);
   });
+
+  it("handles deleting by solution owner", async () => {
+    const solutionSummary: ISolutionPrecis = {
+      id: "sln1234567890",
+      title: "Solution Title",
+      folder: "fld1234567890",
+      items: [
+        {
+          id: "itm1234567890",
+          type: "Web Mapping Application",
+          title: "Item Title",
+          modified: 1234567890,
+          owner: "fred",
+        },
+      ],
+      groups: [],
+    };
+
+    spyOn(arcGISRestJS, "unprotectItem").and.resolveTo(utils.getSuccessResponse());
+    const removeItemSpy = spyOn(restHelpers, "removeItem").and.resolveTo(utils.getSuccessResponse("itm1234567890"));
+
+    const expectedResult: ISolutionPrecis[] = [
+      {
+        // Successful deletions
+        id: "sln1234567890",
+        title: "Solution Title",
+        folder: "fld1234567890",
+        items: [
+          {
+            id: "itm1234567890",
+            type: "Web Mapping Application",
+            title: "Item Title",
+            modified: 1234567890,
+            owner: "fred",
+          },
+        ],
+        groups: [],
+      },
+      {
+        // Failed deletions
+        id: "sln1234567890",
+        title: "Solution Title",
+        folder: "fld1234567890",
+        items: [],
+        groups: [],
+      },
+    ];
+
+    const result: ISolutionPrecis[] = await removeItems.removeItems(
+      solutionSummary,
+      [], // hubSiteItemIds
+      MOCK_USER_SESSION,
+      50, // percentDone
+      10, // progressPercentStep
+      {
+        solutionOwner: "pwong"
+      }, // deleteOptions
+    );
+
+    expect(removeItemSpy).toHaveBeenCalledWith(
+      "itm1234567890",
+      MOCK_USER_SESSION,
+      true,
+      "pwong"
+    );
+    expect(result).toEqual(expectedResult);
+  });
+
+
 });

--- a/packages/common/test/deleteSolution.test.ts
+++ b/packages/common/test/deleteSolution.test.ts
@@ -24,6 +24,7 @@ import * as createHRO from "../src/create-hub-request-options";
 import * as deleteEmptyGroups from "../src/deleteHelpers/deleteEmptyGroups";
 import * as deleteGroupIfEmpty from "../src/deleteHelpers/deleteGroupIfEmpty";
 import * as deleteSolution from "../src/deleteSolution";
+import * as deleteSolutionItem from "../src/deleteHelpers/deleteSolutionItem";
 import * as deleteSolutionContents from "../src/deleteHelpers/deleteSolutionContents";
 import * as hubSites from "@esri/hub-sites";
 import * as interfaces from "../src/interfaces";
@@ -835,8 +836,10 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       } as any);
 
       const result = await deleteSolutionFolder.deleteSolutionFolder([], "fld1234567890", MOCK_USER_SESSION);
+      const resultWithUser = await deleteSolutionFolder.deleteSolutionFolder([], "fld1234567890", MOCK_USER_SESSION, "pwong");
       expect(result).toBeTruthy();
-      expect(removeFolderSpy.calls.count()).toEqual(1);
+      expect(resultWithUser).toBeTruthy();
+      expect(removeFolderSpy.calls.count()).toEqual(2);
     });
 
     it("deletes a folder with only solution items remaining", async () => {
@@ -1264,6 +1267,89 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       expect(consoleSpy.calls.argsFor(0)[2]).toBe("Ginger");
       expect(consoleSpy.calls.argsFor(0)[3]).toBe("3 Finished");
       expect(consoleSpy.calls.argsFor(0)[4]).toBe("50%");
+    });
+  });
+
+  describe("deleteSolutionContents", () => {
+    it("uses solutionOwner overloads for deleteSolutionItem and deleteSolutionFolder", async () => {
+      // Arrange
+      const solutionItemId = "sol1234567890";
+      const solutionOwner = "ownerUser";
+
+      // Create a solution summary with items so solutionIds get computed
+      const solutionSummary: interfaces.ISolutionPrecis = mockItems.getSolutionPrecis([
+        mockItems.getAGOLItemPrecis("Web Map"),
+        mockItems.getAGOLItemPrecis("Web Mapping Application"),
+      ]);
+
+      // Make sure we can predict expected solutionIds
+      const expectedSolutionIds = solutionSummary.items.map((i) => i.id).concat([solutionItemId]);
+
+      const deletedSummary: interfaces.ISolutionPrecis = {
+        id: solutionSummary.id,
+        title: solutionSummary.title,
+        folder: solutionSummary.folder,
+        items: [],
+        groups: [],
+      };
+
+      const failureSummary: interfaces.ISolutionPrecis = {
+        id: solutionSummary.id,
+        title: solutionSummary.title,
+        folder: solutionSummary.folder,
+        items: [],
+        groups: [],
+      };
+
+      const options: interfaces.IDeleteSolutionOptions = {
+        sendToRecycling: true,
+        solutionOwner,
+      };
+
+      spyOn(reportProgress, "reportProgress"); // not required but keeps noise down
+
+      spyOn(removeItems, "removeItems").and.resolveTo([deletedSummary, failureSummary]);
+
+      const emptyFolderResponse = await deleteEmptyGroups.deleteEmptyGroups([], MOCK_USER_SESSION);
+      expect(emptyFolderResponse).toEqual([]);
+
+      spyOn(deleteSolutionItem, "deleteSolutionItem").and.resolveTo({
+        success: true,
+        itemId: solutionItemId,
+      } as interfaces.IStatusResponse);
+
+      spyOn(deleteSolutionFolder, "deleteSolutionFolder").and.resolveTo(true as unknown as boolean);
+
+      const result = await deleteSolutionContents.deleteSolutionContents(
+        solutionItemId,
+        solutionSummary,
+        MOCK_USER_SESSION,
+        options,
+      );
+
+      const noOptionResult = await deleteSolutionContents.deleteSolutionContents(
+        solutionItemId,
+        solutionSummary,
+        MOCK_USER_SESSION,
+      );
+
+      expect(deleteSolutionItem.deleteSolutionItem).toHaveBeenCalledWith(
+        solutionItemId,
+        MOCK_USER_SESSION,
+        false,
+        solutionOwner,
+      );
+
+      expect(deleteSolutionFolder.deleteSolutionFolder).toHaveBeenCalledWith(
+        expectedSolutionIds,
+        solutionSummary.folder,
+        MOCK_USER_SESSION,
+        solutionOwner,
+      );
+
+      // Also assert it returns the same delete summaries returned by removeItems
+      expect(result).toEqual([deletedSummary, failureSummary]);
+      expect(noOptionResult).toEqual([deletedSummary, failureSummary]);
     });
   });
 });

--- a/packages/common/test/deleteSolution.test.ts
+++ b/packages/common/test/deleteSolution.test.ts
@@ -836,7 +836,12 @@ describe("Module `deleteSolution`: functions for deleting a deployed Solution it
       } as any);
 
       const result = await deleteSolutionFolder.deleteSolutionFolder([], "fld1234567890", MOCK_USER_SESSION);
-      const resultWithUser = await deleteSolutionFolder.deleteSolutionFolder([], "fld1234567890", MOCK_USER_SESSION, "pwong");
+      const resultWithUser = await deleteSolutionFolder.deleteSolutionFolder(
+        [],
+        "fld1234567890",
+        MOCK_USER_SESSION,
+        "pwong",
+      );
       expect(result).toBeTruthy();
       expect(resultWithUser).toBeTruthy();
       expect(removeFolderSpy.calls.count()).toEqual(2);

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -2883,6 +2883,16 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
       expect(actual.success).toEqual(true);
     });
 
+    it("removes an item by solution owner", async () => {
+      const itemId: string = "ABC123";
+      fetchMock.post(
+        utils.PORTAL_SUBSET.restUrl + "/content/users/pwong/items/" + itemId + "/delete",
+        utils.getSuccessResponse({ itemId }),
+      );
+      const actual = await restHelpers.removeItem(itemId, MOCK_USER_SESSION, true, "pwong");
+      expect(actual.success).toEqual(true);
+    });
+
     it("fails to remove an item", async () => {
       const itemId: string = "ABC123";
       fetchMock.post(
@@ -3345,6 +3355,31 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           data: "fred",
           text: undefined,
         },
+      });
+    });
+
+    it("handles update by solution owner", async () => {
+      const itemInfo: IItemUpdate = {
+        id: "itm1234567890",
+      };
+      const additionalParams: any = {
+        solutionOwner: "pwong"
+      };
+      const updateItemFnStub = sinon.stub(arcGISRestJS, "restUpdateItem").resolves(utils.getSuccessResponse());
+
+      await restHelpers.updateItem(itemInfo, MOCK_USER_SESSION, undefined, additionalParams);
+      const updateItemFnCall = updateItemFnStub.getCall(0);
+      expect(updateItemFnCall.args[0]).toEqual({
+        item: {
+          id: "itm1234567890",
+        },
+        folderId: undefined,
+        authentication: MOCK_USER_SESSION,
+        params: {
+          solutionOwner: "pwong",
+          text: undefined,
+        },
+        owner: "pwong"
       });
     });
 

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -3527,6 +3527,23 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
       );
     });
 
+    it("with solution owner", async () => {
+      itemTemplate.item.id = "itm1234567890";
+      fetchMock.post(
+        utils.PORTAL_SUBSET.restUrl + "/content/users/pwong/items/itm1234567890/update",
+        '{"success":true}',
+      );
+      return restHelpers.updateItemExtended(
+        itemTemplate.item,
+        itemTemplate.data,
+        MOCK_USER_SESSION,
+        undefined,
+        undefined,
+        null,
+        "pwong",
+      );
+    });
+
     it("with org share", async () => {
       itemTemplate.item.id = "itm1234567890";
       fetchMock.post(

--- a/packages/common/test/restHelpers.test.ts
+++ b/packages/common/test/restHelpers.test.ts
@@ -3363,7 +3363,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
         id: "itm1234567890",
       };
       const additionalParams: any = {
-        solutionOwner: "pwong"
+        solutionOwner: "pwong",
       };
       const updateItemFnStub = sinon.stub(arcGISRestJS, "restUpdateItem").resolves(utils.getSuccessResponse());
 
@@ -3379,7 +3379,7 @@ describe("Module `restHelpers`: common REST utility functions shared across pack
           solutionOwner: "pwong",
           text: undefined,
         },
-        owner: "pwong"
+        owner: "pwong",
       });
     });
 


### PR DESCRIPTION
ArcGIS Rest JS has a function to check owner.  It is done by passing in the owner property in request/delete/update Options. If not it uses the logged on user.  Right now in SolutionJS, we don't pass owner property.  This change adds a solutionOwner prop to some functions and alters the interface with solutionOwner in other places.  So that the URL to request a REST operation does it on the right url path.